### PR TITLE
Fix #8: Harden FocusGraph lifecycle and Three types

### DIFF
--- a/app/components/FocusGraph.d.ts
+++ b/app/components/FocusGraph.d.ts
@@ -1,1 +1,0 @@
-declare module 'three';

--- a/app/components/FocusGraph.tsx
+++ b/app/components/FocusGraph.tsx
@@ -8,12 +8,11 @@ import ForceGraph3D, {
 } from "react-force-graph-3d";
 import {AxesHelper, PerspectiveCamera} from "three";
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js';
+import {createFocusGraphResources} from "./focusGraphResources";
 
 function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: number }) {
     const fgRef = useRef<ForceGraphMethods>(undefined);
-    const axesHelperRef = useRef<AxesHelper>(undefined);
-    const rotateTimer = useRef<ReturnType<typeof setInterval>>(undefined);
-    const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const resources = useMemo(() => createFocusGraphResources(), []);
 
     const graphData = useMemo<GraphData>(() => {
         try {
@@ -30,19 +29,16 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
     const [isRotationActive, setIsRotationActive] = useState(true);
 
     const stopRotation = useCallback(() => {
-        if (rotateTimer.current !== undefined) {
-            clearInterval(rotateTimer.current);
-            rotateTimer.current = undefined;
-        }
-    }, []);
+        resources.stopRotation();
+    }, [resources]);
 
     const startRotation = useCallback(() => {
         const graph = fgRef.current;
-        if (graph === undefined || rotateTimer.current !== undefined) {
+        if (graph === undefined) {
             return;
         }
 
-        rotateTimer.current = setInterval(() => {
+        resources.startRotation(() => {
             const currentGraph = fgRef.current;
             if (currentGraph === undefined) {
                 return;
@@ -52,8 +48,8 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
             const up = currentCamera.up.clone();
             currentCamera.position.applyAxisAngle(up, -Math.PI / 300);
             currentCamera.rotateOnAxis(up, -Math.PI / 300);
-        }, 20);
-    }, []);
+        });
+    }, [resources]);
 
     useEffect(() => {
         const graph = fgRef.current;
@@ -74,36 +70,19 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
         const axesHelper = new AxesHelper(5000);
         axesHelper.name = "myAxesHelper";
         axesHelper.visible = false;
-        axesHelperRef.current = axesHelper;
-        scene.add(axesHelper);
+        resources.attachAxes(scene, axesHelper);
 
         controls.update();
         graph.refresh();
         setClickEnabled(false);
 
-        const interactionTimer = setTimeout(() => {
+        resources.scheduleInteraction(() => {
             setClickEnabled(true);
             fgRef.current?.refresh();
         }, enableDelay);
 
-        return () => {
-            clearTimeout(interactionTimer);
-            if (resetTimer.current !== undefined) {
-                clearTimeout(resetTimer.current);
-                resetTimer.current = undefined;
-            }
-            stopRotation();
-            scene.remove(axesHelper);
-            axesHelper.geometry.dispose();
-            const materials = Array.isArray(axesHelper.material)
-                ? axesHelper.material
-                : [axesHelper.material];
-            materials.forEach((material) => material.dispose());
-            if (axesHelperRef.current === axesHelper) {
-                axesHelperRef.current = undefined;
-            }
-        };
-    }, [enableDelay, graphData, stopRotation]);
+        return resources.cleanup;
+    }, [enableDelay, graphData, resources]);
 
     const handleDragEnd = useCallback(
         (node: NodeObject) => {
@@ -177,22 +156,17 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
         () => {
             const graph = fgRef.current;
             if (graph !== undefined) {
-                if (resetTimer.current !== undefined) {
-                    clearTimeout(resetTimer.current);
-                    resetTimer.current = undefined;
-                }
                 if (isRotationActive) {
                     stopRotation()
                 }
                 graph.zoomToFit(1000)
-                resetTimer.current = setTimeout(() => {
-                    resetTimer.current = undefined;
+                resources.scheduleReset(() => {
                     if (isRotationActive) {
                         startRotation()
                     }
                 }, 1001)
             }
-        }, [isRotationActive, startRotation, stopRotation]
+        }, [isRotationActive, resources, startRotation, stopRotation]
     )
 
     useEffect(() => {
@@ -204,18 +178,13 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
 
         return () => {
             stopRotation();
-            if (resetTimer.current !== undefined) {
-                clearTimeout(resetTimer.current);
-                resetTimer.current = undefined;
-            }
+            resources.cancelReset();
         };
-    }, [graphData, isRotationActive, startRotation, stopRotation])
+    }, [graphData, isRotationActive, resources, startRotation, stopRotation])
 
     useEffect(() => {
-        if (axesHelperRef.current !== undefined) {
-            axesHelperRef.current.visible = areAxesVisible;
-        }
-    }, [areAxesVisible, graphData])
+        resources.setAxesVisible(areAxesVisible);
+    }, [areAxesVisible, graphData, resources])
 
     const Graph = <ForceGraph3D
         ref={fgRef}

--- a/app/components/FocusGraph.tsx
+++ b/app/components/FocusGraph.tsx
@@ -1,176 +1,140 @@
 'use client'
 
-import {useCallback, useEffect, useRef, useState} from "react";
-import ForceGraph3D, {ForceGraphMethods} from "react-force-graph-3d";
-import {PerspectiveCamera, Scene, Vector3, AxesHelper} from "three";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import ForceGraph3D, {
+    ForceGraphMethods,
+    GraphData,
+    NodeObject,
+} from "react-force-graph-3d";
+import {AxesHelper, PerspectiveCamera} from "three";
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js';
 
 function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: number }) {
     const fgRef = useRef<ForceGraphMethods>(undefined);
-    const counter = useRef<number>(0);
-    const mainEffectCounter = 1
+    const axesHelperRef = useRef<AxesHelper>(undefined);
+    const rotateTimer = useRef<ReturnType<typeof setInterval>>(undefined);
+    const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-    // eslint-disable-next-line prefer-const
-    let Graph: any;
-
-    let parsedData: { nodes: never[], links: never[] }
-    try {
-        parsedData = JSON.parse(data)
-    } catch (err) {
-        let errorMessage
-        if (err instanceof Error) {
-            errorMessage = err.cause;
+    const graphData = useMemo<GraphData>(() => {
+        try {
+            return JSON.parse(data) as GraphData;
+        } catch (error) {
+            const cause = error instanceof Error ? error.cause : undefined;
+            console.error(`-- JSON Parsing error --\n${error}\n-- Cause --\n${cause}`)
+            return {nodes: [], links: []};
         }
-        console.error(`-- JSON Parsing error --\n${err}\n-- Cause --\n${errorMessage}`)
-        parsedData = {nodes: [], links: []}
-    }
+    }, [data]);
 
-    const [graphData, setGraphData] = useState({nodes: [], links: []});
+    const [clickEnabled, setClickEnabled] = useState(false);
+    const [areAxesVisible, setAreAxesVisible] = useState(false);
+    const [isRotationActive, setIsRotationActive] = useState(true);
 
-    const rotateTimer = useRef<NodeJS.Timeout>(undefined);
-
-    const [clickEnabled, setClickEnabled] = useState<boolean>(false);
-
-    const defaultAxesVisible = false;
-    const [areAxesVisible, setAreAxesVisible] = useState<boolean>(defaultAxesVisible.valueOf());
-
-    const defaultStartRotation = true;
-    const [isRotationActive, setIsRotationActive] = useState<boolean>(defaultStartRotation.valueOf());
-
-    function rotate() {
-        if (rotateTimer.current === undefined) {
-            const threeControls = (fgRef.current?.controls() as TrackballControls)
-            const threeCamera = fgRef.current?.camera() as PerspectiveCamera
-            console.debug("--------------------------------")
-            console.debug("camera pos ", threeCamera.position)
-            console.debug("camera up ", threeCamera.up)
-            const worldDir = new Vector3();
-            threeCamera.getWorldDirection(worldDir)
-            console.debug("world dir ", worldDir)
-            console.debug("control target  ", threeControls.target)
-            console.debug("--------------------------------")
-
-
-            rotateTimer.current = setInterval(() => {
-                if (fgRef.current !== undefined) {
-                    const threeCam = fgRef.current.camera() as PerspectiveCamera
-                    const upVec = threeCam.up.clone()
-                    threeCam.position.applyAxisAngle(upVec, -Math.PI / 300);
-
-                    threeCam.rotateOnAxis(upVec, -Math.PI / 300); // rotate the OBJECT
-                }
-            }, 20);
-        } else {
-            console.debug("ROTATE rotation already on")
+    const stopRotation = useCallback(() => {
+        if (rotateTimer.current !== undefined) {
+            clearInterval(rotateTimer.current);
+            rotateTimer.current = undefined;
         }
-    }
+    }, []);
 
-    function disableRotate() {
-        clearInterval(rotateTimer.current)
-        rotateTimer.current = undefined
-    }
-
-    function showAxes() {
-        if (fgRef.current !== undefined) {
-            const threeScene = (fgRef.current.scene() as Scene)
-            const axesHelper = threeScene.getObjectByName("myAxesHelper")!
-            axesHelper.visible = true;
+    const startRotation = useCallback(() => {
+        const graph = fgRef.current;
+        if (graph === undefined || rotateTimer.current !== undefined) {
+            return;
         }
-    }
 
-    function hideAxes() {
-        if (fgRef.current !== undefined) {
-            const threeScene = (fgRef.current.scene() as Scene)
-            const axesHelper = threeScene.getObjectByName("myAxesHelper")!
-            axesHelper.visible = false;
-        }
-    }
+        rotateTimer.current = setInterval(() => {
+            const currentGraph = fgRef.current;
+            if (currentGraph === undefined) {
+                return;
+            }
+
+            const currentCamera = currentGraph.camera() as PerspectiveCamera;
+            const up = currentCamera.up.clone();
+            currentCamera.position.applyAxisAngle(up, -Math.PI / 300);
+            currentCamera.rotateOnAxis(up, -Math.PI / 300);
+        }, 20);
+    }, []);
 
     useEffect(() => {
-        if (fgRef.current !== undefined) {
-            counter.current += 1;
-            console.debug("!!! updated counter:", counter.current)
-            if (counter.current == mainEffectCounter) {
-                console.info("MAIN USE EFFECT!")
-                setGraphData(parsedData);
-
-                const threeCamera = (fgRef.current.camera() as PerspectiveCamera)
-                const threeControls = (fgRef.current.controls() as TrackballControls)
-                threeControls.noPan = true
-                threeControls.zoomSpeed = 1.0
-
-                console.debug("Starting PerspectiveCamera", threeCamera.fov, threeCamera.aspect, threeCamera.near, threeCamera.far)
-                threeCamera.fov = 40
-                threeCamera.near = 1
-                threeCamera.far = 200
-                threeCamera.updateProjectionMatrix()
-                console.info("Changed PerspectiveCamera", threeCamera.fov, threeCamera.aspect, threeCamera.near, threeCamera.far)
-
-                const threeScene = (fgRef.current.scene() as Scene)
-                const axesHelper = new AxesHelper(5000);
-                axesHelper.name = "myAxesHelper";
-                axesHelper.visible = defaultAxesVisible;
-                threeScene.add(axesHelper);
-
-                fgRef.current.refresh();
-
-                console.debug("!!! STARTING timers")
-                if (defaultStartRotation) {
-                    setTimeout(() => {
-                        setIsRotationActive(true);
-                        console.info("SET isRotationActive to true!");
-                    }, 200)
-                }
-                setTimeout(() => {
-                    setClickEnabled(true);
-                    console.info("SET clickEnabled to true!");
-                    fgRef.current?.refresh();
-                }, enableDelay)
-            }
-            if (counter.current >= mainEffectCounter) {
-                (fgRef.current.controls() as TrackballControls).update();
-                console.debug("!!! updated controls !!!");
-            }
+        const graph = fgRef.current;
+        if (graph === undefined) {
+            return;
         }
-    }, [defaultAxesVisible, defaultStartRotation, parsedData, enableDelay]);
 
+        const camera = graph.camera() as PerspectiveCamera;
+        const controls = graph.controls() as TrackballControls;
+        controls.noPan = true;
+        controls.zoomSpeed = 1.0;
+        camera.fov = 40;
+        camera.near = 1;
+        camera.far = 200;
+        camera.updateProjectionMatrix();
 
-    function printNode(node: any) {
-        return `Node ${node.id}: x = ${node.x}, y = ${node.y}, z = ${node.z}, fx = ${node.fx}, fy = ${node.fy}, fz = ${node.fz}`;
-    }
+        const scene = graph.scene();
+        const axesHelper = new AxesHelper(5000);
+        axesHelper.name = "myAxesHelper";
+        axesHelper.visible = false;
+        axesHelperRef.current = axesHelper;
+        scene.add(axesHelper);
+
+        controls.update();
+        graph.refresh();
+        setClickEnabled(false);
+
+        const interactionTimer = setTimeout(() => {
+            setClickEnabled(true);
+            fgRef.current?.refresh();
+        }, enableDelay);
+
+        return () => {
+            clearTimeout(interactionTimer);
+            if (resetTimer.current !== undefined) {
+                clearTimeout(resetTimer.current);
+                resetTimer.current = undefined;
+            }
+            stopRotation();
+            scene.remove(axesHelper);
+            axesHelper.geometry.dispose();
+            const materials = Array.isArray(axesHelper.material)
+                ? axesHelper.material
+                : [axesHelper.material];
+            materials.forEach((material) => material.dispose());
+            if (axesHelperRef.current === axesHelper) {
+                axesHelperRef.current = undefined;
+            }
+        };
+    }, [enableDelay, graphData, stopRotation]);
 
     const handleDragEnd = useCallback(
-        (node: any) => {
+        (node: NodeObject) => {
             if (clickEnabled) {
-                Graph?.props.graphData.nodes.forEach((origNode: any) => {
+                graphData.nodes.forEach((origNode) => {
                     if (origNode.fx !== undefined && origNode.x !== node.x && origNode.y !== node.y && origNode.z !== node.z) {
-                        console.debug("UNFIXED previously dragged node - before", printNode(origNode));
                         origNode.fx = undefined
                         origNode.fy = undefined
                         origNode.fz = undefined
-                        console.debug("UNFIXED previously dragged node - after", printNode(origNode));
                     }
                 })
-                console.debug("NODE DRAG END - current", printNode(node))
                 node.fx = node.x;
                 node.fy = node.y;
                 node.fz = node.z;
-                console.debug("NODE DRAG END - set fx, fy, fz to x, y, z", printNode(node))
             }
         },
-        [Graph?.props.graphData.nodes, clickEnabled]
+        [clickEnabled, graphData.nodes]
     );
 
-
     const handleClick = useCallback(
-        (node: any) => {
+        (node: NodeObject) => {
             if (clickEnabled) {
                 if (isRotationActive) {
                     setIsRotationActive(false)
                 }
 
                 handleDragEnd(node)
-                console.debug("LEFT CLICK - current", printNode(node))
+                if (node.x === undefined || node.y === undefined || node.z === undefined) {
+                    return;
+                }
+
                 const viewDistance = 80;
                 const distRatio = 1 + viewDistance / Math.hypot(node.x, node.y, node.z);
 
@@ -187,13 +151,11 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
     );
 
     const handleRightClick = useCallback(
-        (node: any) => {
+        (node: NodeObject) => {
             if (clickEnabled && node.fx !== undefined) {
-                console.debug("RIGHT CLICK - current", printNode(node))
                 node.fx = undefined
                 node.fy = undefined
                 node.fz = undefined
-                console.debug("RIGHT CLICK - set fx, fy, fz to undefined", printNode(node))
             }
         },
         [clickEnabled]
@@ -201,62 +163,61 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
 
     const handleAxesClick = useCallback(
         () => {
-            setAreAxesVisible(!areAxesVisible)
-        }, [areAxesVisible]
+            setAreAxesVisible((visible) => !visible)
+        }, []
     )
-
 
     const handleRotationClick = useCallback(
         () => {
-            setIsRotationActive(!isRotationActive)
-        }, [isRotationActive]
+            setIsRotationActive((active) => !active)
+        }, []
     )
 
     const handleResetClick = useCallback(
         () => {
-            if (fgRef.current !== undefined) {
-                if (isRotationActive) {
-                    console.debug("RESET camera turn OFF rotation ")
-                    disableRotate()
+            const graph = fgRef.current;
+            if (graph !== undefined) {
+                if (resetTimer.current !== undefined) {
+                    clearTimeout(resetTimer.current);
+                    resetTimer.current = undefined;
                 }
-                fgRef.current.zoomToFit(1000)
-                setTimeout(() => {
+                if (isRotationActive) {
+                    stopRotation()
+                }
+                graph.zoomToFit(1000)
+                resetTimer.current = setTimeout(() => {
+                    resetTimer.current = undefined;
                     if (isRotationActive) {
-                        console.debug("RESET camera turn ON rotation ")
-                        rotate()
+                        startRotation()
                     }
                 }, 1001)
             }
-        }, [isRotationActive]
+        }, [isRotationActive, startRotation, stopRotation]
     )
 
+    useEffect(() => {
+        if (isRotationActive) {
+            startRotation();
+        } else {
+            stopRotation();
+        }
+
+        return () => {
+            stopRotation();
+            if (resetTimer.current !== undefined) {
+                clearTimeout(resetTimer.current);
+                resetTimer.current = undefined;
+            }
+        };
+    }, [graphData, isRotationActive, startRotation, stopRotation])
 
     useEffect(() => {
-        if (fgRef.current !== undefined && counter.current >= mainEffectCounter) {
-            if (!isRotationActive) {
-                console.debug("USE EFFECT turn OFF rotation ")
-                disableRotate()
-            } else {
-                console.debug("USE EFFECT turn ON rotation ")
-                rotate()
-            }
+        if (axesHelperRef.current !== undefined) {
+            axesHelperRef.current.visible = areAxesVisible;
         }
-    }, [isRotationActive])
+    }, [areAxesVisible, graphData])
 
-
-    useEffect(() => {
-        if (fgRef.current !== undefined && counter.current >= mainEffectCounter) {
-            if (!areAxesVisible) {
-                console.debug("USE EFFECT axes HIDE")
-                hideAxes()
-            } else {
-                console.debug("USE EFFECT axes SHOW")
-                showAxes()
-            }
-        }
-    }, [areAxesVisible])
-
-    Graph = <ForceGraph3D
+    const Graph = <ForceGraph3D
         ref={fgRef}
         controlType="trackball"
         backgroundColor="#000003"
@@ -273,7 +234,6 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
         onNodeDragEnd={handleDragEnd}
         onNodeRightClick={handleRightClick}
     />
-
 
     return <div className="bg-background text-foreground">
         {Graph}

--- a/app/components/focusGraphResources.ts
+++ b/app/components/focusGraphResources.ts
@@ -1,0 +1,96 @@
+import type {AxesHelper, Scene} from "three";
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type TimerScheduler = {
+    setInterval(callback: () => void, delay: number): IntervalHandle;
+    clearInterval(handle: IntervalHandle): void;
+    setTimeout(callback: () => void, delay: number): TimeoutHandle;
+    clearTimeout(handle: TimeoutHandle): void;
+};
+
+export function createFocusGraphResources(
+    scheduler: TimerScheduler = globalThis,
+) {
+    let rotationTimer: IntervalHandle | undefined;
+    let resetTimer: TimeoutHandle | undefined;
+    let interactionTimer: TimeoutHandle | undefined;
+    let axes: {scene: Scene; helper: AxesHelper} | undefined;
+
+    const stopRotation = () => {
+        if (rotationTimer !== undefined) {
+            scheduler.clearInterval(rotationTimer);
+            rotationTimer = undefined;
+        }
+    };
+
+    const cancelReset = () => {
+        if (resetTimer !== undefined) {
+            scheduler.clearTimeout(resetTimer);
+            resetTimer = undefined;
+        }
+    };
+
+    const cancelInteraction = () => {
+        if (interactionTimer !== undefined) {
+            scheduler.clearTimeout(interactionTimer);
+            interactionTimer = undefined;
+        }
+    };
+
+    const detachAxes = () => {
+        if (axes === undefined) {
+            return;
+        }
+
+        const {scene, helper} = axes;
+        axes = undefined;
+        scene.remove(helper);
+        helper.geometry.dispose();
+        const materials = Array.isArray(helper.material)
+            ? helper.material
+            : [helper.material];
+        materials.forEach((material) => material.dispose());
+    };
+
+    return {
+        startRotation(callback: () => void) {
+            if (rotationTimer === undefined) {
+                rotationTimer = scheduler.setInterval(callback, 20);
+            }
+        },
+        stopRotation,
+        scheduleReset(callback: () => void, delay: number) {
+            cancelReset();
+            resetTimer = scheduler.setTimeout(() => {
+                resetTimer = undefined;
+                callback();
+            }, delay);
+        },
+        cancelReset,
+        scheduleInteraction(callback: () => void, delay: number) {
+            cancelInteraction();
+            interactionTimer = scheduler.setTimeout(() => {
+                interactionTimer = undefined;
+                callback();
+            }, delay);
+        },
+        attachAxes(scene: Scene, helper: AxesHelper) {
+            detachAxes();
+            axes = {scene, helper};
+            scene.add(helper);
+        },
+        setAxesVisible(visible: boolean) {
+            if (axes !== undefined) {
+                axes.helper.visible = visible;
+            }
+        },
+        cleanup() {
+            stopRotation();
+            cancelReset();
+            cancelInteraction();
+            detachAxes();
+        },
+    };
+}

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-8
 title: harden-focusgraph-lifecycle-an
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T03:44:48.480Z'
-updated_at: '2026-07-18T03:44:48.481Z'
+updated_at: '2026-07-18T03:48:12.262Z'

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-18T08:05:46.765Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T03:44:48.480Z'
-updated_at: '2026-07-18T04:00:52.178Z'
+updated_at: '2026-07-18T08:05:46.766Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-8
 title: harden-focusgraph-lifecycle-an
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T03:44:48.480Z'
-updated_at: '2026-07-18T03:48:12.262Z'
+updated_at: '2026-07-18T04:00:52.178Z'

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-8
 title: harden-focusgraph-lifecycle-an
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T03:44:48.480Z'
-updated_at: '2026-07-18T08:23:34.865Z'
+updated_at: '2026-07-18T08:23:40.970Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-8
+title: harden-focusgraph-lifecycle-an
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-18T03:44:48.480Z'
+updated_at: '2026-07-18T03:44:48.481Z'

--- a/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
+++ b/codev/projects/bugfix-8-harden-focusgraph-lifecycle-an/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-18T08:05:46.765Z'
+    approved_at: '2026-07-18T08:23:34.864Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T03:44:48.480Z'
-updated_at: '2026-07-18T08:05:46.766Z'
-pr_ready_for_human: true
+updated_at: '2026-07-18T08:23:34.865Z'
+pr_ready_for_human: false

--- a/codev/state/bugfix-8_thread.md
+++ b/codev/state/bugfix-8_thread.md
@@ -14,3 +14,4 @@
 
 - Replaced the counter guard with symmetric effect setup/cleanup, stable memoized graph data, owned timer/helper refs, and direct node-data callbacks. Removed the ambient Three declaration and handled the typed material union during disposal.
 - Added `tests/focus-graph-lifecycle.test.mjs`. Lint, clean typecheck, unit tests (14/14), production build/start, Playwright smoke, and a development-mode control/error check pass.
+- Initial CMAP: Gemini approved; Codex requested a behavioral resource-ownership regression instead of source-only assertions; Claude was unavailable due quota. Extracted the timer/axes owner into `focusGraphResources.ts` and replaced the cleanup regex test with an injected-scheduler/scene test covering replay, replacement, idempotency, and teardown.

--- a/codev/state/bugfix-8_thread.md
+++ b/codev/state/bugfix-8_thread.md
@@ -1,0 +1,16 @@
+# Bugfix #8 builder thread
+
+## Investigate
+
+- Confirmed issue #7 is merged at `d605178`; no competing open PR exists.
+- Reproduced in development with the pinned Node 22.23.1/npm 10.9.8 toolchain: one page mount logged the main effect three times (`counter` 1, 2, and 3). React's development setup/cleanup replay accounts for the second run, while `parsedData` being reconstructed on render makes it an unstable dependency and causes the third.
+- The counter at `FocusGraph.tsx:10-11,89-135` suppresses later setup rather than making setup/cleanup symmetric. The first setup creates two timeouts and an axes helper with no cleanup; the rotation effect separately creates an interval with no unmount cleanup. Reset creates another untracked timeout.
+- `handleDragEnd` reads nodes from the transient `Graph` React element and lists `Graph?.props.graphData.nodes` as a callback dependency instead of using component graph data.
+- Axes are found by a global scene name and only hidden/shown; setup can add duplicates and never removes/disposes the helper.
+- Removing `FocusGraph.d.ts` in a temporary clean typecheck confirmed the installed Three types already cover the current application without compiler errors. The ambient declaration nevertheless blankets all Three imports as `any` and must be removed.
+- Expected fix is contained to `FocusGraph.tsx`, deletion of `FocusGraph.d.ts`, and a focused lifecycle regression test, comfortably within BUGFIX scope.
+
+## Fix
+
+- Replaced the counter guard with symmetric effect setup/cleanup, stable memoized graph data, owned timer/helper refs, and direct node-data callbacks. Removed the ambient Three declaration and handled the typed material union during disposal.
+- Added `tests/focus-graph-lifecycle.test.mjs`. Lint, clean typecheck, unit tests (14/14), production build/start, Playwright smoke, and a development-mode control/error check pass.

--- a/tests/focus-graph-lifecycle.test.mjs
+++ b/tests/focus-graph-lifecycle.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import {access, readFile} from "node:fs/promises";
+import test from "node:test";
+import {URL} from "node:url";
+
+const focusGraphPath = new URL(
+    "../app/components/FocusGraph.tsx",
+    import.meta.url,
+);
+const ambientDeclarationPath = new URL(
+    "../app/components/FocusGraph.d.ts",
+    import.meta.url,
+);
+const source = await readFile(focusGraphPath, "utf8");
+
+test("uses stable graph data directly without blanket Three type suppression", async () => {
+    await assert.rejects(access(ambientDeclarationPath));
+    assert.match(source, /const graphData = useMemo<GraphData>/);
+    assert.match(source, /graphData\.nodes\.forEach/);
+    assert.doesNotMatch(source, /Graph\?\.props\.graphData/);
+    assert.doesNotMatch(source, /mainEffectCounter|counter\.current/);
+});
+
+test("owns and cleans up graph lifecycle resources", () => {
+    assert.match(source, /clearTimeout\(interactionTimer\)/);
+    assert.match(source, /clearTimeout\(resetTimer\.current\)/);
+    assert.match(source, /clearInterval\(rotateTimer\.current\)/);
+    assert.match(source, /scene\.remove\(axesHelper\)/);
+    assert.match(source, /axesHelper\.geometry\.dispose\(\)/);
+    assert.match(source, /material\.dispose\(\)/);
+});

--- a/tests/focus-graph-lifecycle.test.mjs
+++ b/tests/focus-graph-lifecycle.test.mjs
@@ -3,6 +3,8 @@ import {access, readFile} from "node:fs/promises";
 import test from "node:test";
 import {URL} from "node:url";
 
+import {createFocusGraphResources} from "../app/components/focusGraphResources.ts";
+
 const focusGraphPath = new URL(
     "../app/components/FocusGraph.tsx",
     import.meta.url,
@@ -21,11 +23,71 @@ test("uses stable graph data directly without blanket Three type suppression", a
     assert.doesNotMatch(source, /mainEffectCounter|counter\.current/);
 });
 
-test("owns and cleans up graph lifecycle resources", () => {
-    assert.match(source, /clearTimeout\(interactionTimer\)/);
-    assert.match(source, /clearTimeout\(resetTimer\.current\)/);
-    assert.match(source, /clearInterval\(rotateTimer\.current\)/);
-    assert.match(source, /scene\.remove\(axesHelper\)/);
-    assert.match(source, /axesHelper\.geometry\.dispose\(\)/);
-    assert.match(source, /material\.dispose\(\)/);
+test("replay and cleanup leave no stale timers or axes helpers", () => {
+    let nextHandle = 0;
+    const intervals = new Map();
+    const timeouts = new Map();
+    const scheduler = {
+        setInterval(callback) {
+            const handle = ++nextHandle;
+            intervals.set(handle, callback);
+            return handle;
+        },
+        clearInterval(handle) {
+            intervals.delete(handle);
+        },
+        setTimeout(callback) {
+            const handle = ++nextHandle;
+            timeouts.set(handle, callback);
+            return handle;
+        },
+        clearTimeout(handle) {
+            timeouts.delete(handle);
+        },
+    };
+    const sceneObjects = new Set();
+    const scene = {
+        add: (object) => sceneObjects.add(object),
+        remove: (object) => sceneObjects.delete(object),
+    };
+    const disposalCounts = new Map();
+    const axesHelper = (name) => {
+        const dispose = () =>
+            disposalCounts.set(name, (disposalCounts.get(name) ?? 0) + 1);
+        return {
+            geometry: {dispose},
+            material: [{dispose}],
+            visible: false,
+        };
+    };
+    const resources = createFocusGraphResources(scheduler);
+    const firstAxes = axesHelper("first");
+    const replacementAxes = axesHelper("replacement");
+    const liveAxes = axesHelper("live");
+
+    resources.attachAxes(scene, firstAxes);
+    resources.attachAxes(scene, replacementAxes);
+    assert.deepEqual([...sceneObjects], [replacementAxes]);
+    assert.equal(disposalCounts.get("first"), 2);
+    resources.cleanup();
+    assert.equal(sceneObjects.size, 0);
+    assert.equal(disposalCounts.get("replacement"), 2);
+
+    // React development replay sets the same effect up again after cleanup.
+    resources.startRotation(() => {});
+    resources.startRotation(() => {});
+    resources.scheduleInteraction(() => assert.fail("stale interaction"), 4000);
+    resources.scheduleReset(() => assert.fail("replaced reset"), 1000);
+    resources.scheduleReset(() => assert.fail("stale reset"), 1000);
+    resources.attachAxes(scene, liveAxes);
+
+    assert.equal(intervals.size, 1, "rotation setup must be idempotent");
+    assert.equal(timeouts.size, 2, "only live interaction/reset timers remain");
+    assert.deepEqual([...sceneObjects], [liveAxes]);
+
+    resources.cleanup();
+    assert.equal(intervals.size, 0);
+    assert.equal(timeouts.size, 0);
+    assert.equal(sceneObjects.size, 0);
+    assert.equal(disposalCounts.get("live"), 2);
 });


### PR DESCRIPTION
## Summary

Make FocusGraph setup and teardown symmetric across React development replay, data replacement, and unmount while preserving its graph controls and delayed interaction behavior. Remove the blanket Three.js ambient declaration and use the installed library types directly.

Fixes #8

## Root Cause

FocusGraph rebuilt parsed graph data on every render and used a one-shot counter to suppress repeat effect setup. The effect, rotation, and reset paths created unowned timers, while axes helpers were added by name without teardown. Drag callbacks also depended on props read from a transient React element, and `FocusGraph.d.ts` suppressed all Three.js type checking.

## Fix

- Memoize parsed graph data and use it directly in callbacks and the graph component.
- Give rotation/reset timers and the axes helper explicit refs with symmetric effect cleanup.
- Reconfigure and recreate resources safely after Strict Mode setup/cleanup replay or dependency replacement.
- Remove the ambient `declare module 'three'` shim and dispose typed axes materials safely.
- Add a lifecycle/type regression contract test.

## Test Plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit --incremental false --pretty false`
- [x] `npm test` (14/14)
- [x] `npm run build`
- [x] Production `npm run start` via Playwright smoke
- [x] `npx playwright test`
- [x] Development-mode canvas/control verification with no console, hydration, page, or WebGL errors