### PR TITLE
[Spec 12] migrate-the-application-to-nex

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ nextjs-3d-force-graph-impl
 
 An implementation of 3d [react-force-graph](https://github.com/vasturiano/react-force-graph) in a [Next.js](https://github.com/vercel/next.js) App Router application and also uses some components directly from [Three.js](https://github.com/mrdoob/three.js).
 
-**NOTE**: Updated for React 19 and Next 15, the minimal changes made to files in this repo are backwards compatible with the previous package.json except for the useRef changes in FocusGraph.tsx.
+**NOTE**: Updated for React 19 and Next 16 Active LTS; production builds (`npm run build`) use the default Turbopack bundler. The original React 19 / Next 15 port made minimal changes to files in this repo that are backwards compatible with the previous package.json except for the useRef changes in FocusGraph.tsx.
 
 Serves as an example of combining various features of react-force-graph-3d + manipulating Three.js Camera, Controls and Scene + handling Next.js dynamic loading  
 

--- a/codev/plans/12-migrate-the-application-to-nex.md
+++ b/codev/plans/12-migrate-the-application-to-nex.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - **ID**: plan-2026-07-20-next-16-active-lts
-- **Status**: draft
+- **Status**: complete (all phases implemented, unanimously reviewed; PR #26)
 - **Specification**: [codev/specs/12-migrate-the-application-to-nex.md](../specs/12-migrate-the-application-to-nex.md)
 - **Created**: 2026-07-20
 
@@ -43,36 +43,36 @@ baseline — **never** `15.1.11`.
 
 Copied from the spec's acceptance scenarios and made implementation-checkable:
 
-- [ ] Target reverified at implementation time (FR1); drift escalated, not
+- [x] Target reverified at implementation time (FR1); drift escalated, not
       silently retargeted.
-- [ ] Official Next 16 codemod run in-branch and its output reviewed/curated;
+- [x] Official Next 16 codemod run in-branch and its output reviewed/curated;
       final manifest equals the exact target group (FR2).
-- [ ] `next@16.2.10` (dependencies) and `@next/eslint-plugin-next@16.2.10`
+- [x] `next@16.2.10` (dependencies) and `@next/eslint-plugin-next@16.2.10`
       (devDependencies) pinned exactly and string-equal; React/DOM unchanged at
       `19.2.7`; lockfile v3; clean `npm ci` with no manifest/lock mutation and no
       framework/3D-chain peer warnings (FR3).
-- [ ] `dev` is `next dev` (no `--turbopack`); no `next lint` invocation remains;
+- [x] `dev` is `next dev` (no `--turbopack`); no `next lint` invocation remains;
       `eslint .` passes under the 16.x plugin (FR4).
-- [ ] `next build` (Turbopack) succeeds; production `next start` serves the root
+- [x] `next build` (Turbopack) succeeds; production `next start` serves the root
       page HTTP 200; client bundle has no Node-only imports and resolves exactly
       one Three runtime through the client-only island (FR5).
-- [ ] No graph prop/handler/timer/camera/control semantic change except any Next
+- [x] No graph prop/handler/timer/camera/control semantic change except any Next
       16 strictly forces, which is called out explicitly (FR6).
-- [ ] Node policy (`22.23.1`) satisfies the Next 16 floor; supported-browser
+- [x] Node policy (`22.23.1`) satisfies the Next 16 floor; supported-browser
       policy verified and documented, compatible with the WebGL2 requirement (FR7).
-- [ ] `lint`, `typecheck`, `npm test`, Turbopack `build`, production `start`,
+- [x] `lint`, `typecheck`, `npm test`, Turbopack `build`, production `start`,
       `test:smoke`, aggregate `validate`, and the audit evidence pipeline all
       pass at the final commit (FR8).
-- [ ] Complete interaction matrix + smoke pass against the Turbopack build
+- [x] Complete interaction matrix + smoke pass against the Turbopack build
       (Chromium required gate + Firefox local qualification), zero unexpected
       errors, per #11 semantics (FR9, error budget).
-- [ ] Lockfile/audit delta documented path-by-path (exit codes preserved);
+- [x] Lockfile/audit delta documented path-by-path (exit codes preserved);
       nested Next-owned `postcss@8.4.31` explicitly dispositioned (FR10).
-- [ ] Supply-chain verification of every changed lockfile entry (registry-only
+- [x] Supply-chain verification of every changed lockfile entry (registry-only
       `resolved`, install-script delta) recorded (FR11).
-- [ ] `tests/toolchain.test.mjs` re-pinned to `16.2.10`; README/`automation.test`
+- [x] `tests/toolchain.test.mjs` re-pinned to `16.2.10`; README/`automation.test`
       enumerations stay truthful (FR12).
-- [ ] Single-revert rollback to `15.5.20` holds; blocking semantics honored (FR13).
+- [x] Single-revert rollback to `15.5.20` holds; blocking semantics honored (FR13).
 
 ## Phases (Machine Readable)
 
@@ -90,9 +90,9 @@ Copied from the spec's acceptance scenarios and made implementation-checkable:
 
 | Phase | Status |
 |-------|--------|
-| framework_upgrade | pending |
-| turbopack_behavioral_qualification | pending |
-| evidence_disposition_and_docs | pending |
+| framework_upgrade | complete |
+| turbopack_behavioral_qualification | complete |
+| evidence_disposition_and_docs | complete |
 
 ## Phase Breakdown
 

--- a/codev/plans/12-migrate-the-application-to-nex.md
+++ b/codev/plans/12-migrate-the-application-to-nex.md
@@ -1,0 +1,426 @@
+# Plan: Migrate the Application to Next 16 Active LTS
+
+## Metadata
+- **ID**: plan-2026-07-20-next-16-active-lts
+- **Status**: draft
+- **Specification**: [codev/specs/12-migrate-the-application-to-nex.md](../specs/12-migrate-the-application-to-nex.md)
+- **Created**: 2026-07-20
+
+## Executive Summary
+
+Implements the spec's selected **Approach C**: a codemod-driven, atomic upgrade
+of the framework from the patched Next 15 baseline (`next@15.5.20`) to Next 16
+Active LTS (`next@16.2.10`), adopting the now-default Turbopack production
+bundler and qualifying it behaviorally against the two-engine interaction matrix
+already established in #11.
+
+The migration surface is minimal (no middleware, no dynamic request APIs, empty
+`next.config.js`, one static async server component rendering a client-only WebGL
+island; React/DOM and the 3D stack stay exactly where #9/#11 qualified them). The
+operational changes Next 16 forces here are: run/review the official upgrade
+codemod, remove the now-redundant `--turbopack` dev flag, adopt and qualify the
+default Turbopack build, verify the Node/browser floors, and re-explain the
+lockfile/audit delta including the Next-owned nested PostCSS residual.
+
+The work lands as **one rollback unit** (single PR; phase commits within it),
+sequenced so each phase commit is coherent:
+
+1. **`framework_upgrade`** — reverify, run/review codemod, land the Next 16
+   manifest + lockfile, remove obsolete idioms, re-pin contract tests; reach a
+   statically-green Next 16 (lint/typecheck/unit + a building Turbopack bundle).
+2. **`turbopack_behavioral_qualification`** — qualify the Turbopack production
+   build and client WebGL bundle behaviorally: full two-engine matrix + smoke
+   (Chromium required gate + Firefox local), single-Three-runtime and
+   no-Node-only-import evidence, preserved semantics, Node/browser policy.
+3. **`evidence_disposition_and_docs`** — lockfile/audit delta path-by-path,
+   supply-chain verification of changed entries, explicit nested-PostCSS
+   disposition, and doc/enumeration truthfulness; assemble review-ready evidence.
+
+A single revert of the unit returns to the fully-qualified `next@15.5.20`
+baseline — **never** `15.1.11`.
+
+## Success Metrics
+
+Copied from the spec's acceptance scenarios and made implementation-checkable:
+
+- [ ] Target reverified at implementation time (FR1); drift escalated, not
+      silently retargeted.
+- [ ] Official Next 16 codemod run in-branch and its output reviewed/curated;
+      final manifest equals the exact target group (FR2).
+- [ ] `next@16.2.10` (dependencies) and `@next/eslint-plugin-next@16.2.10`
+      (devDependencies) pinned exactly and string-equal; React/DOM unchanged at
+      `19.2.7`; lockfile v3; clean `npm ci` with no manifest/lock mutation and no
+      framework/3D-chain peer warnings (FR3).
+- [ ] `dev` is `next dev` (no `--turbopack`); no `next lint` invocation remains;
+      `eslint .` passes under the 16.x plugin (FR4).
+- [ ] `next build` (Turbopack) succeeds; production `next start` serves the root
+      page HTTP 200; client bundle has no Node-only imports and resolves exactly
+      one Three runtime through the client-only island (FR5).
+- [ ] No graph prop/handler/timer/camera/control semantic change except any Next
+      16 strictly forces, which is called out explicitly (FR6).
+- [ ] Node policy (`22.23.1`) satisfies the Next 16 floor; supported-browser
+      policy verified and documented, compatible with the WebGL2 requirement (FR7).
+- [ ] `lint`, `typecheck`, `npm test`, Turbopack `build`, production `start`,
+      `test:smoke`, aggregate `validate`, and the audit evidence pipeline all
+      pass at the final commit (FR8).
+- [ ] Complete interaction matrix + smoke pass against the Turbopack build
+      (Chromium required gate + Firefox local qualification), zero unexpected
+      errors, per #11 semantics (FR9, error budget).
+- [ ] Lockfile/audit delta documented path-by-path (exit codes preserved);
+      nested Next-owned `postcss@8.4.31` explicitly dispositioned (FR10).
+- [ ] Supply-chain verification of every changed lockfile entry (registry-only
+      `resolved`, install-script delta) recorded (FR11).
+- [ ] `tests/toolchain.test.mjs` re-pinned to `16.2.10`; README/`automation.test`
+      enumerations stay truthful (FR12).
+- [ ] Single-revert rollback to `15.5.20` holds; blocking semantics honored (FR13).
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "framework_upgrade", "title": "Reverify, Run/Review Codemod, and Land the Next 16 Manifest + Contract Tests"},
+    {"id": "turbopack_behavioral_qualification", "title": "Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)"},
+    {"id": "evidence_disposition_and_docs", "title": "Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs"}
+  ]
+}
+```
+
+## Phase Status
+
+| Phase | Status |
+|-------|--------|
+| framework_upgrade | pending |
+| turbopack_behavioral_qualification | pending |
+| evidence_disposition_and_docs | pending |
+
+## Phase Breakdown
+
+### Phase 1: Reverify, Run/Review Codemod, and Land the Next 16 Manifest + Contract Tests
+**Dependencies**: None
+**Implements**: FR1, FR2, FR3, FR4, FR12 (contract-test pins); establishes the
+FR13 rollback unit.
+
+#### Objectives
+- Reach a statically-green Next 16 baseline: the framework and its lint plugin at
+  exactly `16.2.10`, obsolete idioms removed, contract tests re-pinned, and a
+  clean `npm ci` under the pinned toolchain.
+- Do this via the official codemod with reviewed, curated output — no incidental
+  version drift, no scope creep.
+
+#### Deliverables
+- [ ] **FR1 reverification** recorded (scratch notes → carried to the review):
+      `next@16.2.10` / `@next/eslint-plugin-next@16.2.10` still `latest`;
+      `engines.node >=20.9.0` (satisfied by `22.23.1`); React peer admits
+      `19.2.7`; no new *required* peer; no superseding 16.x patch. On any
+      contradiction (Node floor > `22.23.1`, new required peer, superseding
+      patch), **STOP and `afx send architect`** rather than retarget.
+- [ ] **FR2 codemod** run in-branch under Node `22.23.1`/npm `10.9.8`
+      (`npx @next/codemod@latest upgrade`, or the invocation the reverified
+      upgrade guide specifies); every proposed change reviewed. Curate: revert any
+      change outside the target group (e.g. React/type bumps, unrelated codemods);
+      a `next.config.js` → `next.config.ts`/ESM change is accepted only if Next 16
+      actually requires it, else config stays effectively empty. Record what the
+      codemod changed / kept / reverted.
+- [ ] **FR3 manifest + lockfile**: `package.json` `next` → `16.2.10`
+      (`dependencies`), `@next/eslint-plugin-next` → `16.2.10`
+      (`devDependencies`); regenerate `package-lock.json` via npm only; lockfile
+      stays v3; `next` and plugin string-equal; React/DOM untouched at `19.2.7`.
+- [ ] **FR4 obsolete idioms**: remove `--turbopack` from the `dev` script
+      (→ `next dev`); confirm (grep) no `next lint` invocation in scripts/CI/docs;
+      leave `lint` as `eslint .` and the flat config's direct
+      `@next/eslint-plugin-next` wiring intact.
+- [ ] **FR12 contract tests**: update `tests/toolchain.test.mjs`
+      `expectedDependencyBaseline` (`next` and `@next/eslint-plugin-next`
+      `15.5.20` → `16.2.10`), preserving the string-equality and lockfile-v3/Node
+      assertions.
+- [ ] Phase commit: `[Spec 12][Phase: framework_upgrade] chore: Upgrade Next to 16.2.10 Active LTS`.
+
+#### Implementation Details
+- Files: `package.json`, `package-lock.json`, `tests/toolchain.test.mjs`, and
+  **only if the codemod strictly requires it** `next.config.js` (or a migrated
+  `next.config.ts`) and/or `app/**` source. Expected app/config churn: none.
+- Toolchain discipline: run the codemod, then reconcile `package.json` to exactly
+  the target group by hand, then `npm install` once to settle the lockfile and
+  verify a subsequent `npm ci` is a no-op on the manifest/lock. Never regenerate
+  under another Node/npm.
+- Do not stage codemod byproducts (`.next/`, backups, editor files); stage
+  explicitly per the no-`git add -A` rule.
+
+#### Acceptance Criteria
+- [ ] `npm ci` completes clean, lockfile v3, no manifest/lock mutation, no
+      framework/3D-chain peer warnings.
+- [ ] `npm run lint` (eslint, 16.x plugin), `npm run typecheck`, and `npm test`
+      (incl. updated contract tests) pass.
+- [ ] `npm run build` (now Turbopack) completes and `npm run start` serves the
+      root page HTTP 200 — a build-sanity check; the *full* behavioral matrix is
+      Phase 2's gate.
+- [ ] Reverification + codemod review notes captured for the review.
+
+#### Test Plan
+- **Unit/contract**: `npm test` — `tests/toolchain.test.mjs` re-pin passes;
+  `tests/automation.test.mjs` still green (dev not enumerated there).
+- **Static**: lint + typecheck under the 16.x plugin.
+- **Build sanity**: `npm run build` + a one-shot `npm run start` HTTP 200 probe.
+
+#### Rollback Strategy
+Revert the phase commit → back to `next@15.5.20`. Because the manifest/lockfile
+move together in this commit, the revert is atomic.
+
+#### Risks
+- **Codemod proposes out-of-scope edits** → curate/revert; escalate genuinely
+  required but out-of-scope changes (FR2).
+- **16.x ESLint plugin changes a rule id/output the flat config relies on** →
+  reconcile explicitly in this phase; no silent absorption (FR4).
+- **Reverification contradicts target** → STOP + escalate (FR1), do not proceed.
+
+---
+
+### Phase 2: Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)
+**Dependencies**: Phase 1 (framework_upgrade)
+**Implements**: FR5, FR6, FR7, FR8, FR9, FR11 (error budget).
+
+#### Objectives
+- Prove the now-default Turbopack production build preserves the app's behavior:
+  the full interaction matrix + smoke pass against `next start`, the client bundle
+  is clean (no Node-only imports, one Three runtime), and semantics/timings are
+  unchanged.
+
+#### Deliverables
+- [ ] **FR5 client-bundle integrity** evidence:
+      - `npm ls three` → single `three@0.185.1`; no nested
+        `node_modules/**/node_modules/three` (also covered by the FR12 contract
+        test from #11).
+      - After `next build`, scan emitted `.next/static/` client assets for the
+        `node:` scheme and bare Node-builtin specifiers
+        (`grep -RolE "node:(fs|path|crypto|os|stream|util|process|module|child_process)" .next/static/`
+        plus the un-prefixed-builtin check) → no matches in shipped client
+        chunks. Commands + output captured for the review.
+- [ ] **FR9 behavioral qualification**: `npm run test:smoke` (build + Playwright:
+      `tests/e2e/smoke.spec.ts` + `tests/e2e/matrix.spec.ts` via
+      `tests/e2e/graph-handle.ts`) passes against the Turbopack build. Local run
+      exercises **both** engines (Chromium + Firefox) — the local qualification
+      gate; `E2E_ENGINES=chromium` is the required CI gate (reused from #11,
+      unchanged). `tests/focus-graph-lifecycle.test.mjs` passes under Next 16.
+      Class B items (drag/right-click) follow #11 acceptance semantics.
+- [ ] **FR6 preserved semantics**: confirm no graph prop/handler/timer/camera/
+      control change; expected `app/` diff = none. Any forced change called out.
+- [ ] **FR7 Node/browser policy**: confirm `22.23.1` ≥ Next 16 Node floor; verify
+      the Next 16 supported-browser policy from the upgrade guide and record it;
+      add a minimal `browserslist`/policy declaration only if Next 16 requires
+      one, else record that none is required.
+- [ ] **FR8 aggregate gate**: `npm run validate` green end-to-end (both engines
+      locally).
+- [ ] **FR11 error budget**: zero unexpected page/console/hydration/timer/
+      WebGL-context/GPU errors across smoke + matrix in both engines (strict
+      collection retained from #11).
+- [ ] Phase commit: `[Spec 12][Phase: turbopack_behavioral_qualification] test: Qualify Turbopack build across the two-engine matrix`.
+
+#### Implementation Details
+- Files: expected none in `app/`. Any test/CI/config change is limited to what a
+  genuine Turbopack/Next 16 difference forces (e.g. a launch-arg or waiter tweak),
+  called out explicitly and replayed against the `15.5.20` baseline before
+  attribution. A `browserslist` line in `package.json` only if FR7 requires it.
+- Evidence-first: if any matrix item diverges from baseline, replay the identical
+  input against the rollback baseline before attributing it to the upgrade; a
+  genuine regression is **blocking** (FR13) — escalate with evidence.
+
+#### Acceptance Criteria
+- [ ] `npm run validate` passes locally in both engines; `E2E_ENGINES=chromium`
+      passes (the CI gate).
+- [ ] Client-bundle scan shows no Node-only imports; single Three runtime
+      confirmed.
+- [ ] Node floor and browser policy verified and recorded; WebGL2 compatibility
+      confirmed.
+- [ ] Zero unexpected errors across all runs (error budget).
+
+#### Test Plan
+- **Integration/behavioral**: full Playwright suite (smoke + 13-item matrix) in
+  Chromium and Firefox against the Turbopack `next start`.
+- **Lifecycle unit**: `tests/focus-graph-lifecycle.test.mjs`.
+- **Bundle integrity**: `npm ls three` + `.next/static/` grep scans.
+
+#### Rollback Strategy
+Revert this phase commit to drop any qualification-driven test/CI tweaks; Phase 1
+(the framework itself) remains independently revertible beneath it.
+
+#### Risks
+- **Turbopack chunking/module-resolution differs from webpack, breaking the WebGL
+  island** → full numeric matrix + client-bundle scan; baseline replay before
+  attribution; blocking on genuine regression (FR13).
+- **A Node-only import leaks into a client chunk under Turbopack** → FR5 scan
+  catches it pre-commit.
+- **Firefox WebGL still unavailable on CI** (unchanged from #11) → reuse the
+  Chromium-required / Firefox-local split; not a regression.
+
+---
+
+### Phase 3: Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs
+**Dependencies**: Phase 2 (turbopack_behavioral_qualification)
+**Implements**: FR10, FR11, FR12 (docs/enumerations).
+
+#### Objectives
+- Produce the honest lockfile/audit/supply-chain story and disposition the
+  Next-owned nested PostCSS residual; keep docs and enumeration contract tests
+  truthful after the upgrade.
+
+#### Deliverables
+- [ ] **FR10 audit + lockfile delta**: before/after resolved versions for `next`,
+      `@next/eslint-plugin-next`, and every transitive entry the upgrade moved;
+      before/after `npm audit` (full) and `npm audit --omit=dev` (production)
+      comparisons path-by-path through `scripts/validate-audit-report.mjs`
+      semantics with original exit codes preserved; identify advisory paths
+      resolved/introduced/unchanged with ownership.
+- [ ] **Nested PostCSS disposition**: confirm `next@16.2.10` still pins
+      `node_modules/next/node_modules/postcss@8.4.31`; state it is Next-owned and
+      not app-controllable here; carry forward as a documented build-time residual
+      (not a new or closed finding).
+- [ ] **FR11 supply-chain**: for every changed lockfile entry, verify
+      `resolved` → `registry.npmjs.org` only (no git/tarball/alt-registry); flag
+      and explain any *newly introduced* install script; confirm (summary, no
+      exhaustive re-enumeration) pre-existing unchanged install scripts; confirm
+      clean `npm ci` behavior. Record findings.
+- [ ] **FR12 docs/enumerations**: update README for the `--turbopack` dev-flag
+      removal and any Turbopack build note; keep `tests/automation.test.mjs`
+      README/script enumerations green (they assert required scripts + README
+      command mentions + CI text — verify all still hold).
+- [ ] Phase commit: `[Spec 12][Phase: evidence_disposition_and_docs] docs: Record Next 16 audit/lockfile delta and update docs`.
+
+#### Implementation Details
+- Files: `README.md` (dev-flag/Turbopack note), possibly `tests/automation.test.mjs`
+  only if an enumeration genuinely changed, and evidence text destined for the
+  review document. Raw audit JSON stays local/CI evidence, not committed source.
+- The review document itself is authored in the SPIR **Review** phase (porch
+  drives it after Implement); this phase assembles the tables/notes it will carry.
+
+#### Acceptance Criteria
+- [ ] Audit evidence pipeline runs with original exit codes preserved; deltas
+      documented path-by-path.
+- [ ] Nested PostCSS residual explicitly dispositioned.
+- [ ] Supply-chain findings recorded; `npm ci` clean.
+- [ ] README truthful; `npm test` (incl. `automation.test.mjs`) green.
+
+#### Test Plan
+- **Contract/docs**: `npm test` — `automation.test.mjs` enumerations pass.
+- **Audit**: `npm run audit:full` / `npm run audit:production` through the
+  validate-audit-report script; exit codes preserved.
+- **Reproducibility**: a final clean `npm ci` is a no-op on manifest/lock.
+
+#### Rollback Strategy
+Docs/evidence-only phase — revert the commit to drop doc changes without touching
+the qualified framework or tests beneath it.
+
+#### Risks
+- **Audit shows a new production advisory introduced by Next 16** → document
+  path-by-path; if it crosses a policy line, escalate (not a silent pass); the
+  no-zero-findings-gate invariant still holds for pre-existing advisories.
+- **README enumeration drift breaks `automation.test.mjs`** → run `npm test`
+  before committing.
+
+---
+
+## Dependency Map
+```
+Phase 1 (framework_upgrade)
+   └─→ Phase 2 (turbopack_behavioral_qualification)
+          └─→ Phase 3 (evidence_disposition_and_docs) ─→ PR (one rollback unit)
+```
+
+## Resource Requirements
+### Development Resources
+- **Expertise**: Next.js App Router upgrades, Turbopack build behavior, Playwright
+  WebGL qualification, npm lockfile/audit hygiene under a pinned toolchain.
+- **Environment**: exact Node `22.23.1` / npm `10.9.8`; a local GPU-capable
+  machine for the Firefox arm of the two-engine local qualification (Chromium
+  SwiftShader is the deterministic CI/local gate).
+
+### Infrastructure
+- No new services. CI unchanged in shape (`.github/workflows/validation.yml`),
+  which already provisions Chromium and sets `E2E_ENGINES=chromium`.
+
+## Integration Points
+### External Systems
+- **npm registry** — the only sanctioned `resolved` source (FR11); target
+  reverification and lockfile regeneration hit it.
+### Internal Systems
+- **Playwright two-engine suite** (from #11) — reused unchanged as the behavioral
+  gate; **audit evidence pipeline** (`scripts/validate-audit-report.mjs`) — reused
+  for the FR10 delta.
+
+## Risk Analysis
+### Technical Risks
+| Risk | Probability | Impact | Mitigation | Owner |
+|------|------------|--------|------------|-------|
+| Turbopack build behaves differently from webpack and breaks the WebGL island | M | H | Full two-engine matrix + client-bundle scan; baseline replay; blocking (Phase 2, FR5/FR9/FR13) | Builder |
+| Codemod introduces out-of-scope drift | M | M | Review + curate every change; reconcile manifest to exact target (Phase 1, FR2) | Builder |
+| 16.x ESLint plugin changes rules the flat config relies on | L | M | Explicit reconciliation, no silent absorption (Phase 1, FR4) | Builder |
+| Node-only import leaks into a client chunk | L | H | `.next/static/` scan before commit (Phase 2, FR5) | Builder |
+| Reverification contradicts the researched target | L | M | STOP + escalate, no silent retarget (Phase 1, FR1) | Builder |
+| New production advisory from Next 16 | L | M | Path-by-path audit delta; escalate if it crosses policy (Phase 3, FR10) | Builder |
+
+### Schedule Risks
+Not tracked — SPIR measures progress by completed phases, not time.
+
+## Validation Checkpoints
+1. **After Phase 1**: `npm ci` clean; lint/typecheck/`npm test` green; Turbopack
+   build + start sanity; reverification + codemod review captured.
+2. **After Phase 2**: `npm run validate` green (both engines locally, Chromium CI
+   gate); client-bundle integrity + Node/browser policy confirmed; error budget
+   clean.
+3. **Before PR (after Phase 3)**: audit/lockfile delta + supply-chain + PostCSS
+   disposition recorded; docs truthful; a final clean `npm ci`; single-revert
+   rollback to `15.5.20` verified in reasoning.
+
+## Monitoring and Observability
+### Metrics to Track
+- Playwright suite pass/fail per engine and the strict error budget (0 unexpected
+  errors) — the standing behavioral signal.
+- Full/production `npm audit` counts before vs. after (evidence, not a gate).
+- First-load JS / bundle size for the graph route, webpack vs. Turbopack —
+  recorded in the review (nice-to-know, not a gate).
+### Logging Requirements
+- Playwright HTML report + test-results and audit JSON are CI artifacts
+  (unchanged), retained per the existing workflow.
+### Alerting
+- CI failure on the required Chromium gate is the alert; a genuine matrix
+  regression is blocking and escalated via `afx send architect`.
+
+## Documentation Updates Required
+- [ ] README: `--turbopack` dev-flag removal; Turbopack production-build note if
+      warranted.
+- [ ] `codev/reviews/12-migrate-the-application-to-nex.md` (authored in the Review
+      phase) carrying reverification, codemod review, matrix/bundle evidence,
+      audit/lockfile/supply-chain tables, PostCSS disposition, and Node/browser
+      policy.
+- [ ] Arch/lessons docs: routed via the `update-arch-docs` skill in the Review
+      phase only if a durable, cross-cutting fact emerged (e.g. "Next build =
+      Turbopack default from 16"); otherwise no change.
+
+## Post-Implementation Tasks
+- [ ] Full two-engine matrix re-run recorded as the qualification evidence.
+- [ ] Audit evidence snapshots captured (full + production).
+- [ ] Rollback path (`15.5.20`, never `15.1.11`) reconfirmed.
+- [ ] Verify phase after PR merge (per the project's Verify Phase instructions).
+
+## Consultation Log
+
+_To be populated by the SPIR 3-way consultation (Gemini, Codex, Claude) that
+porch runs after this draft, and updated after any human feedback._
+
+## Approval
+- [ ] Expert AI Consultation Complete (3-way)
+- [ ] Human plan-approval gate
+
+## Change Log
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-07-20 | Initial implementation plan | Plan phase draft | Builder (spir-12) |
+
+## Notes
+- No time estimates (SPIR: phases are done/not-done).
+- Elections confirmed by the architect at the spec gate: rely on the default
+  Turbopack bundler (no explicit `--webpack`/`--turbopack` flag); exact
+  string-equal `next`/plugin pins.
+- The PR is opened during/after Phase 3 with all phase commits on the branch
+  (per the project's PR Strategy: phases are git commits within one PR, not
+  separate PRs).

--- a/codev/plans/12-migrate-the-application-to-nex.md
+++ b/codev/plans/12-migrate-the-application-to-nex.md
@@ -129,7 +129,11 @@ FR13 rollback unit.
 - [ ] **FR4 obsolete idioms**: remove `--turbopack` from the `dev` script
       (→ `next dev`); confirm (grep) no `next lint` invocation in scripts/CI/docs;
       leave `lint` as `eslint .` and the flat config's direct
-      `@next/eslint-plugin-next` wiring intact.
+      `@next/eslint-plugin-next` wiring intact. Specifically re-verify under the
+      16.x plugin that `eslint.config.mjs`'s accesses still resolve —
+      `nextPlugin.configs.recommended.rules` and
+      `nextPlugin.configs['core-web-vitals'].rules` — since a changed plugin
+      export shape would break the config; reconcile explicitly if it moved.
 - [ ] **FR12 contract tests**: update `tests/toolchain.test.mjs`
       `expectedDependencyBaseline` (`next` and `@next/eslint-plugin-next`
       `15.5.20` → `16.2.10`), preserving the string-equality and lockfile-v3/Node
@@ -178,7 +182,7 @@ move together in this commit, the revert is atomic.
 
 ### Phase 2: Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)
 **Dependencies**: Phase 1 (framework_upgrade)
-**Implements**: FR5, FR6, FR7, FR8, FR9, FR11 (error budget).
+**Implements**: FR5, FR6, FR7, FR8, FR9 (matrix + error budget).
 
 #### Objectives
 - Prove the now-default Turbopack production build preserves the app's behavior:
@@ -211,9 +215,9 @@ move together in this commit, the revert is atomic.
       one, else record that none is required.
 - [ ] **FR8 aggregate gate**: `npm run validate` green end-to-end (both engines
       locally).
-- [ ] **FR11 error budget**: zero unexpected page/console/hydration/timer/
+- [ ] **FR9 error budget**: zero unexpected page/console/hydration/timer/
       WebGL-context/GPU errors across smoke + matrix in both engines (strict
-      collection retained from #11).
+      collection retained from #11). (Supply-chain FR11 is handled in Phase 3.)
 - [ ] Phase commit: `[Spec 12][Phase: turbopack_behavioral_qualification] test: Qualify Turbopack build across the two-engine matrix`.
 
 #### Implementation Details
@@ -281,9 +285,12 @@ Revert this phase commit to drop any qualification-driven test/CI tweaks; Phase 
       exhaustive re-enumeration) pre-existing unchanged install scripts; confirm
       clean `npm ci` behavior. Record findings.
 - [ ] **FR12 docs/enumerations**: update README for the `--turbopack` dev-flag
-      removal and any Turbopack build note; keep `tests/automation.test.mjs`
-      README/script enumerations green (they assert required scripts + README
-      command mentions + CI text — verify all still hold).
+      removal and any Turbopack build note; **update the stale version statement
+      on README line 6** ("Updated for React 19 and Next 15…") to reflect Next 16
+      (it is not asserted by `automation.test.mjs` but would otherwise be false);
+      keep `tests/automation.test.mjs` README/script enumerations green (they
+      assert required scripts + README command mentions + CI text — verify all
+      still hold).
 - [ ] Phase commit: `[Spec 12][Phase: evidence_disposition_and_docs] docs: Record Next 16 audit/lockfile delta and update docs`.
 
 #### Implementation Details
@@ -387,7 +394,8 @@ Not tracked — SPIR measures progress by completed phases, not time.
 
 ## Documentation Updates Required
 - [ ] README: `--turbopack` dev-flag removal; Turbopack production-build note if
-      warranted.
+      warranted; refresh the stale line-6 "React 19 and Next 15" statement to
+      Next 16.
 - [ ] `codev/reviews/12-migrate-the-application-to-nex.md` (authored in the Review
       phase) carrying reverification, codemod review, matrix/bundle evidence,
       audit/lockfile/supply-chain tables, PostCSS disposition, and Node/browser
@@ -404,8 +412,40 @@ Not tracked — SPIR measures progress by completed phases, not time.
 
 ## Consultation Log
 
-_To be populated by the SPIR 3-way consultation (Gemini, Codex, Claude) that
-porch runs after this draft, and updated after any human feedback._
+### Iteration 1 — initial three-way review (2026-07-20)
+
+- **Gemini: APPROVE (high confidence).** "Perfectly translates the spec into
+  three highly coherent, executable phases." Endorsed the phase split
+  (upgrade → qualification → evidence), the single-PR rollback unit with
+  coherent per-phase commits, and the FR5 `npm ls three` + `.next/static/` grep
+  evidence method. One note: Phase 2 mislabeled the error budget as FR11 (it is
+  FR9).
+- **Claude: APPROVE (high confidence).** Traced every FR (FR1–FR13) to a phase
+  and verified each factual claim against the codebase (dev script, pins, empty
+  config, static page, client island, contract-test pins, `dev` not enumerated
+  in `automation.test.mjs`, `E2E_ENGINES`, CI). Full coverage, correct ordering,
+  literally-executable acceptance criteria. Notes: same FR11→FR9 mislabel; the
+  stale README line-6 statement; and a refinement to name the exact
+  `nextPlugin.configs.recommended.rules` / `configs['core-web-vitals'].rules`
+  accesses to re-verify under the 16.x plugin.
+- **Codex: COMMENT (high confidence).** "Strong, implementation-ready plan with
+  good spec coverage." One point: README currently says "Updated for React 19
+  and Next 15", which becomes false after the upgrade — call the line out
+  explicitly. Otherwise file targets, sequencing, risks, and test strategy align
+  with the repo.
+
+**Changes applied (all feedback incorporated):**
+1. Corrected the Phase 2 error-budget label from FR11 → FR9 (header, deliverable,
+   and risk text); FR11 (supply-chain) remains correctly in Phase 3.
+2. Phase 3 FR12 now explicitly calls out refreshing the stale README line-6
+   "React 19 and Next 15" statement (also noted in Documentation Updates).
+3. Phase 1 FR4 now names the exact ESLint plugin config accesses to re-verify
+   under `@next/eslint-plugin-next@16.2.10`
+   (`nextPlugin.configs.recommended.rules`,
+   `nextPlugin.configs['core-web-vitals'].rules`).
+
+_Second consultation (after human/gate feedback) to be appended if the plan is
+revised at the plan-approval gate._
 
 ## Approval
 - [ ] Expert AI Consultation Complete (3-way)
@@ -415,6 +455,7 @@ porch runs after this draft, and updated after any human feedback._
 | Date | Change | Reason | Author |
 |------|--------|--------|--------|
 | 2026-07-20 | Initial implementation plan | Plan phase draft | Builder (spir-12) |
+| 2026-07-20 | FR11→FR9 label fix (Phase 2); explicit README line-6 refresh (Phase 3); named ESLint plugin config accesses (Phase 1) | 3-way plan review | Builder (spir-12) |
 
 ## Notes
 - No time estimates (SPIR: phases are done/not-done).

--- a/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-claude.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-claude.txt
@@ -1,0 +1,93 @@
+I'll review the plan against the spec and verify key claims against the actual codebase. Let me start by reading the relevant project files in parallel.Good — I've now read all the key project files. Let me check one more thing: the README to verify the plan's claims about documentation updates.I've now read all the key files. Let me compile my review.
+
+---
+
+## Plan Review: 12-migrate-the-application-to-nex
+
+### 1. Spec Coverage
+
+I traced every functional requirement (FR1–FR13) to a plan phase:
+
+| FR | Phase(s) | Covered? |
+|---|---|---|
+| FR1 (reverification) | Phase 1 | ✓ |
+| FR2 (codemod) | Phase 1 | ✓ |
+| FR3 (manifest/lockfile) | Phase 1 | ✓ |
+| FR4 (obsolete idioms) | Phase 1 | ✓ |
+| FR5 (Turbopack build) | Phase 2 | ✓ |
+| FR6 (preserved semantics) | Phase 2 | ✓ |
+| FR7 (Node/browser policy) | Phase 2 | ✓ |
+| FR8 (validation gates) | Phase 2 | ✓ |
+| FR9 (browser matrix) | Phase 2 | ✓ |
+| FR10 (audit/lockfile delta) | Phase 3 | ✓ |
+| FR11 (supply-chain) | Phase 3 | ✓ |
+| FR12 (contract tests/docs) | Phase 1 (pins) + Phase 3 (docs) | ✓ |
+| FR13 (rollback/blocking) | Cross-cutting | ✓ |
+
+All 10 acceptance scenarios map to plan deliverables. No phase goes beyond spec scope. Full coverage.
+
+### 2. Phase Breakdown & Ordering
+
+Three phases in a linear dependency chain — sound:
+
+1. **framework_upgrade** — land the manifest, lockfile, codemod output, contract test re-pins, build sanity.
+2. **turbopack_behavioral_qualification** — full two-engine matrix + bundle integrity against the Turbopack build.
+3. **evidence_disposition_and_docs** — audit delta, supply-chain, PostCSS disposition, README.
+
+The ordering respects dependencies: you can't qualify a build you haven't landed (Phase 2 → Phase 1), and you can't document the delta until it's qualified (Phase 3 → Phase 2). Each phase produces a coherent, independently-revertible commit. No phase is oversized or trivially small.
+
+### 3. Technical Approach — Verified Against the Codebase
+
+I verified every factual claim the plan makes:
+
+- **`package.json` line 8**: `"dev": "next dev --turbopack"` — confirmed; removing `--turbopack` is correct for Next 16. ✓
+- **`package.json` line 24/32**: `next: "15.5.20"` / `@next/eslint-plugin-next: "15.5.20"` — confirmed as the current baseline. ✓
+- **`next.config.js`**: effectively empty (`const nextConfig = {}; module.exports = nextConfig;`) — confirmed; minimal codemod surface. ✓
+- **`app/page.tsx`**: static async server component, no dynamic request APIs — confirmed. ✓
+- **`FocusGraphWrapper.tsx`**: `dynamic(() => import("./FocusGraph"), {ssr: false})` — confirmed; the client-only island pattern. ✓
+- **`eslint.config.mjs`**: flat config directly importing `@next/eslint-plugin-next` and wiring rules — confirmed; no dependency on `next lint`. ✓
+- **`tests/toolchain.test.mjs` lines 17-28**: `expectedDependencyBaseline` pins `next: "15.5.20"` and `@next/eslint-plugin-next: "15.5.20"` with a string-equality assertion (line 92-94) — confirmed. ✓
+- **`tests/automation.test.mjs` lines 80-91**: enumerates `lint`, `typecheck`, `build`, `start`, `browser:install`, `test:smoke`, `validate`, `audit:full`, `audit:production` — `dev` is **not** enumerated, so removing `--turbopack` from `dev` won't break these tests. ✓
+- **`playwright.config.ts`**: `E2E_ENGINES` selection, two-engine setup (Chromium + Firefox), `webServer` uses `npm run start` — confirmed. ✓
+- **CI workflow**: `E2E_ENGINES: chromium`, installs only Chromium, no `--turbopack` references — confirmed; no CI changes needed. ✓
+- **`test:smoke` script** (`npm run build && playwright test`): the build will automatically use Turbopack under Next 16 — no script change needed, which matches the plan. ✓
+
+The file list per phase is accurate and minimal. The plan correctly predicts near-zero `app/` source churn.
+
+### 4. Testability
+
+Each phase has concrete, runnable test criteria:
+
+- **Phase 1**: `npm ci` + `npm test` (re-pinned contract tests) + lint + typecheck + build sanity (Turbopack build + HTTP 200 probe). Clear and sufficient for a "statically green" checkpoint.
+- **Phase 2**: `npm run validate` (both engines locally), `npm ls three`, `.next/static/` grep scans, `focus-graph-lifecycle.test.mjs`. This is the heavyweight gate — the full behavioral proof.
+- **Phase 3**: `npm test` (including `automation.test.mjs` enumerations), audit pipeline with exit codes, clean `npm ci`.
+
+A builder can execute every acceptance criterion literally. The Defend step (writing tests) is straightforward since contract tests just need re-pinning, and behavioral tests are *reused*, not authored.
+
+### 5. Risk Assessment
+
+The six risks identified (Turbopack chunking, codemod scope creep, ESLint plugin rule changes, Node-only import leakage, reverification contradiction, new production advisory) are the right ones. Each has a specific mitigation tied to a plan deliverable.
+
+One implicit risk worth noting: the `eslint.config.mjs` accesses `nextPlugin.configs.recommended.rules` and `nextPlugin.configs['core-web-vitals'].rules` (lines 14-17). If `@next/eslint-plugin-next@16.2.10` changes the export shape (e.g., renamed or restructured configs), this would break. Phase 1's FR4 coverage addresses this ("reconcile explicitly, no silent absorption"), but a builder might benefit from knowing *exactly* which config property access to check. This is a refinement, not a gap.
+
+### 6. Issues Found
+
+**One labeling error (non-blocking):**
+
+Phase 2's header says it implements **"FR11 (error budget)"**, but FR11 in the spec is *Supply-chain verification of changed lockfile entries*, not the error budget. The zero-unexpected-errors requirement is part of **FR9** (browser matrix acceptance semantics). Phase 3 correctly covers the actual FR11 (supply-chain). The Phase 2 deliverables themselves are correct — the deliverable labeled "FR11 error budget" describes the error-budget requirement accurately — it's just tagged with the wrong FR number. A builder following the deliverable text would do the right thing, but the wrong FR label could cause confusion during review alignment.
+
+**One minor README note (non-blocking):**
+
+README line 6 says *"Updated for React 19 and Next 15"* — this will become stale after the upgrade. The plan covers README updates under Phase 3 FR12 ("keep enumerations green") and `automation.test.mjs` doesn't assert this specific text, so it won't cause a test failure. But a conscientious builder should update it. This is implicit in "stay truthful" but isn't explicitly called out.
+
+---
+
+**VERDICT: APPROVE**
+**SUMMARY: Thorough, codebase-accurate plan with correct phase ordering, complete FR coverage, and one cosmetic FR-labeling error in Phase 2 (FR11 should be FR9 for the error-budget deliverable)**
+**CONFIDENCE: HIGH**
+
+---
+
+KEY_ISSUES:
+- Phase 2 header and deliverable mislabel the error-budget requirement as "FR11" — it is part of FR9; FR11 (supply-chain) is correctly handled in Phase 3. Non-blocking: the deliverable text itself is correct, only the FR tag is wrong.
+- README line 6 ("Updated for React 19 and Next 15") will need updating, implicitly covered by Phase 3 FR12 "stay truthful" but not explicitly called out.

--- a/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-codex.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-codex.txt
@@ -1,0 +1,9 @@
+I'll verify the referenced files in the repo before judging the plan.I’m checking the remaining referenced app/test/workflow files that the plan relies on.---
+VERDICT: COMMENT
+SUMMARY: Strong, implementation-ready plan with good spec coverage; only minor doc-truthfulness clarification is missing.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- The plan should explicitly call out updating README text that currently says “Updated for React 19 and Next 15.” Phase 3 mentions README updates for `--turbopack` removal/Turbopack notes, but this existing version-specific statement will also become false after the upgrade.
+- None otherwise — file targets, sequencing, risks, and test strategy align well with the current repo state.

--- a/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-gemini.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-plan-iter1-gemini.txt
@@ -1,0 +1,14 @@
+---
+VERDICT: APPROVE
+SUMMARY: The plan perfectly translates the spec into three highly coherent and executable phases, honoring all constraints and rollback requirements.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None
+
+**Notes:**
+- **Phase Breakdown:** The 3-phase split (Framework Upgrade → Behavioral Qualification → Evidence/Docs) is excellent. It logically sequences the work so that the statically-green framework is established before the rigorous Turbopack matrix testing begins, keeping the documentation and audit delta tasks neatly separated at the end.
+- **Rollback Unit:** The plan correctly preserves the single-PR revertibility (FR13) while ensuring individual commits are coherent and independently revertible during the branch's development.
+- **Verification Evidence:** The use of `npm ls three` and the explicit `grep` scan of `.next/static/` for `node:` schemes and builtins is a robust, pragmatic way to fulfill the FR5 requirement (no Node-only imports in the client chunk).
+- **Minor Typo:** In Phase 2's Deliverables, "FR11 error budget" is listed, but the error budget is actually part of FR9 (FR11 is supply-chain verification). This is completely harmless as the text accurately describes the error budget tasks, and FR11 is correctly addressed in Phase 3.

--- a/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-claude.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-claude.txt
@@ -1,0 +1,89 @@
+I'll read the key project files to verify the spec's claims against the actual codebase before rendering a verdict.Now let me check the app page and a few remaining items to complete the verification.I've now read all the key project files. Let me compile my findings and render a verdict.
+
+## Specification Review: 12 — Migrate the Application to Next 16 Active LTS
+
+### 1. Codebase Verification — Factual Claims
+
+Every factual claim I could verify against the actual codebase checks out:
+
+| Claim | Verified |
+|---|---|
+| `next@15.5.20` / `@next/eslint-plugin-next@15.5.20` | ✅ `package.json` lines 24, 32 |
+| `react@19.2.7` / `react-dom@19.2.7` | ✅ lines 25–26 |
+| `dev` script is `next dev --turbopack` | ✅ line 8 |
+| `build` script is `next build` | ✅ line 9 |
+| `lint` script is `eslint .` (not `next lint`) | ✅ line 11 |
+| `next.config.js` effectively empty (`{}`) | ✅ confirmed |
+| No `middleware.*` file | ✅ glob returned empty |
+| `app/page.tsx` is a static async server component | ✅ `export default async function Index()` |
+| `FocusGraphWrapper.tsx` uses `dynamic(..., {ssr: false})` | ✅ exact match |
+| `FocusGraph.tsx` uses `AxesHelper`, `PerspectiveCamera`, `TrackballControls`, imperative ref | ✅ all present |
+| Camera: fov 40, near 1, far 200, focus distance 80 | ✅ lines 63–66 and 118 |
+| Enable delay 4000ms default, ~1s reset (1001ms) | ✅ lines 13, 164 |
+| Node `22.23.1` in `.nvmrc` and `engines` | ✅ both confirmed |
+| `@playwright/test@1.61.1` | ✅ line 33 |
+| Contract tests enforce `next`/plugin string equality | ✅ `toolchain.test.mjs` line 91–94 |
+| Playwright config selects engines via `E2E_ENGINES` | ✅ confirmed |
+| `eslint.config.mjs` directly wires `@next/eslint-plugin-next` | ✅ line 7, 12–18 |
+| `dev` not asserted by `automation.test.mjs` (so flag removal is contract-safe) | ✅ not in the enumerated script list (lines 81–90) |
+| `three@0.185.1`, `react-force-graph-3d@1.29.1` | ✅ lines 27–28 |
+
+No factual errors found.
+
+### 2. Completeness
+
+**Excellent.** The spec:
+- Precisely identifies the two-package change set and one script-flag removal — nothing more
+- Defines 13 functional requirements, each testable
+- Has 10 acceptance scenarios that map cleanly to the FRs
+- Explicitly scopes in/out with no ambiguity
+- Addresses supply-chain verification (FR11) — an often-missed concern in upgrade specs
+- Carries forward the PostCSS nested-dependency disposition rather than ignoring it
+- Defines clear rollback semantics to `15.5.20` (FR13)
+
+### 3. Correctness
+
+No contradictions found. The confirmed decisions are internally consistent:
+- Decision #5 (default Turbopack, no explicit `--turbopack`/`--webpack` flag) aligns with FR4/FR5
+- Decision #7 (exact equal pins) aligns with FR3/FR12
+- The in-scope/out-of-scope boundary is clean — no React/Tailwind/TypeScript scope creep
+
+### 4. Feasibility
+
+**High.** The migration surface is genuinely minimal:
+- No middleware, no dynamic request APIs, empty config, single page with one client island
+- Already on React 19.2.7, already using Turbopack for dev
+- The ESLint CLI path (#7) is already in place — the `next lint` removal is a non-event
+- The only novel qualification surface is the Turbopack *production* build (previously only used for dev), and the spec builds a full qualification protocol around it
+
+### 5. Testing Strategy
+
+**Thorough.** The spec reuses the #11 two-engine interaction matrix — a strong existing bar — and applies it against the Turbopack production build. The CI/local engine split (Chromium required, Firefox local) is explicitly reused unchanged. FR5 adds the client-bundle integrity checks (no Node-only imports, single Three runtime). FR8 requires all static gates to pass. This is comprehensive.
+
+### 6. Edge Cases and Risk Handling
+
+Well covered:
+- **Codemod drift** (FR2): curate output, revert out-of-scope changes, escalate genuinely required ones
+- **Target supersession** (FR1): reverify at implementation time, escalate on drift
+- **Bundler behavioral differences** (FR5/FR9): full numeric matrix + baseline replay before attribution
+- **ESLint plugin rule changes** (FR4): explicit reconciliation, no silent absorption
+- **Blocking semantics** (FR13): no partial workarounds, no silent `--webpack` fallback
+
+### 7. Minor Comments (Non-Blocking)
+
+1. **`next.config.js` → `next.config.ts`/ESM potential**: Next 16 may prefer or suggest ESM config format. The spec implicitly handles this through FR2 (codemod review) and the constraint that config stays empty unless Next 16 mandates a change — but it could be called out as a known potential codemod change surface. Not a gap, just a documentation opportunity.
+
+2. **README `dev` script reference**: The spec correctly notes via FR12 that the README must be updated for the `--turbopack` removal. The `automation.test.mjs` checks README mentions of scripts but doesn't assert exact command values, so this is clean. Just confirming the spec's reasoning holds.
+
+3. **Bundle size comparison**: The "Nice-to-know" section mentions webpack-vs-Turbopack bundle size as worth recording. I'd agree — since this is the first Turbopack production build, the review should record the delta even though it's not a gate. The spec already covers this.
+
+---
+
+**VERDICT: APPROVE**
+**SUMMARY: Exceptionally thorough, factually accurate spec for a well-scoped framework upgrade with minimal migration surface; every codebase claim verified.**
+**CONFIDENCE: HIGH**
+
+---
+
+**KEY_ISSUES:**
+- None. Every factual claim is verified against the codebase. Requirements are complete, testable, and correctly scoped. The qualification strategy is appropriate for the bundler change risk. The rollback contract is well-defined.

--- a/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-codex.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-codex.txt
@@ -1,0 +1,9 @@
+Using direct file reads to verify the spec against the actual repo context.---
+VERDICT: COMMENT
+SUMMARY: Strong, implementation-ready spec with clear scope and validation; only minor evidence-method clarifications would improve builder consistency.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- The spec should define the acceptable evidence method for FR5's “no Node-only imports reaches the client graph chunk” check (e.g. grep built chunks, build manifest inspection, or another explicit repo-local method) so builders don't invent inconsistent proofs.
+- FR9 relies on “the canonical matrix qualified in #11”; adding a direct pointer to the exact existing test file(s)/review section that define that matrix would make the requirement easier to execute without ambiguity.
+- FR10/FR11 are strong on lockfile review, but the review deliverable could more explicitly say whether unchanged pre-existing install scripts in the changed dependency subgraph must be re-listed or only newly introduced ones must be called out.

--- a/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-gemini.txt
+++ b/codev/projects/12-migrate-the-application-to-nex/12-specify-iter1-gemini.txt
@@ -1,0 +1,18 @@
+This specification is exceptionally thorough and well-aligned with the repository's strict validation, testing, and operational constraints.
+
+### Review Highlights
+
+1. **Completeness & Correctness**: The spec correctly identifies all moving parts, including exact package targets, the required changes to `tests/toolchain.test.mjs` for the string-equality assertions, and the nuance that `dev` is not enumerated in `tests/automation.test.mjs` while acknowledging that related docs (like the README) still need updates to reflect the removed `--turbopack` flag. 
+2. **Feasibility**: Relying on the official Next 16 codemod (`@next/codemod upgrade`) while strictly curating its output to avoid scope creep (e.g., unintended React bumps) is the correct and feasible approach.
+3. **Risk Mitigation**: Moving to the now-default Turbopack bundler for production builds introduces risk around chunking and Node imports for the WebGL island. The spec effectively neutralizes this risk by explicitly defining checks to ensure no Node-only imports leak into the client chunk and exactly one Three.js runtime is resolved, backed by the existing two-engine Playwright interaction matrix.
+4. **Supply Chain & Security**: Explicitly dispositioning the nested, Next-owned `postcss@8.4.31` dependency and enforcing exact version pinning preserves the project's rigid reproducibility invariants. 
+
+There are no missing details, contradictions, or infeasible requirements.
+
+---
+VERDICT: APPROVE
+SUMMARY: The specification is exceptionally thorough, correctly aligning the upgrade with existing rigid validation and contract-test constraints.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:23:09.852Z'
+updated_at: '2026-07-20T11:29:28.085Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T12:16:54.090Z'
+updated_at: '2026-07-20T12:17:31.721Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-07-20T11:33:40.869Z'
     approved_at: '2026-07-20T11:34:25.510Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-20T11:43:05.369Z'
+    approved_at: '2026-07-20T11:44:00.412Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:43:05.370Z'
+updated_at: '2026-07-20T11:44:00.412Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -1,0 +1,20 @@
+id: '12'
+title: migrate-the-application-to-nex
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-20T11:23:09.851Z'
+updated_at: '2026-07-20T11:23:09.852Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:04:52.125Z'
+updated_at: '2026-07-20T17:10:35.586Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -1,7 +1,7 @@
 id: '12'
 title: migrate-the-application-to-nex
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: framework_upgrade
     title: Reverify, Run/Review Codemod, and Land the Next 16 Manifest + Contract Tests
@@ -11,8 +11,8 @@ plan_phases:
     status: complete
   - id: evidence_disposition_and_docs
     title: Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs
-    status: in_progress
-current_plan_phase: evidence_disposition_and_docs
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:10:35.586Z'
+updated_at: '2026-07-20T17:13:51.293Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:13:51.293Z'
+updated_at: '2026-07-20T17:21:12.668Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -1,7 +1,7 @@
 id: '12'
 title: migrate-the-application-to-nex
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:34:25.510Z'
+updated_at: '2026-07-20T11:35:00.523Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:00:49.410Z'
+updated_at: '2026-07-20T17:01:30.658Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-07-20T11:33:40.869Z'
   plan-approval:
     status: pending
   pr:
@@ -14,7 +15,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:29:28.085Z'
+updated_at: '2026-07-20T11:33:40.870Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -1,9 +1,18 @@
 id: '12'
 title: migrate-the-application-to-nex
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: framework_upgrade
+    title: Reverify, Run/Review Codemod, and Land the Next 16 Manifest + Contract Tests
+    status: in_progress
+  - id: turbopack_behavioral_qualification
+    title: Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)
+    status: pending
+  - id: evidence_disposition_and_docs
+    title: Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs
+    status: pending
+current_plan_phase: framework_upgrade
 gates:
   spec-approval:
     status: approved
@@ -21,4 +30,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:44:00.412Z'
+updated_at: '2026-07-20T11:44:19.067Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -23,13 +23,14 @@ gates:
     requested_at: '2026-07-20T11:43:05.369Z'
     approved_at: '2026-07-20T11:44:00.412Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-20T17:27:42.552Z'
+    approved_at: '2026-07-20T17:44:50.893Z'
   verify-approval:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:27:42.552Z'
-pr_ready_for_human: true
+updated_at: '2026-07-20T17:44:50.893Z'
+pr_ready_for_human: false

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -26,8 +26,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: framework_upgrade
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-gemini.txt
+      - model: codex
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-codex.txt
+      - model: claude
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T12:00:23.864Z'
+updated_at: '2026-07-20T12:16:54.090Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T12:20:15.181Z'
+updated_at: '2026-07-20T16:40:00.471Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -8,11 +8,11 @@ plan_phases:
     status: complete
   - id: turbopack_behavioral_qualification
     title: Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)
-    status: in_progress
+    status: complete
   - id: evidence_disposition_and_docs
     title: Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs
-    status: pending
-current_plan_phase: turbopack_behavioral_qualification
+    status: in_progress
+current_plan_phase: evidence_disposition_and_docs
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:01:30.658Z'
+updated_at: '2026-07-20T17:04:52.125Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:35:00.523Z'
+updated_at: '2026-07-20T11:38:59.515Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -5,14 +5,14 @@ phase: implement
 plan_phases:
   - id: framework_upgrade
     title: Reverify, Run/Review Codemod, and Land the Next 16 Manifest + Contract Tests
-    status: in_progress
+    status: complete
   - id: turbopack_behavioral_qualification
     title: Qualify the Default Turbopack Build and Client WebGL Bundle (Two-Engine Matrix)
-    status: pending
+    status: in_progress
   - id: evidence_disposition_and_docs
     title: Lockfile/Audit Delta, Supply-Chain, PostCSS Disposition, and Docs
     status: pending
-current_plan_phase: framework_upgrade
+current_plan_phase: turbopack_behavioral_qualification
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T12:17:31.721Z'
+updated_at: '2026-07-20T12:20:15.181Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-20T11:33:40.869Z'
+    approved_at: '2026-07-20T11:34:25.510Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:33:40.870Z'
+updated_at: '2026-07-20T11:34:25.510Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: framework_upgrade
@@ -45,5 +45,21 @@ history:
         verdict: REQUEST_CHANGES
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
+  - iteration: 1
+    plan_phase: turbopack_behavioral_qualification
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T16:40:00.471Z'
+updated_at: '2026-07-20T17:00:49.410Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -11,12 +11,13 @@ gates:
     approved_at: '2026-07-20T11:34:25.510Z'
   plan-approval:
     status: pending
+    requested_at: '2026-07-20T11:43:05.369Z'
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:38:59.515Z'
+updated_at: '2026-07-20T11:43:05.370Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T11:44:19.067Z'
+updated_at: '2026-07-20T12:00:23.864Z'

--- a/codev/projects/12-migrate-the-application-to-nex/status.yaml
+++ b/codev/projects/12-migrate-the-application-to-nex/status.yaml
@@ -24,42 +24,12 @@ gates:
     approved_at: '2026-07-20T11:44:00.412Z'
   pr:
     status: pending
+    requested_at: '2026-07-20T17:27:42.552Z'
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
-history:
-  - iteration: 1
-    plan_phase: framework_upgrade
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-gemini.txt
-      - model: codex
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-codex.txt
-      - model: claude
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-framework_upgrade-iter1-claude.txt
-  - iteration: 1
-    plan_phase: turbopack_behavioral_qualification
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-12/codev/projects/12-migrate-the-application-to-nex/12-turbopack_behavioral_qualification-iter1-claude.txt
+build_complete: false
+history: []
 started_at: '2026-07-20T11:23:09.851Z'
-updated_at: '2026-07-20T17:21:12.668Z'
+updated_at: '2026-07-20T17:27:42.552Z'
+pr_ready_for_human: true

--- a/codev/resources/arch-critical.md
+++ b/codev/resources/arch-critical.md
@@ -12,3 +12,4 @@ STARTER: replace the examples below with YOUR project's facts and arch.md sectio
 
 ## Map of arch.md (consult when…)
 - Validation Baseline — consult when changing toolchains, dependencies, CI, browser validation, or audit handling.
+- Framework and Bundler Baseline — consult when changing the Next major, the bundler default (Turbopack), lint integration, or the Node/browser floors.

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -43,3 +43,23 @@ The ESLint flat config (`eslint.config.mjs`) uses
 explicitly (`react-hooks/rules-of-hooks`, `react-hooks/exhaustive-deps`) rather
 than spreading `configs.recommended`, whose v7 form bundles ~16 rules — spreading
 it would silently expand coverage.
+
+## Framework and Bundler Baseline
+
+The app runs on Next.js 16 (Active LTS) with React 19 (`react`/`react-dom`
+exact-pinned at `19.2.7`). Turbopack is the Next 16 default bundler for **both**
+`dev` (`next dev`) and `build` (`next build`); the scripts rely on that default
+rather than pinning `--turbopack`/`--webpack`, and the production Turbopack build is
+behaviorally qualified against the two-engine interaction matrix (not just build
+success). The `next lint` command is gone; linting is the explicit `eslint .` CLI
+path with `@next/eslint-plugin-next` wired directly in `eslint.config.mjs` and
+exact-pinned string-equal to `next`. The Node floor is `>=20.9.0` (the repo pins
+`22.23.1`); the supported-browser floor is Chrome/Edge/Firefox 111 and Safari 16.4
+(Next's zero-config default, all WebGL2-capable), so the app declares no
+`browserslist`.
+
+`next` bundles its own nested `postcss` (`node_modules/next/node_modules/postcss`,
+currently `8.4.31`) that the app cannot control in this stage. It is a documented,
+Next-owned build-time residual (audit-neutral and un-fixable from the app — npm
+offers only a bogus major downgrade), independent of the app's own top-level
+`postcss` (kept patched). Treat it as carried-forward, not a new or closed finding.

--- a/codev/resources/lessons-critical.md
+++ b/codev/resources/lessons-critical.md
@@ -11,6 +11,8 @@ STARTER: a few universal lessons are seeded; add your project's as you learn the
 - "It compiled" / "tests pass" is not "it works" — verify the real user path before calling it done.
 - When stuck (2 failed hypotheses or ~30 min), get an outside perspective instead of guessing.
 - Before consultation, ensure every new deliverable is included in the canonical review diff; untracked files are invisible to reviewers.
+- A local gate failure caused only by an untracked builder-harness file (e.g. `.claude/hooks/*`, absent from clean checkouts) is environment noise, not a project failure — prove the gate on a clean checkout (`git worktree add --detach HEAD` + real `npm ci`), don't suppress it in committed config.
 
 ## Map of lessons-learned.md (consult when…)
 - Validation Evidence — consult when automating browser checks or preserving nonzero diagnostic evidence.
+- Toolchain and Worktree Hygiene — consult when a local gate fails on an untracked harness file or the lockfile name/dependencies look worktree-contaminated.

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -43,3 +43,21 @@ gotcha, or constraint.
   identically across the three 0.172→0.185 upgrade in both Chromium and Firefox
   — treat the intermittent/blocked cases as a known harness delivery limitation,
   not an app defect, and qualify them with rate comparison against baseline.
+
+## Toolchain and Worktree Hygiene
+
+- A local gate failure caused **only** by an untracked builder-harness file
+  (e.g. `.claude/hooks/worktree-write-guard.cjs`, which `eslint .` lints but which
+  is absent from any `git clone`/`actions/checkout`) is environment noise, not a
+  project-gate failure. Do **not** add a suppression to committed config (e.g.
+  `.claude/**` to `eslint.config.mjs`) to silence it. Prove the gate on the
+  committed tree instead: `git worktree add --detach <tmp> HEAD` (untracked harness
+  files do not propagate) + real `npm ci` + `npm run validate` → exit 0. Use a real
+  `npm ci`, not a symlinked `node_modules` — Turbopack rejects a symlink that
+  "points out of the filesystem root".
+- When `package.json` declares no `name`, `npm install` inside a builder worktree
+  rewrites `package-lock.json`'s top-level `name` to the worktree directory
+  basename (e.g. `spir-12` instead of the canonical `primary`). Reset it before
+  committing — it is worktree contamination, not a dependency delta, and it muddies
+  the lockfile diff. `npm ci` never rewrites the lockfile, so once corrected the
+  value is stable for clean reproduction.

--- a/codev/reviews/12-migrate-the-application-to-nex.md
+++ b/codev/reviews/12-migrate-the-application-to-nex.md
@@ -1,0 +1,222 @@
+# Review: migrate-the-application-to-nex
+
+Issue #12 — Migrate the application to Next 16 Active LTS. Strict SPIR, high-risk
+integration review. Depends on #11; tracked under #6.
+
+## Summary
+
+Moved the framework from the qualified Next 15.5.20 baseline to **Next 16.2.10
+(Active LTS)** as a single revertible unit, on the already-qualified React 19.2.7
+line. The migration:
+
+- Pinned `next` and `@next/eslint-plugin-next` to exact `16.2.10`; re-pinned the
+  contract test; removed the now-redundant `--turbopack` dev flag; kept `build` as
+  bare `next build` (Turbopack is the Next 16 default).
+- Reviewed the official Next upgrade codemods and **curated out all out-of-scope
+  drift** (the `next-lint-to-eslint-cli` orchestrator would have added a 15.x
+  `eslint-config-next` dep and broadened the flat config — reverted entirely; the
+  repo already uses the explicit `eslint .` path from #7). Net accepted codemod
+  source/config change: none.
+- **Behaviorally qualified the now-default Turbopack production build** across the
+  two-engine interaction matrix (Chromium SwiftShader + Firefox), confirmed the
+  client bundle ships no Node-only imports and a single Three runtime, verified the
+  Node/browser policy, and produced the honest audit/lockfile/supply-chain delta
+  with the Next-owned nested PostCSS residual explicitly dispositioned.
+
+Three plan phases, all on branch `builder/spir-12`, all unanimously approved by the
+3-way CMAP review (Gemini/Codex/Claude). The framework work touches only
+`package.json`, `package-lock.json`, `tests/toolchain.test.mjs`, `tsconfig.json`,
+and `README.md` — zero `app/` source changes.
+
+## Spec Compliance
+
+| FR | Requirement | Status | Evidence |
+|----|-------------|--------|----------|
+| FR1 | Reverify target (16.2.10, support, migration guide, peers) | ✅ | dist-tag `latest`=16.2.10; Node floor `>=20.9.0`; React peer satisfied by 19.2.7; new optional peers only (`@playwright/test ^1.51.1` satisfied by pinned 1.61.1). No new required peer. |
+| FR2 | Run/review codemod, curate drift | ✅ | 4 jscodeshift transforms dry-ran = 0 modified; `next-lint-to-eslint-cli` orchestrator reverted (out-of-scope dep + config broadening). Net accepted source/config change: none. |
+| FR3 | Manifest + lockfile pin | ✅ | `next`/plugin → 16.2.10 (deps/devDeps); one `npm install`; lockfile v3; single `three@0.185.1`; no peer warnings; `npm ci` no-op. |
+| FR4 | Remove obsolete next-lint/turbopack idioms | ✅ | `dev` → `next dev` (flag dropped); no `next lint` in scripts/CI/anywhere; `lint` stays `eslint .`; plugin 16.2.10 `configs.recommended`/`core-web-vitals` rule objects resolve spreadable. |
+| FR5 | Qualify Turbopack build + client bundle | ✅ | `next build` (Turbopack) OK; `.next/static/` scan: 0 `node:` scheme, 0 bare-builtin import specifiers; single `three@0.185.1` deduped; `dynamic(...,{ssr:false})` island preserved. |
+| FR6 | Preserved client boundary + interaction semantics | ✅ | Zero `app/` diff; all timers/camera/control values intact; build-stable. |
+| FR7 | Node + browser policy | ✅ | `22.23.1` ≥ `>=20.9.0`; browser floor Chrome/Edge/Firefox 111 + Safari 16.4 (zero-config, WebGL2-compatible); no `browserslist` required. |
+| FR8 | Automated validation gates | ✅ | typecheck 0; lint 0 on committed tree (clean-worktree proof); `npm test` 21/21; Turbopack build 0; `next start` root 200; `test:smoke`/`validate` green; audit pipeline preserves exit codes. |
+| FR9 | Browser smoke + interaction matrix | ✅ | Two-engine Playwright 20/20 (Chromium 10 + Firefox 10) vs the Turbopack `next start`; `focus-graph-lifecycle` unit green; strict error budget clean in both engines. |
+| FR10 | Lockfile/audit delta + PostCSS disposition | ✅ | 11 changed lockfile entries, all Next-owned, 15.5.20→16.2.10; audit byte-identical before/after (0 resolved / 0 introduced / all unchanged); nested `postcss@8.4.31` dispositioned as Next-owned residual. |
+| FR11 | Supply-chain verification | ✅ | All 11 changed entries → `registry.npmjs.org`; no install-script deltas; `npm ci` clean no-op. |
+| FR12 | Contract-test + docs updates | ✅ | `toolchain.test.mjs` pins moved to 16.2.10 (string-equal); README line 6 → Next 16 Active LTS + Turbopack note; `automation.test.mjs` enumerations green. |
+| FR13 | Rollback unit + blocking semantics | ✅ | Manifest+lock+config+contract tests+docs = one revert unit restoring `next@15.5.20` (never `15.1.11`); no genuine regression → nothing blocked/escalated. |
+
+### Issue acceptance criteria
+- [x] Next 16 target/support/migration/peers reverified (FR1)
+- [x] No obsolete `next lint` or redundant Turbopack dev flag (FR4)
+- [x] Node/browser policy satisfies the release (FR7)
+- [x] Lint, typecheck, Turbopack build, production start, audits, browser smoke, full graph UX matrix pass (FR8/FR9)
+- [x] Client bundle has no Node-only imports; one Three runtime via the client-only island (FR5)
+- [x] Lockfile/audit changes explained; residual nested PostCSS dispositioned (FR10/FR11)
+- [x] Rollback returns to the patched Next 15 baseline, never `15.1.11` (FR13)
+
+## Deviations from Plan
+
+- **Phase 1 — forced `tsconfig.json` change (documented).** Next 16's `next build`
+  makes a mandatory tsconfig change: `jsx: "preserve"` → `"react-jsx"` plus a
+  suggested `include` of `.next/dev/types/**/*.ts`. Behavior-preserving (typecheck
+  passes both ways); committed as part of the rollback unit though not in the plan's
+  expected file list, because the Next 16 build strictly forces it.
+- **Phase 1 — lockfile `name` fix as a follow-up commit.** A worktree `npm install`
+  rewrote the lockfile top-level `name` (`primary` → `spir-12`); caught by CMAP
+  (Claude, iter1) and corrected. Because the remote blocks force-push on builder
+  branches (GH013), the fix landed as a follow-up content commit rather than an
+  amend. Cumulative branch content is correct; the PR diff is clean.
+- No other deviations. Phases 2 and 3 matched the plan exactly (Phase 2 was a
+  zero-source-diff qualification, as anticipated).
+
+## Lessons Learned
+
+### What Went Well
+- **Codemod curation held the line.** Dry-running every transform and reverting the
+  self-installing `next-lint-to-eslint-cli` orchestrator kept the diff to an exact,
+  minimal framework delta — no out-of-scope deps or config broadening.
+- **Evidence-first qualification.** The two-engine matrix + client-bundle scan +
+  before/after audit gave a fully-substantiated "audit-neutral, behavior-preserving"
+  story rather than an "it built" assertion.
+- **Honest environment separation.** The `.claude/hooks` lint artifact and the
+  nested-worktree lockfile warning were documented as environment noise and proven
+  clean on a real checkout, instead of being silenced in committed config.
+
+### Challenges Encountered
+- **Local `npm run validate` was red on an untracked harness file.** `eslint .`
+  lints `.claude/hooks/worktree-write-guard.cjs` (a builder-harness artifact absent
+  from any clone/CI checkout). Resolved by proving the gate on a clean detached
+  worktree (`git worktree add --detach HEAD` + `npm ci` + `npm run validate` → exit
+  0), **not** by editing `eslint.config.mjs` (FR4 forbids new suppressions). Codex
+  raised this at Phase 2 iter1; the clean-tree evidence flipped it to APPROVE.
+- **Turbopack rejects a symlinked `node_modules`** ("symlink points out of the
+  filesystem root") — the first clean-tree reproduction used a symlink and panicked;
+  redone with a real `npm ci`.
+- **Worktree lockfile `name` contamination** (see Deviations) — a recurring trap
+  when `package.json` has no `name`.
+
+### What Would Be Done Differently
+- Reset the lockfile `name` immediately after the first worktree `npm install`
+  rather than discovering the contamination via review — it is now a hot lesson.
+- Reach for the clean detached-worktree gate proof at the first sign of an
+  environment-only failure, instead of arguing it in prose first.
+
+### Methodology Improvements
+- The strict-SPIR "commit content before `porch done`/consult" rule proved its worth
+  again: reviewers verified real diffs each round. No protocol change proposed.
+- CMAP caught a real contamination bug (lockfile `name`) that self-review missed
+  because self-diffing working-tree-vs-own-commit hid it; diffing commit-vs-parent
+  is the reliable check. Worth internalizing, not a protocol change.
+
+## Technical Debt
+- **Next-owned nested `postcss@8.4.31`** (`node_modules/next/node_modules/postcss`)
+  carries the moderate `GHSA-qx2v-qp2m-jg93` advisory (via the `next` and `postcss`
+  audit paths). It is not app-fixable in this stage (npm offers only a bogus
+  `next@9.3.3` major downgrade) and is unchanged from the pre-upgrade baseline. Not
+  new debt introduced here — a carried-forward, documented build-time residual to
+  revisit if/when a future Next release re-vendors PostCSS.
+
+## Consultation Feedback
+
+### Specify Phase (Round 1)
+#### Gemini — APPROVE
+- No blocking concerns. "Exceptionally thorough" spec aligning with existing
+  validation/contract-test constraints.
+#### Codex — COMMENT
+- **Concern**: minor evidence-method clarifications would improve builder guidance.
+  - **Addressed**: the spec's FR5/FR9 evidence methods (explicit scan commands,
+    engine split) were tightened so builders can't invent inconsistent proofs.
+#### Claude — reviewed (detailed, no blocking change)
+- Confirmed scope, rollback target, and validation alignment.
+
+### Plan Phase (Round 1)
+#### Gemini — APPROVE
+- Plan "perfectly translates the spec into three coherent, executable phases,"
+  honoring constraints and rollback.
+#### Codex — COMMENT
+- **Concern**: a minor doc-truthfulness clarification was missing.
+  - **Addressed**: Phase 3 FR12 now explicitly calls out refreshing the stale
+    README line-6 version statement; the Phase 2 error-budget label was corrected
+    FR11→FR9; Phase 1 FR4 names the exact ESLint plugin config accesses to verify.
+#### Claude — reviewed (detailed, no blocking change)
+
+### Phase 1 — framework_upgrade (Round 1)
+#### Gemini — APPROVE · #### Codex — APPROVE
+#### Claude — REQUEST_CHANGES
+- **Concern**: `package-lock.json` top-level `name` was `spir-12` (worktree
+  contamination) instead of the canonical `primary`.
+  - **Addressed**: restored to `primary`; verified `npm ci` keeps it; delivered as a
+    follow-up commit (remote blocks force-push).
+
+### Phase 1 — framework_upgrade (Round 2)
+#### Gemini / Codex / Claude — APPROVE (unanimous). Lockfile-name fix verified; no
+further concerns.
+
+### Phase 2 — turbopack_behavioral_qualification (Round 1)
+#### Gemini — APPROVE · #### Claude — APPROVE
+#### Codex — REQUEST_CHANGES
+- **Concern 1**: `npm run validate` isn't green locally because `npm run lint`
+  exits 1.
+  - **Rebutted (with evidence)**: the failure is solely the untracked
+    `.claude/hooks/worktree-write-guard.cjs` harness artifact (not in HEAD, absent
+    from clean checkouts). Demonstrated the literal `npm run validate` → exit 0 on a
+    clean detached-worktree `npm ci` checkout, both engines. Editing
+    `eslint.config.mjs` would violate FR4.
+- **Concern 2**: `status.yaml` shows the phase `in_progress`, not `complete`.
+  - **Rebutted**: this is the correct porch strict-mode review-cycle state
+    (`build_complete: true`, awaiting unanimous approval); porch owns the file and
+    the builder is forbidden to edit it.
+
+### Phase 2 — turbopack_behavioral_qualification (Round 2)
+#### Gemini / Codex / Claude — APPROVE (unanimous). Codex flipped to APPROVE: "the
+prior validate concern is credibly rebutted against the actual worktree state."
+
+### Phase 3 — evidence_disposition_and_docs (Round 1)
+#### Gemini / Codex / Claude — APPROVE (unanimous, first iteration). No concerns;
+all four acceptance criteria verified (audit exit codes + path-by-path delta;
+PostCSS disposition; supply-chain + `npm ci` no-op; README truthful + `npm test`
+21/21).
+
+## Architecture Updates
+
+Routed by tier (Spec 987):
+- **COLD `codev/resources/arch.md`** — added a "Framework and Bundler Baseline"
+  section (current state): Next 16 Active LTS on React 19; Turbopack as the default
+  bundler for `dev` and `build` (relied on by default, qualified against the
+  two-engine matrix); `next lint` removed in favor of the explicit `eslint .` path;
+  Node floor `>=20.9.0` (repo pins 22.23.1); browser floor Chrome/Edge/Firefox 111 +
+  Safari 16.4 (no `browserslist`); the Next-owned nested `postcss@8.4.31` build-time
+  residual.
+- **HOT `codev/resources/arch-critical.md`** — added one map line pointing to the
+  new cold section (map now 2 topics, within cap). No new hot *fact*: the
+  reproducibility-contract and `npm run validate`-gate facts already cover the
+  behavior-changers; the Next-16/Turbopack detail is reference material for the cold
+  archive.
+
+## Lessons Learned Updates
+
+Routed by tier (Spec 987):
+- **COLD `codev/resources/lessons-learned.md`** — added a "Toolchain and Worktree
+  Hygiene" section with two durable gotchas: (1) a local gate failure caused only by
+  an untracked builder-harness file is environment noise — prove the gate on a clean
+  detached-worktree `npm ci` (Turbopack rejects a symlinked `node_modules`), don't
+  suppress it in committed config; (2) `npm install` in a worktree rewrites the
+  lockfile top-level `name` to the dir basename when `package.json` has no `name` —
+  reset it before committing.
+- **HOT `codev/resources/lessons-critical.md`** — promoted the env-artifact-vs-gate
+  lesson to one capped hot line (behavior-changing and cross-cutting for every
+  builder in this worktree model; 5 lessons total, within cap) and added the
+  matching cold-doc map line (2 map topics). The lockfile-name gotcha stays cold
+  (narrower reference recipe).
+
+## Flaky Tests
+No flaky tests encountered. All suites (`node --test` 21/21; Playwright 20/20 both
+engines) passed deterministically across repeated runs; nothing skipped.
+
+## Follow-up Items
+- Revisit the nested `postcss@8.4.31` residual if a future Next release re-vendors
+  PostCSS (would resolve `GHSA-qx2v-qp2m-jg93` at the framework level).
+- Next roadmap stages (tracked under #6) continue from this Next 16 Active-LTS base;
+  no Tailwind 4 / TS-major / ESLint 10 / React Compiler / 3D-stack upgrade was in
+  scope here.

--- a/codev/reviews/12-migrate-the-application-to-nex.md
+++ b/codev/reviews/12-migrate-the-application-to-nex.md
@@ -42,7 +42,7 @@ and `README.md` — zero `app/` source changes.
 | FR8 | Automated validation gates | ✅ | typecheck 0; lint 0 on committed tree (clean-worktree proof); `npm test` 21/21; Turbopack build 0; `next start` root 200; `test:smoke`/`validate` green; audit pipeline preserves exit codes. |
 | FR9 | Browser smoke + interaction matrix | ✅ | Two-engine Playwright 20/20 (Chromium 10 + Firefox 10) vs the Turbopack `next start`; `focus-graph-lifecycle` unit green; strict error budget clean in both engines. |
 | FR10 | Lockfile/audit delta + PostCSS disposition | ✅ | 11 changed lockfile entries, all Next-owned, 15.5.20→16.2.10; audit byte-identical before/after (0 resolved / 0 introduced / all unchanged); nested `postcss@8.4.31` dispositioned as Next-owned residual. |
-| FR11 | Supply-chain verification | ✅ | All 11 changed entries → `registry.npmjs.org`; no install-script deltas; `npm ci` clean no-op. |
+| FR11 | Supply-chain verification | ✅ | All 11 changed entries → `registry.npmjs.org`; no install-script deltas; `npm ci` clean no-op. One dev→prod scope promotion: `baseline-browser-mapping@2.10.43` (now a direct `next@16.2.10` dep) — same version, registry-resolved, Apache-2.0, no advisory, audit-neutral. |
 | FR12 | Contract-test + docs updates | ✅ | `toolchain.test.mjs` pins moved to 16.2.10 (string-equal); README line 6 → Next 16 Active LTS + Turbopack note; `automation.test.mjs` enumerations green. |
 | FR13 | Rollback unit + blocking semantics | ✅ | Manifest+lock+config+contract tests+docs = one revert unit restoring `next@15.5.20` (never `15.1.11`); no genuine regression → nothing blocked/escalated. |
 
@@ -177,6 +177,28 @@ prior validate concern is credibly rebutted against the actual worktree state."
 all four acceptance criteria verified (audit exit codes + path-by-path delta;
 PostCSS disposition; supply-chain + `npm ci` no-op; README truthful + `npm test`
 21/21).
+
+### PR Review — `--type pr` (Round 1)
+#### Gemini — APPROVE (high). No issues.
+#### Claude — APPROVE (high)
+- **Observation** (non-blocking): `baseline-browser-mapping@2.10.43` was promoted
+  from dev-only to production scope because `next@16.2.10` declares it as a direct
+  dependency; the "0 added, 0 removed" framing covered version changes but not this
+  scope flip.
+  - **Addressed**: verified (it is the only dev→prod flip; same version, registry,
+    Apache-2.0, no advisory, production audit unchanged at 5) and documented in the
+    FR11 row above.
+#### Codex — COMMENT (high), two non-blocking nits:
+- **Nit 1**: the checked-in plan looked stale (`Status: draft`, unchecked success
+  metrics, phase statuses `pending`) vs `status.yaml`.
+  - **Addressed**: updated the plan's Status, Phase Status table (→ complete), and
+    the 13 Success Metrics checkboxes to reflect completion.
+- **Nit 2**: many `chore(porch): …` commits don't match the `[Spec N][Phase]`
+  convention; worth squashing if strict history matters.
+  - **Rebutted / N/A**: those are machine-generated porch state-transition commits,
+    not builder commits; the builder cannot rewrite them (remote blocks force-push,
+    GH013), and integration/merge (incl. any squash) is the architect's call. The
+    builder-authored commits follow the `[Spec 12]…` convention.
 
 ## Architecture Updates
 

--- a/codev/specs/12-migrate-the-application-to-nex.md
+++ b/codev/specs/12-migrate-the-application-to-nex.md
@@ -1,0 +1,616 @@
+# Specification 12: Migrate the Application to Next 16 Active LTS
+
+## Summary
+
+Move the framework from the patched Next 15 baseline (`next@15.5.20`, landed by
+#11's predecessor #9 and carried through #11) to Next 16 **Active LTS**
+(`next@16.2.10`) in an isolated stage, and behaviorally qualify the result. This
+is [Stage 3 — Next 16 Active LTS](../research/architecture-dependency-modernization.md#stage-3--next-16-active-lts)
+of the architecture/dependency modernization roadmap (tracked under #6; depends
+on #11, which shipped as PR #25).
+
+The intended package actions are:
+
+| Package | Checked-in version | Intended target | Dependency group | Action |
+| --- | ---: | ---: | --- | --- |
+| `next` | `15.5.20` (exact) | exact `16.2.10` | `dependencies` | Upgrade; pin exactly |
+| `@next/eslint-plugin-next` | `15.5.20` (exact) | exact `16.2.10` | `devDependencies` | Upgrade; pin exactly; kept string-equal to `next` |
+
+React and React-DOM stay **exactly** at the already-qualified `19.2.7`; the
+Three.js/force-graph stack qualified in #11 (`three@0.185.1`,
+`react-force-graph-3d@1.29.1`) is unchanged. All other manifest entries are
+unchanged. The lockfile moves with the two upgraded packages and their
+transitive deltas and is reviewed, not independently pinned.
+
+Next 16 has almost no request-API/config migration surface in this repository
+(no middleware, no dynamic request APIs, empty `next.config.js`, a single static
+async server component). Its user-visible changes here are operational: it
+raises the Node and supported-browser floors, removes the `next lint` command
+integration, and makes **Turbopack the default bundler for both `dev` and
+`build`**. The stage therefore centers on: running and reviewing the official
+Next upgrade codemod; removing the now-redundant `--turbopack` dev flag;
+explicitly qualifying the now-default Turbopack production build and the
+client-only WebGL island; verifying the Node/browser policy; and re-explaining
+the lockfile/audit delta including the known Next-owned nested PostCSS state.
+
+Install/build success cannot validate the imperative WebGL surface, so — exactly
+as in #11 — this stage reuses the established two-engine interaction-matrix
+qualification (Chromium as the required CI gate, Firefox as the documented local
+qualification gate). The whole manifest/lockfile/config/code/test change is one
+rollback unit; rollback returns to the patched Next 15 baseline `15.5.20`, never
+to `15.1.11`.
+
+## Problem Analysis
+
+### Current state
+
+- `next@15.5.20` and `@next/eslint-plugin-next@15.5.20` are the patched Next 15
+  baseline. `15.5.20` is the registry's `backport` dist-tag — the current
+  supported 15.x line — and is the sanctioned rollback target for this stage.
+- The framework is one Active-LTS line behind: `next@16.2.10` is the registry
+  `latest` dist-tag and the current Active LTS. Staying on 15.x keeps the app
+  off the supported LTS line the roadmap targets and blocks later stages that
+  assume a Next 16 base.
+- `package.json` scripts carry two Next-16-obsolete idioms: `dev` is
+  `next dev --turbopack` (Turbopack is the Next 16 default for dev, so the flag
+  is redundant), and while `lint` is already the explicit `eslint .` CLI path
+  established in #7 (Next's removed `next lint` command is not invoked anywhere),
+  that removal must be re-confirmed against Next 16, which deletes the command
+  outright.
+- `build` is `next build`. In Next 16 that defaults to the **Turbopack**
+  production bundler rather than webpack; the app has never built or been
+  qualified under Turbopack in production mode. Install/build success does not
+  exercise the imperative WebGL surface (`app/components/FocusGraph.tsx`:
+  `AxesHelper`, `PerspectiveCamera`, `TrackballControls`, and the
+  react-force-graph imperative handle), so a bundler change must be behaviorally
+  qualified, not asserted.
+- The client boundary is a client-only dynamic island: `FocusGraphWrapper.tsx`
+  does `dynamic(() => import("./FocusGraph"), {ssr: false})`. The build must keep
+  producing a client bundle with exactly one resolved Three runtime and no
+  Node-only imports.
+- Migration surface is minimal and verified: no `middleware.*`, no dynamic
+  request APIs (`cookies`/`headers`/`params`/`searchParams`/`useSearchParams`)
+  in `app/`, an empty `next.config.js` (`module.exports = {}`), and
+  `app/page.tsx` is a static async server component that stringifies checked-in
+  data and renders the island.
+- Browser validation is the two-engine Playwright suite qualified in #11:
+  Chromium (SwiftShader) is the required CI gate (`E2E_ENGINES=chromium`);
+  Firefox is a documented local qualification gate (GPU-less Actions runners
+  cannot bring up a Firefox WebGL context). `playwright.config.ts` selects
+  engines by `E2E_ENGINES`.
+- Contract tests pin the framework: `tests/toolchain.test.mjs` asserts
+  `dependencies.next === "15.5.20"`,
+  `devDependencies["@next/eslint-plugin-next"] === "15.5.20"`, and that the two
+  are string-equal. These move in the same commit as the manifest.
+- The lockfile carries a nested `node_modules/next/node_modules/postcss@8.4.31`.
+  This is pinned by `next` itself (Stage-0/#10 finding); it is a Next-owned
+  build-time residual, not app-controlled.
+- Post-#11 audit evidence is the current baseline; existing advisories are
+  tracked evidence, not a zero-findings gate.
+
+### Desired state
+
+- `next` and `@next/eslint-plugin-next` at exactly `16.2.10`, kept string-equal;
+  React/DOM unchanged at `19.2.7`; a clean supported peer tree; a regenerated
+  lockfile (v3) that a fresh `npm ci` reproduces without mutating manifest or
+  lock and without 3D-chain or framework peer warnings.
+- The official Next 16 upgrade codemod has been run and its output reviewed; the
+  final manifest is the exact target group above (no incidental version drift
+  the codemod may propose); every codemod change is documented.
+- `dev` is `next dev` (no redundant `--turbopack`); no `next lint` invocation
+  anywhere; the #7 `eslint .` path and the flat config's direct
+  `@next/eslint-plugin-next` wiring are intact and pass under the 16.x plugin.
+- `next build` produces a working production build under the now-default
+  Turbopack bundler; `next start` serves the root page HTTP 200; the client
+  bundle contains no Node-only imports and resolves exactly one Three runtime
+  through the client-only island.
+- Node and supported-browser policies are verified against the Next 16 upgrade
+  guide and documented; they satisfy Next 16 and remain compatible with the
+  app's WebGL2 requirement.
+- Lint, typecheck, unit/contract tests, Turbopack build, production start, full
+  and production audits, the automated browser smoke, and the complete graph
+  interaction matrix all pass; the smoke/matrix run per the #11 CI/local split.
+- The lockfile review documents the framework delta and re-explains the audit
+  delta, and the residual Next-owned nested PostCSS state is explicitly
+  dispositioned (it persists: `next@16.2.10` also bundles `postcss@8.4.31`).
+- Contract tests and docs are re-pinned to `16.2.10` and stay truthful.
+
+### Stakeholders
+
+- **Site visitors** — the 3D graph is the page's entire interactive surface; any
+  regression in canvas bring-up, camera/pointer behavior, or bundle loading from
+  the bundler change is a user-facing breakage.
+- **Maintainers** — need the app on the Active-LTS line with the default
+  Turbopack bundler qualified, without losing the reproducibility contract.
+- **Later roadmap stages** (#6) — Stage 4 (language/lint) and beyond assume a
+  Next 16 base with a qualified Turbopack build and an intact ESLint CLI path.
+
+## Confirmed Decisions
+
+Registry facts verified 2026-07-20 under the repository toolchain (must be
+reverified at implementation time per FR1; this observation does not replace
+that verification):
+
+1. **Targets exist and are current/supported.** `next@16.2.10` and
+   `@next/eslint-plugin-next@16.2.10` are both the `latest` dist-tag of their
+   packages — zero drift from the researched target. The `next` `backport`
+   dist-tag is `15.5.20`, confirming the current 15.x line and the rollback
+   target.
+2. **Node floor is satisfied with margin.** `next@16.2.10` declares
+   `engines.node >=20.9.0`; the repository's exact `22.23.1` (in `engines`,
+   `.nvmrc`, and enforced by CI/contract tests) satisfies it. No Node change is
+   required or permitted by this stage.
+3. **React peer is satisfied; no new required peers.** `next@16.2.10` peers
+   `react`/`react-dom` at `^18.2.0 || 19.0.0-rc-… || ^19.0.0`; the qualified
+   exact `19.2.7` stays. Every other Next 16 peer — `sass`, `@playwright/test`,
+   `@opentelemetry/api`, `babel-plugin-react-compiler` — is
+   `peerDependenciesMeta.optional`. (`@playwright/test` newly appears as an
+   optional peer at `^1.51.1`; the pinned `1.61.1` already satisfies it.) So the
+   upgrade introduces no new required runtime or dev dependency.
+4. **`next lint` is already removed; only `--turbopack` (dev) is obsolete here.**
+   The `lint` script is `eslint .` (the explicit ESLint CLI path from #7); the
+   flat config (`eslint.config.mjs`) wires `@next/eslint-plugin-next` directly;
+   nothing invokes the `next lint` command that Next 16 deletes. The only
+   Next-16-obsolete script idiom left is `--turbopack` on `dev`. `dev` is not
+   enumerated by `tests/automation.test.mjs`, so removing the flag is
+   contract-safe.
+5. **Turbopack is the Next 16 default for `dev` and `build`; rely on the
+   default (election).** This spec drops `--turbopack` from `dev` and keeps
+   `build` as bare `next build`, which defaults to Turbopack in Next 16, rather
+   than pinning an explicit `--turbopack`/`--webpack` flag on either script. The
+   now-default Turbopack production build is then explicitly qualified (FR5).
+   This is an election, not forced by the issue; the alternative (pin
+   `--webpack` to keep the old bundler, or pin `--turbopack` explicitly) is a
+   veto point at the spec gate.
+6. **The nested PostCSS state persists and is Next-owned.** `next@16.2.10`
+   bundles `postcss@8.4.31` exactly as `next@15.5.20` does
+   (`node_modules/next/node_modules/postcss`). It is not resolvable by this
+   stage without patching Next and is out of scope to change; it is dispositioned
+   explicitly in the review (FR10) rather than treated as a new or closed
+   finding.
+7. **Exact, equal pins retained (house style).** `next` and
+   `@next/eslint-plugin-next` are pinned exactly and kept string-equal, and the
+   contract test enforces the equality, so the framework runtime and its lint
+   plugin cannot silently diverge.
+
+The issue body contains no "Baked Decisions" section; the decisions above are
+derived from the issue's scope/acceptance-criteria text (treated as fixed) and
+direct registry verification. Decisions 5 and 7 are elections made by this spec;
+approving the spec gate confirms them, and the architect may override any at that
+gate.
+
+## Scope
+
+### In scope
+
+- Upgrading `next` (→ exact `16.2.10`, `dependencies`) and
+  `@next/eslint-plugin-next` (→ exact `16.2.10`, `devDependencies`) in one atomic
+  manifest + lockfile + config + code + test change under the exact Node
+  `22.23.1` / npm `10.9.8` / lockfile v3 / `npm ci` contract.
+- Running the official Next 16 upgrade codemod (`@next/codemod upgrade`) in the
+  dedicated branch and reviewing/curating every change it proposes.
+- Removing the redundant `--turbopack` flag from the `dev` script and
+  re-confirming no `next lint` invocation remains, with the #7 ESLint CLI path
+  intact under the 16.x plugin.
+- Explicitly qualifying the now-default Turbopack production build (`next build`)
+  and a direct production `next start`, including the client WebGL bundle.
+- Verifying the client bundle contains no Node-only imports and continues to load
+  exactly one Three runtime through the client-only island.
+- Verifying and documenting the Node and supported-browser policies against the
+  Next 16 upgrade guide.
+- Regenerating/reviewing the lockfile and the full/production audit delta,
+  path-by-path, and explicitly dispositioning the residual Next-owned nested
+  PostCSS state.
+- Re-running the two-engine automated smoke and the complete graph interaction
+  matrix (Chromium required CI gate + Firefox local qualification, per #11).
+- Updating the framework-pinning contract tests (`tests/toolchain.test.mjs`) and
+  any README/doc/test enumerations affected by the change (e.g. the `dev`
+  script), truthfully.
+
+### Out of scope (non-goals)
+
+- No Tailwind 4, TypeScript major, ESLint 10, React Compiler, or 3D-stack
+  upgrade (all are later/separate roadmap stages).
+- No React/React-DOM version change — they stay exactly `19.2.7`.
+- No new Next features, caching changes, or `next.config.js` additions beyond
+  what the upgrade codemod strictly requires; the config stays effectively empty
+  unless Next 16 mandates a change.
+- No new application routes, features, or test-only application surface. All
+  qualification is driven from outside the app (Playwright/CDP against the
+  unmodified production page), consistent with #11.
+- No opting into the webpack bundler as a permanent choice, and no removal of the
+  Next-owned nested PostCSS pin (not app-controlled).
+- No zero-findings audit gate: pre-existing advisories remain separately tracked
+  evidence, not a blocker here.
+- No change to the #11 CI/local engine split (Chromium required in CI, Firefox
+  local qualification) — it is reused, not revisited.
+
+## Constraints and Invariants
+
+From the issue (fixed):
+
+- Reverify the current Next 16 target, support status, migration guide, and peer
+  requirements before implementation.
+- Keep React/DOM exact and supported on the already-qualified React 19 baseline.
+- Run and review the official Next upgrade codemod in the dedicated branch.
+- Replace the removed `next lint` integration with the explicit ESLint CLI path
+  established in #7 (already in place — re-confirm, do not regress).
+- Remove the redundant development `--turbopack` flag.
+- Explicitly qualify the now-default Turbopack production build and the client
+  WebGL bundle.
+- Verify Node and supported-browser policies meet Next 16 requirements.
+- The client bundle contains no Node-only imports and continues to load exactly
+  one Three runtime through the client-only island.
+- Explain lockfile/audit changes; explicitly disposition residual nested PostCSS
+  risk.
+- Rollback returns to the patched Next 15 baseline `15.5.20`, never to
+  `15.1.11`.
+
+Repository invariants (fixed):
+
+- Exact Node `22.23.1` / npm `10.9.8`, lockfile v3, clean `npm ci`; no dependency
+  regeneration under any other toolchain (the codemod's edits are reconciled to
+  the exact target group and the lockfile is regenerated only via npm under the
+  pinned toolchain).
+- `npm run validate` (lint → typecheck → build+smoke) is the green gate; full and
+  production audits are separately validated evidence, and existing advisories
+  are not a zero-findings gate.
+- Never `git add -A` / `git add .`; commit messages follow
+  `[Spec 12][Phase: name] type: Description`.
+- `next` stays in `dependencies`; `@next/eslint-plugin-next` stays in
+  `devDependencies`.
+
+## Solution Exploration
+
+### Approach A: Manifest-only bump, keep webpack build, skip codemod
+
+Bump the two packages, pin `--webpack` on `build` to keep the old bundler, and
+rely on existing gates.
+
+- **Pros**: smallest diff; avoids qualifying a new bundler.
+- **Cons**: fails the issue — it explicitly requires running the codemod and
+  qualifying the *now-default Turbopack* build. Pinning `--webpack` freezes a
+  bundler Next 16 is moving off of, deferring (not removing) the qualification
+  and adding a flag the roadmap would later have to unwind.
+- **Risk**: medium (defers required work; diverges from LTS defaults).
+  **Rejected.**
+
+### Approach B: Chase latest Next at implementation time
+
+Upgrade to whatever `next` is latest on the merge day and re-derive
+compatibility on the fly.
+
+- **Pros**: never behind on merge day.
+- **Cons**: abandons the researched, reviewable target; any post-research release
+  lands without staged analysis. As of 2026-07-20 latest *is* `16.2.10`, so the
+  approach buys nothing today and removes the drift tripwire for tomorrow.
+- **Risk**: medium-high (unreviewed target). **Rejected** — drift discovered at
+  implementation time escalates to the architect instead (FR1).
+
+### Approach C: Codemod-driven atomic upgrade to the researched target, default Turbopack, two-engine behavioral qualification (selected)
+
+Run and review the official Next 16 codemod; pin exactly to `16.2.10`; remove the
+redundant `--turbopack` dev flag; keep `build` on the now-default Turbopack and
+qualify it plus a direct production start and the client WebGL bundle; verify
+Node/browser policy; re-run the two-engine matrix (Chromium CI + Firefox local);
+land manifest, lockfile, config, code, tests, and docs as one rollback unit to
+`15.5.20`.
+
+- **Pros**: satisfies every acceptance criterion; qualifies the default bundler
+  the roadmap is converging on; reuses #11's durable two-engine qualification
+  bar; single revert restores the fully-qualified Next 15 baseline.
+- **Cons**: qualifying a new production bundler is new surface (mitigated by the
+  existing numeric matrix + smoke); the codemod may propose changes beyond the
+  target group that must be curated.
+- **Risk**: medium, actively mitigated. **Selected.**
+
+**On the bundler election**: `next build` defaults to Turbopack in Next 16.
+Staying on webpack (`--webpack`) would minimize behavioral change but is a
+deliberate divergence from the LTS default and merely defers the qualification
+this stage is meant to do. The spec elects the default because the issue mandates
+qualifying the now-default Turbopack build, the numeric interaction matrix + smoke
+already provide a behavioral safety net, and adopting the default now avoids a
+later forced migration. Veto point at the spec gate (Confirmed Decisions #5).
+
+## Functional Requirements
+
+### FR1 — Implementation-time target reverification
+
+Before any manifest edit, reverify against the npm registry under the repository
+toolchain: (a) `next@16.2.10` and `@next/eslint-plugin-next@16.2.10` still exist
+and remain the intended (latest/Active-LTS) targets; (b) `next@16.2.10`'s
+`engines.node` still admits `22.23.1` and its React peer still admits `19.2.7`
+with no new *required* peer; (c) the Next 16 support policy and upgrade guide
+have not materially changed the Node/browser floors or the migration steps
+relevant here; (d) whether a newer supported 16.x patch has superseded
+`16.2.10`. If reverification contradicts the researched target (e.g. a Node floor
+above `22.23.1`, a new required peer, or a superseding patch), **stop and
+escalate to the architect via `afx send`** rather than silently retargeting.
+Record the verification date and findings in the review.
+
+### FR2 — Official upgrade codemod, run and reviewed
+
+Run the official Next 16 upgrade codemod (`@next/codemod upgrade`, or the exact
+invocation the reverified upgrade guide specifies) in the dedicated branch under
+the pinned toolchain. Review every change it proposes — manifest edits,
+`next.config` edits, source codemods, and any script changes. Curate the result:
+the final manifest must be exactly the target group (FR3); any incidental version
+drift the codemod introduces beyond that group (e.g. bumping React, types, or
+unrelated deps) is reverted as out of scope. Document, in the review, what the
+codemod changed, what was kept, and what was reverted and why. If the codemod
+proposes a change that is genuinely required but out of the stated scope, escalate
+rather than silently expanding scope.
+
+### FR3 — Atomic manifest and lockfile update
+
+Update `package.json` (`next` → exact `16.2.10` in `dependencies`;
+`@next/eslint-plugin-next` → exact `16.2.10` in `devDependencies`) and regenerate
+`package-lock.json` only via npm under Node `22.23.1` / npm `10.9.8`. Lockfile
+stays v3; a subsequent clean `npm ci` must succeed without mutating
+`package.json` or `package-lock.json` and without peer-dependency
+warnings/errors for the framework or the 3D chain. `next` and
+`@next/eslint-plugin-next` remain string-equal. Manifest, lockfile, config, code,
+and test changes land as one unit (single PR; phase commits within it).
+
+### FR4 — Remove obsolete Next-lint/Turbopack idioms
+
+The `dev` script is `next dev` (no `--turbopack`). No `next lint` command is
+invoked anywhere in scripts, CI, or docs; the `lint` script stays `eslint .` (the
+#7 CLI path) and the flat config's direct `@next/eslint-plugin-next` wiring
+passes under the 16.x plugin with no new suppressions or rule regressions. If the
+16.x plugin changes any rule id/output the config relies on, that is called out
+and reconciled explicitly, not absorbed silently.
+
+### FR5 — Qualify the now-default Turbopack production build and client bundle
+
+`next build` (defaulting to Turbopack in Next 16) completes successfully; a
+direct production `next start` serves the root page HTTP 200; the built client
+bundle loads and runs the graph. The client-only dynamic boundary
+(`FocusGraphWrapper.tsx`: `dynamic(..., {ssr: false})`) is preserved. The client
+bundle contains **no Node-only imports** and resolves **exactly one** Three
+runtime through the client-only island (`npm ls three` shows a single
+`three@0.185.1`; no nested `node_modules/**/node_modules/three`; no `node:`/
+Node-builtin import reaches the client graph chunk). Any Turbopack-specific build
+output difference relevant to correctness is recorded in the review.
+
+### FR6 — Preserved client boundary and interaction semantics
+
+No graph prop, handler, timer value (4000 ms enable delay, 20 ms rotation tick,
+~1 s reset window), camera parameter (fov 40, near 1, far 200, focus distance
+80), or control semantic changes as a result of the framework upgrade — and if
+any is forced by Next 16, it is called out explicitly in the review, not absorbed
+silently. `app/` source changes are limited to what the codemod strictly requires
+(expected: none, given the minimal migration surface); any such change is
+documented.
+
+### FR7 — Node and supported-browser policy verification
+
+Confirm and document that the repository's Node policy (`22.23.1`) satisfies Next
+16's floor, and reverify Next 16's supported-browser policy from the upgrade
+guide. Document the resulting supported-browser statement and confirm it remains
+compatible with the app's existing WebGL2 requirement (the qualification engines
+already exceed any Next 16 browser floor). If Next 16's browser floor would
+require an app-level `browserslist`/policy declaration, add the minimal truthful
+declaration and note it; otherwise record that no declaration is required.
+
+### FR8 — Automated validation gates
+
+All of the following pass at the final commit: `npm run lint`,
+`npm run typecheck`, `npm test` (including updated contract tests),
+`npm run build` (Turbopack), a direct production `npm run start` serving the root
+page HTTP 200, `npm run test:smoke`, aggregate `npm run validate`, and the audit
+evidence pipeline (`npm run audit:full` / `audit:production` through
+`scripts/validate-audit-report.mjs` semantics, preserving original exit codes).
+
+### FR9 — Browser smoke and complete interaction matrix
+
+The automated smoke and the complete graph interaction matrix (the canonical
+matrix qualified in #11: canvas creation, initial layout, auto-rotation,
+delayed pointer enablement, trackball zoom/rotation, node drag→fix, right-click
+unfix, click-to-focus, reset, axes toggle, resize, unmount/remount) pass against
+the **Turbopack** production build. The #11 CI/local engine split is reused
+unchanged: Chromium (SwiftShader) is the required gate (`E2E_ENGINES=chromium`)
+locally and in CI; Firefox remains the documented local qualification gate.
+Verification stays numeric via the react-force-graph imperative handle, driven
+from outside the app; no test-only application surface is added. Class B items
+(node drag, node right-click) follow the #11 acceptance semantics (real input
+attempted; scripted imperative-handle evidence with baseline-replay recording is
+acceptable only for input *delivery* limits, never for wrong handler behavior).
+Any behavioral difference from the Next 15 baseline is replayed against the
+rollback baseline before being attributed to the upgrade.
+
+### FR10 — Lockfile and audit delta review, PostCSS disposition
+
+Record before/after resolved versions for `next`, `@next/eslint-plugin-next`, and
+every transitive entry the upgrade moves; summarize meaningful framework changes
+relevant to this app (bundler default, lint integration, Node/browser floors).
+Provide before/after full (`npm audit`) and production (`npm audit --omit=dev`)
+comparisons, path-by-path, preserving original exit codes per the
+validate-audit-report methodology; identify which advisory paths the upgrade
+resolves, introduces, or leaves unchanged, with ownership notes. Explicitly
+disposition the residual **Next-owned** nested `postcss@8.4.31`
+(`node_modules/next/node_modules/postcss`): confirm whether `next@16.2.10` still
+pins it (expected: yes), state that it is not app-controllable in this stage, and
+carry it forward as a documented build-time residual rather than a closed or new
+finding. Raw JSON stays local/CI evidence; the review carries the comparison
+tables.
+
+### FR11 — Supply-chain verification of changed lockfile entries
+
+For every lockfile entry changed by this upgrade: (a) `resolved` URLs point only
+at the public npm registry (`registry.npmjs.org`) — no git, tarball-URL, or
+alternate-registry sources; (b) no changed entry introduces an install script
+(`hasInstallScript`/`preinstall`/`install`/`postinstall`) its previous version
+lacked, and any pre-existing install script in the changed set is identified and
+explained; (c) `npm ci` output shows no unexpected package-manager behavior.
+Findings go in the review's lockfile section.
+
+### FR12 — Contract-test and docs updates
+
+`tests/toolchain.test.mjs` moves its `next` and `@next/eslint-plugin-next` pins
+from `15.5.20` to `16.2.10` (keeping the string-equality assertion) and continues
+to enforce the Node/npm/lockfile-v3 invariants. `tests/automation.test.mjs`,
+README, and any doc/test enumerations affected by the `dev`-script change or the
+bundler qualification are updated to stay truthful (e.g. the removed
+`--turbopack` flag; any Turbopack build note). All doc/test enumerations updated
+in the same rollback unit.
+
+### FR13 — Rollback unit and blocking semantics
+
+The manifest, lockfile, `next.config`/scripts, any codemod source edits, contract
+tests, and docs are one revertible unit: a single revert restores the
+fully-qualified `next@15.5.20` baseline (**never** `15.1.11`). If any validation
+gate or matrix item fails under Next 16 and baseline replay attributes it to the
+upgrade, the stage is **blocked** (escalate with evidence); do not ship partial
+workarounds (e.g. mixing a 16.x runtime with a 15.x lint plugin, or silently
+pinning `--webpack` to dodge a Turbopack failure without architect sign-off).
+
+## Non-Functional Requirements
+
+### Reproducibility
+
+Everything under the exact Node `22.23.1` / npm `10.9.8` / lockfile v3 / `npm ci`
+contract; no toolchain drift; the codemod's edits reconciled to the exact target
+group; lockfile provenance stays the public registry.
+
+### Behavior preservation
+
+The user-visible contract of the page — timing, camera semantics, pointer
+semantics, control buttons, canvas bring-up — is identical before and after,
+across the bundler change. This stage exists to prove that, not merely assert it.
+
+### Evidence honesty
+
+Every claim in the review states the bundler (webpack baseline vs. Turbopack
+target), engine, renderer, input method (real event vs. scripted handle), and
+result. Environment-limited results (e.g. Firefox WebGL on CI) are recorded as
+such, consistent with #11.
+
+### Supply-chain integrity
+
+The upgraded framework introduces no new install scripts, no non-registry
+sources, and no unexpected package-manager behavior (FR11); audit evidence is
+compared path-by-path with original exit codes preserved (FR10).
+
+### Maintainability
+
+The app lands on the Active-LTS line with the default Turbopack bundler qualified
+and the ESLint CLI path intact, keeping later stages (language/lint, CSS)
+unblocked and the reproducibility/qualification bars unchanged.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Turbopack production build differs from webpack (chunking, module resolution, client/server boundary) and breaks the WebGL island | User-visible regression / broken bundle | FR5 qualifies the Turbopack build + start + single-Three-runtime + no-Node-import checks; FR9 runs the full numeric matrix against the Turbopack build; baseline replay before attribution |
+| Codemod proposes out-of-scope changes (React bump, config rewrites, unrelated codemods) | Scope creep / unreviewed drift | FR2 requires reviewing and curating every codemod change; final manifest reconciled to the exact target group; escalate genuinely-required-but-out-of-scope changes |
+| `@next/eslint-plugin-next@16` changes rule ids/output the flat config relies on | Lint failure or silent coverage change | FR4 requires the #7 config to pass under the 16.x plugin with explicit reconciliation of any rule change, no silent absorption |
+| Next 16 raises the Node or browser floor beyond current policy | Unsupported toolchain / dropped browsers | FR1/FR7 reverify both floors against the upgrade guide; `22.23.1` already exceeds `>=20.9.0`; escalate if a floor exceeds current policy |
+| A newer 16.x patch supersedes `16.2.10` at implementation time | Unreviewed target ships | FR1 reverification with escalation, not silent retarget |
+| Residual Next-owned nested PostCSS misread as a new/closed finding | Misleading audit story | FR10 confirms `next@16.2.10` still pins `postcss@8.4.31` and carries it forward as a documented, non-app-controllable residual |
+| Node-only import leaks into the client bundle under the new bundler | Client runtime break | FR5 explicit no-Node-only-import + single-Three-runtime checks on the client graph chunk |
+| Firefox WebGL still cannot run on CI (unchanged from #11) | Misread as regression | Reuse the #11 CI/local split unchanged; Chromium enforces every behavioral assertion in CI; Firefox stays local qualification |
+
+## Acceptance Scenarios
+
+### Scenario 1 — Verified supported target group
+`npm ci` on the updated manifest under the exact toolchain completes with a
+supported peer tree, lockfile v3, no manifest mutation, exactly `next@16.2.10`
+and `@next/eslint-plugin-next@16.2.10` (string-equal), and React/DOM unchanged at
+`19.2.7`.
+
+### Scenario 2 — Codemod reviewed and curated
+The official Next 16 codemod has been run in the branch; the review lists what it
+changed, what was kept, and what incidental drift was reverted, with the final
+manifest equal to the target group.
+
+### Scenario 3 — Obsolete idioms gone
+`dev` is `next dev` (no `--turbopack`); no `next lint` invocation remains; lint
+passes under the 16.x plugin via the `eslint .` CLI path.
+
+### Scenario 4 — Turbopack build qualified
+`next build` (Turbopack) succeeds; a direct production `next start` returns the
+root page HTTP 200; the client bundle has no Node-only imports and resolves
+exactly one Three runtime through the client-only island.
+
+### Scenario 5 — Static and automated gates
+Lint, typecheck, `npm test`, Turbopack build, direct production start, the
+Chromium-required smoke, and aggregate `validate` all exit 0 at the final commit.
+
+### Scenario 6 — Interaction matrix on the Turbopack build
+The complete graph interaction matrix passes (Chromium required gate + Firefox
+local qualification) against the Turbopack production build with zero unexpected
+page/console/hydration/timer/WebGL-context/GPU errors, per #11 semantics.
+
+### Scenario 7 — Honest lockfile and audit story
+The review documents the framework before/after versions, the full/production
+audit deltas path-by-path (exit codes preserved), and the explicit disposition of
+the residual Next-owned nested `postcss@8.4.31`.
+
+### Scenario 8 — Node/browser policy verified
+The review records that `22.23.1` satisfies Next 16's Node floor and states the
+Next 16 supported-browser policy, confirming compatibility with the app's WebGL2
+requirement.
+
+### Scenario 9 — Atomic rollback
+A single revert of the unit restores the fully-qualified `next@15.5.20` baseline
+(never `15.1.11`); no follow-up fixes are required to return to green.
+
+### Scenario 10 — Blocking honored
+If any gate or interaction fails under Next 16 and baseline replay attributes it
+to the upgrade, the stage stops with evidence and escalation — no partial
+workarounds, no mixed 16.x-runtime/15.x-plugin combination, no undisclosed
+`--webpack` fallback.
+
+## Open Questions
+
+### Critical
+
+- None. Registry verification (2026-07-20) confirmed target existence/currency,
+  the Node floor (`>=20.9.0` vs. `22.23.1`), the React peer (`^19.0.0` vs.
+  `19.2.7`), no new required peers, and that the nested PostCSS pin persists in
+  `next@16.2.10`.
+
+### Important
+
+- None open. The previously contingent choices are settled decisions,
+  overridable only at the spec-approval gate: rely on the default Turbopack
+  bundler rather than pin `--webpack`/`--turbopack` (Confirmed Decisions #5,
+  FR5); exact equal `next`/plugin pins (Confirmed Decisions #7, FR3/FR12); reuse
+  the #11 CI/local engine split unchanged (FR9). If the architect wants any
+  changed, that happens at the gate, and the spec is amended before planning.
+
+### Nice-to-know
+
+- Whether the Turbopack build materially changes first-load JS / bundle size for
+  the graph route versus webpack — worth recording in the review, not a gate.
+- Whether Next 16 changes any default `next.config` behavior worth pinning
+  explicitly later (kept out of scope here; config stays effectively empty).
+
+## References
+
+- Issue #12; roadmap issue #6; research:
+  `codev/research/architecture-dependency-modernization.md` (Stage 3 — Next 16
+  Active LTS).
+- Direct dependency: spec/plan/review 11 (3D/WebGL two-engine qualification,
+  merged PR #25) — source of the interaction matrix, the CI/local engine split,
+  and the exact-pin/contract-test discipline reused here.
+- Prior stages: spec/plan/review 9 (Next 15/React 19), 10 (CSS/build/ESLint —
+  nested PostCSS finding and the #7 ESLint CLI path), 7 (reproducible Node
+  toolchain), bugfix 8 (FocusGraph lifecycle hardening).
+- `codev/resources/arch.md` / `arch-critical.md` (Validation Baseline;
+  reproducibility contract), `codev/resources/lessons-learned.md` /
+  `lessons-critical.md` (Validation Evidence).
+- Registry verification 2026-07-20: `npm view next dist-tags`,
+  `npm view next@16.2.10 engines peerDependencies peerDependenciesMeta`,
+  `npm view @next/eslint-plugin-next@16.2.10`, and inspection of the checked-in
+  lockfile's `node_modules/next/node_modules/postcss` entry (`8.4.31`, confirmed
+  still pinned by `next@16.2.10` and `next@15.5.20`).
+- [Next.js support policy](https://nextjs.org/support-policy),
+  [Next.js 16 upgrade guide](https://nextjs.org/docs/app/guides/upgrading/version-16),
+  [Node.js release status](https://nodejs.org/en/about/previous-releases).
+
+## Consultation Log
+
+_To be populated by the SPIR 3-way consultation (Gemini, Codex, Claude) that
+porch runs after this draft, and updated after any human feedback._

--- a/codev/specs/12-migrate-the-application-to-nex.md
+++ b/codev/specs/12-migrate-the-application-to-nex.md
@@ -333,7 +333,10 @@ Record the verification date and findings in the review.
 Run the official Next 16 upgrade codemod (`@next/codemod upgrade`, or the exact
 invocation the reverified upgrade guide specifies) in the dedicated branch under
 the pinned toolchain. Review every change it proposes — manifest edits,
-`next.config` edits, source codemods, and any script changes. Curate the result:
+`next.config` edits (including a possible `next.config.js` → `next.config.ts`/ESM
+format migration, which is reviewed and accepted only if Next 16 actually
+requires it; otherwise the config stays as the effectively-empty
+`next.config.js`), source codemods, and any script changes. Curate the result:
 the final manifest must be exactly the target group (FR3); any incidental version
 drift the codemod introduces beyond that group (e.g. bumping React, types, or
 unrelated deps) is reverted as out of scope. Document, in the review, what the
@@ -368,10 +371,26 @@ direct production `next start` serves the root page HTTP 200; the built client
 bundle loads and runs the graph. The client-only dynamic boundary
 (`FocusGraphWrapper.tsx`: `dynamic(..., {ssr: false})`) is preserved. The client
 bundle contains **no Node-only imports** and resolves **exactly one** Three
-runtime through the client-only island (`npm ls three` shows a single
-`three@0.185.1`; no nested `node_modules/**/node_modules/three`; no `node:`/
-Node-builtin import reaches the client graph chunk). Any Turbopack-specific build
-output difference relevant to correctness is recorded in the review.
+runtime through the client-only island.
+
+**Evidence method (explicit, repo-local, so builders don't invent inconsistent
+proofs):**
+- *Single Three runtime*: `npm ls three` resolves exactly one `three@0.185.1`
+  and the lockfile contains no nested `node_modules/**/node_modules/three` entry
+  (also enforced by the existing FR12 contract test, mirroring #11).
+- *No Node-only imports in the client bundle*: after `next build`, scan the
+  emitted client assets under `.next/static/` (the chunks actually shipped to
+  the browser) for the `node:` scheme and bare Node-builtin specifiers
+  (e.g. `grep -RolE "node:(fs|path|crypto|os|stream|util|process|module|child_process)" .next/static/`
+  and the analogous check for the un-prefixed builtins the graph chunk could
+  pull in) — the shipped client chunks must match none. A clean production
+  `next build` plus successful client-side graph bring-up in the smoke (the
+  island renders under `{ssr:false}`) is corroborating evidence, but the
+  built-asset scan is the primary proof. The exact commands and their output are
+  recorded in the review.
+
+Any Turbopack-specific build output difference relevant to correctness is
+recorded in the review.
 
 ### FR6 — Preserved client boundary and interaction semantics
 
@@ -408,7 +427,12 @@ The automated smoke and the complete graph interaction matrix (the canonical
 matrix qualified in #11: canvas creation, initial layout, auto-rotation,
 delayed pointer enablement, trackball zoom/rotation, node drag→fix, right-click
 unfix, click-to-focus, reset, axes toggle, resize, unmount/remount) pass against
-the **Turbopack** production build. The #11 CI/local engine split is reused
+the **Turbopack** production build. The canonical matrix and smoke are the
+existing committed suites — `tests/e2e/matrix.spec.ts` (13-item matrix),
+`tests/e2e/smoke.spec.ts` (canvas/WebGL readiness + controls + strict error
+budget), the shared `tests/e2e/graph-handle.ts` imperative-handle helper, and
+the `tests/focus-graph-lifecycle.test.mjs` unit suite — as defined in review 11
+(§"Spec Compliance" / FR9). This stage re-runs them, not re-authors them. The #11 CI/local engine split is reused
 unchanged: Chromium (SwiftShader) is the required gate (`E2E_ENGINES=chromium`)
 locally and in CI; Firefox remains the documented local qualification gate.
 Verification stays numeric via the react-force-graph imperative handle, driven
@@ -441,9 +465,14 @@ For every lockfile entry changed by this upgrade: (a) `resolved` URLs point only
 at the public npm registry (`registry.npmjs.org`) — no git, tarball-URL, or
 alternate-registry sources; (b) no changed entry introduces an install script
 (`hasInstallScript`/`preinstall`/`install`/`postinstall`) its previous version
-lacked, and any pre-existing install script in the changed set is identified and
-explained; (c) `npm ci` output shows no unexpected package-manager behavior.
-Findings go in the review's lockfile section.
+lacked. **Listing scope**: every *newly introduced* install script (an entry that
+gains one relative to its pre-upgrade version, or a newly added package that has
+one) must be individually called out and explained; *pre-existing, unchanged*
+install scripts in the changed subgraph need only be confirmed as pre-existing
+and unchanged (a summary count/identification suffices — no exhaustive
+re-enumeration), consistent with #11's FR6. (c) `npm ci` output shows no
+unexpected package-manager behavior. Findings go in the review's lockfile
+section.
 
 ### FR12 — Contract-test and docs updates
 
@@ -612,5 +641,37 @@ workarounds, no mixed 16.x-runtime/15.x-plugin combination, no undisclosed
 
 ## Consultation Log
 
-_To be populated by the SPIR 3-way consultation (Gemini, Codex, Claude) that
-porch runs after this draft, and updated after any human feedback._
+### Iteration 1 — initial three-way review (2026-07-20)
+
+- **Gemini: APPROVE (high confidence).** Endorsed the exact-pin discipline, the
+  codemod-then-curate approach to avoid scope creep, the Turbopack client-bundle
+  risk mitigation (no Node-only imports + single Three runtime, backed by the
+  two-engine matrix), and the explicit nested-PostCSS disposition. No issues.
+- **Claude: APPROVE (high confidence).** Independently verified every factual
+  claim against the codebase (manifest versions, scripts, empty config, no
+  middleware, static async page, client island, camera/timer parameters,
+  contract-test string-equality, `E2E_ENGINES` selection, `dev` not asserted by
+  `automation.test.mjs`). No factual errors; internally consistent decisions.
+  Three non-blocking notes: (1) call out a possible `next.config.js` →
+  `next.config.ts`/ESM codemod change surface; (2) README `dev`-script update
+  (already covered by FR12); (3) record webpack-vs-Turbopack bundle-size delta
+  (already in Nice-to-know).
+- **Codex: COMMENT (high confidence).** Strong, implementation-ready spec; three
+  minor evidence-method clarifications, all accepted and incorporated:
+  1. FR5 lacked an explicit evidence method for "no Node-only imports reach the
+     client chunk" → FR5 now specifies a repo-local method: scan emitted
+     `.next/static/` client assets for `node:`/bare-builtin specifiers, plus
+     `npm ls three` for the single runtime.
+  2. FR9 referenced "the canonical matrix qualified in #11" without a concrete
+     pointer → FR9 now names the exact suites (`tests/e2e/matrix.spec.ts`,
+     `tests/e2e/smoke.spec.ts`, `tests/e2e/graph-handle.ts`,
+     `tests/focus-graph-lifecycle.test.mjs`) and review 11's FR9 section.
+  3. FR10/FR11 install-script listing scope was ambiguous → FR11 now states that
+     newly introduced install scripts are individually called out, while
+     pre-existing unchanged ones need only be confirmed (no exhaustive
+     re-enumeration), consistent with #11's FR6.
+- Claude note (1) was applied to FR2 (config-format migration is a reviewed
+  codemod surface, accepted only if Next 16 requires it).
+
+_Second consultation (after human/gate feedback) to be appended if the spec is
+revised at the spec-approval gate._

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -473,3 +473,18 @@ REQUEST_CHANGES. Addressed the non-blocking points to strengthen the deliverable
   squash/integration is the architect's call. Builder commits follow `[Spec 12]…`.
 Recorded in review Consultation Feedback → "PR Review (Round 1)". Committing the
 improvements; then `porch next 12` (advance to pr gate / verify).
+
+## GATE REACHED: `pr` (STOP — human approval required)
+`porch next 12` → `gate_pending`. All reviewers approved (gemini APPROVE, codex
+COMMENT [non-blocking], claude APPROVE); porch advanced to the `pr` gate and is
+WAITING FOR HUMAN APPROVAL. Per strict mode I STOP here and do NOT run
+`porch approve` — only the architect approves gates. Architect notified. Improvement
+commit `46e8e0b` pushed to PR #26.
+
+**On architect approval of the `pr` gate:** `porch next 12` → merge the PR
+(builder merges own PR after architect approves), record with
+`porch done 12 --merged 26` if applicable, then the project enters the **verify**
+phase: pull the integration branch (main) into the worktree, `porch done 12` to
+signal verification ready, architect approves `verify-approval`. If verify is
+unneeded: `porch verify 12 --skip "reason"`. NOTE: builder branches block
+force-push (GH013); merge via the PR, not a local rewrite.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -1,0 +1,36 @@
+# spir-12 thread — Migrate the application to Next 16 Active LTS
+
+Builder for Issue #12 (Stage 3 of the dependency-modernization roadmap #6).
+Strict-mode SPIR. Depends on #11 (Next 15 baseline, merged as PR #25).
+
+## Specify phase
+
+Started specify. No pre-existing spec — authoring from the issue + Stage 3 research.
+
+### Grounding done before drafting (2026-07-20)
+- Current baseline (post-#11): `next@15.5.20`, `@next/eslint-plugin-next@15.5.20`
+  (devDep), `react`/`react-dom` `19.2.7`, Node `22.23.1`/npm `10.9.8`, lockfile v3.
+- Registry reverification (`npm view`):
+  - `next` latest = `16.2.10`; `@next/eslint-plugin-next` latest = `16.2.10`.
+  - `backport` dist-tag = `15.5.20` (our rollback baseline — never `15.1.11`).
+  - `next@16.2.10` engines `node >=20.9.0` (22.23.1 satisfies); peers
+    react/react-dom `^18.2.0 || ^19.0.0` (19.2.7 satisfies). All other peers
+    (`sass`, `@playwright/test`, `@opentelemetry/api`,
+    `babel-plugin-react-compiler`) are `peerDependenciesMeta.optional`.
+- Migration surface confirmed minimal: no middleware, no dynamic request APIs
+  (cookies/headers/params/searchParams) in `app/`, empty `next.config.js`,
+  `app/page.tsx` is a static async server component rendering the client island.
+- `next lint` already gone: `lint` script is `eslint .` (#7); flat config wires
+  `@next/eslint-plugin-next` directly. Only obsolete flag left = `--turbopack`
+  on the `dev` script. `automation.test.mjs` does NOT pin `dev`, so dropping it
+  is contract-safe.
+- Nested PostCSS: `node_modules/next/node_modules/postcss@8.4.31` is pinned by
+  `next` itself — `next@16.2.10` bundles `postcss@8.4.31` exactly as 15.5.20
+  does. Next-owned build-time residual; persists across the upgrade → explicit
+  disposition, not a fixable finding here.
+- Contract test to update: `tests/toolchain.test.mjs` pins next/plugin to
+  `15.5.20` and asserts `next === @next/eslint-plugin-next`.
+
+No "Baked Decisions" heading in the issue; scope/acceptance-criteria text
+treated as fixed. Elections (Turbopack-by-default, exact pins) flagged in the
+spec's Confirmed Decisions, overridable at the spec gate.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -80,3 +80,77 @@ REQUEST_CHANGES. Applied all feedback:
   16.x (`nextPlugin.configs.recommended.rules`, `configs['core-web-vitals'].rules`).
 Committed "Plan with multi-agent review". Next: porch → plan-approval GATE →
 notify architect and STOP.
+
+## Plan-approval gate — APPROVED (2026-07-20)
+Architect approved the plan (3 phases, one rollback unit), restarted me fresh, and
+told me to resume via porch into Implement. `porch next 12` transitioned to
+implement / plan_phase=framework_upgrade (iter 1).
+
+## Implement Phase 1 — framework_upgrade (2026-07-20)
+Scope: FR1, FR2, FR3, FR4, FR12 (+ FR13 rollback unit). Fresh worktree =
+node_modules ABSENT at start; lockfile baseline correctly locks next@15.5.20 /
+react@19.2.7 / plugin@15.5.20.
+
+**FR1 reverify (registry, under pinned toolchain):** PASS, no escalation.
+- `next` + `@next/eslint-plugin-next` `latest` = 16.2.10 (both). No superseding
+  stable 16.x (16.3.0 only preview/canary). `backport` = 15.5.20 (rollback tgt).
+- next@16.2.10 `engines.node >=20.9.0` admits 22.23.1; React peer `^19.0.0` admits
+  19.2.7; all non-React peers (sass, @playwright/test ^1.51.1, @opentelemetry/api,
+  babel-plugin-react-compiler) are peerDependenciesMeta.optional → no NEW required
+  peer. Playwright 1.61.1 satisfies the new optional peer.
+
+**FR2 codemod — run & curated.** `@next/codemod upgrade 16.2.10` orchestrator is a
+TTY multi-select (can't complete under builder non-TTY stdin; also self-installs,
+bypassing the pinned single-`npm install`). Recommended 5 codemods; reviewed each:
+- 4 jscodeshift transforms (remove-experimental-ppr, remove-unstable-prefix,
+  middleware-to-proxy, next-experimental-turbo-to-turbopack) → dry-run over whole
+  tree = 0 modified / 13 unmodified. Zero source changes (matches minimal surface).
+- `next-lint-to-eslint-cli` is an orchestrator that IGNORES --dry: it added
+  eslint-config-next@^15.5.20 (out-of-scope new dep, 15.x) + rewrote
+  eslint.config.mjs to `[...next, ...nextCoreWebVitals, ...nextTypescript]`
+  (broadens rule surface). **REVERTED entirely** — not applicable (repo already on
+  the #7 `eslint .` path w/ direct @next/eslint-plugin-next wiring). Curated out
+  per FR2/FR4. Net accepted codemod source/config change: NONE.
+Version bump + lockfile settle done by hand-reconciliation per the plan's toolchain
+discipline (not the orchestrator's self-install).
+
+**FR3 manifest+lockfile.** package.json next→16.2.10 (deps), plugin→16.2.10
+(devDeps); one `npm install` under Node 22.23.1/npm 10.9.8. Verified: lockfile v3;
+resolved next/plugin=16.2.10 (string-equal); react/react-dom unchanged 19.2.7;
+single three@0.185.1 (deduped, no nested); root deps/devDeps mirror manifest; NO
+peer warnings. `npm ci` = perfect no-op (lockfile md5 identical before/after 2nd
+ci). Nested next-owned postcss@8.4.31 persists (expected; FR10 disposition = Ph3).
+
+**FR4 obsolete idioms.** dev → `next dev` (dropped --turbopack). No `next lint` in
+scripts/CI(.github/workflows/validation.yml)/anywhere; lint stays `eslint .`.
+Plugin 16.2.10 `configs.recommended.rules` (21) & `configs['core-web-vitals'].rules`
+(21) resolve as spreadable objects → flat-config export-shape intact under 16.x.
+
+**FR12 contract tests.** toolchain.test.mjs expectedDependencyBaseline next+plugin
+15.5.20→16.2.10 (string-equality + lockfile-v3/Node assertions preserved).
+
+**DEVIATION (documented, FR6): tsconfig.json.** `next build` (Next 16) makes a
+mandatory tsconfig change: `jsx: "preserve"` → `"react-jsx"` (React automatic
+runtime) + suggested include `.next/dev/types/**/*.ts` (Turbopack dev types).
+Behavior-preserving (tsc is noEmit; jsx only affects type-check handling — typecheck
+passes both ways). Committed the minimal semantic form (2 edits, original
+formatting); verified BUILD-STABLE (2nd build leaves tsconfig untouched, no
+reconfigure msg). Not in the plan's expected file list but strictly forced by the
+Next 16 build → belongs in this rollback unit.
+
+**Environmental notes (NOT project issues, NOT committed):**
+- `npm run lint` in-worktree flags only the untracked harness file
+  `.claude/hooks/worktree-write-guard.cjs` (not in HEAD, not gitignored, absent in
+  clean CI checkouts). Project source lints CLEAN under 16.x plugin
+  (`eslint . --ignore-pattern .claude/**` = exit 0). Did NOT touch eslint.config.mjs
+  (out-of-scope + FR4 forbids new suppressions).
+- `next build` warns about multiple lockfiles (parent main-checkout + nested
+  worktree) and infers parent as turbopack root — artifact of nested-worktree
+  topology; absent in clean CI. Not silenced (would need an out-of-scope
+  `turbopack.root` path in config; spec keeps config effectively empty).
+
+**Phase 1 gates:** lint (project source exit 0) ✓ · typecheck exit 0 ✓ · npm test
+21/21 ✓ · Turbopack build exit 0 ✓ · next start root `/` HTTP 200 ✓ · npm ci no-op ✓.
+Files changed: package.json, package-lock.json (48/48 framework-only delta,
+registry URLs), tests/toolchain.test.mjs, tsconfig.json. Next: commit phase →
+`porch done 12` (checks + 3-way consult on the committed diff).

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -47,3 +47,26 @@ REQUEST_CHANGES. Incorporated all feedback (minor/clarifying):
 - FR2: `next.config.js` → `.ts`/ESM noted as a reviewed codemod surface.
 Committed as "Specification with multi-agent review". Next: porch drives to the
 spec-approval GATE → notify architect and STOP for human approval.
+
+## Spec-approval gate — APPROVED (2026-07-20)
+Architect approved the spec, verified factual claims against main, and confirmed
+both elections (default-Turbopack + exact string-equal next/plugin pins). Told me
+to continue to Plan. Architect ran `porch approve` themselves (`porch pending`
+empty; `porch next 12` returned plan-phase tasks). Per porch skill, builders
+NEVER call `porch approve` — the human runs it.
+
+## Plan phase
+Drafted `codev/plans/12-migrate-the-application-to-nex.md`. Three phases (one
+rollback unit, phase commits within one PR):
+1. framework_upgrade — reverify (FR1), run/review codemod (FR2), manifest+lock →
+   16.2.10 (FR3), drop `--turbopack` dev flag + confirm no `next lint` (FR4),
+   re-pin toolchain.test.mjs (FR12). Static-green target.
+2. turbopack_behavioral_qualification — full two-engine matrix + smoke vs the
+   Turbopack build (FR9), client-bundle integrity: no Node imports + single Three
+   runtime (FR5), preserved semantics (FR6), Node/browser policy (FR7), validate
+   green (FR8), error budget (FR11).
+3. evidence_disposition_and_docs — audit/lockfile delta + PostCSS disposition
+   (FR10), supply-chain verify (FR11), docs/enumeration truthfulness (FR12).
+Design note: no infra-first phase (unlike plan 11) — the matrix/Firefox infra
+already exists from #11; this reuses it unchanged. Porch plan checks pass
+(plan_exists, has_phases_json, min_two_phases=3). Committed initial plan draft.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -445,3 +445,11 @@ Follow-ups). Routed governance updates by tier via the update-arch-docs skill:
 npm test still 21/21. Next: commit review+governance+thread, push, open the single
 PR (Closes #12), run porch review checks (pr_exists/arch/lessons/e2e), `porch done`,
 notify architect PR-ready.
+
+**PR OPENED: #26** → https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/pull/26
+(base main, Closes #12). Review commit `89550a9` pushed. Porch review checks all
+green (pr_exists ✓, review_has_arch_updates ✓, review_has_lessons_updates ✓,
+e2e_tests skipped ✓). Architect notified PR-ready. Running PR 3-way consult next;
+then the `pr` gate awaits human approval (I do NOT approve gates). After merge →
+verify phase (pull integration branch, `porch done 12`, architect approves
+verify-approval).

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -429,3 +429,19 @@ implementation is code-complete: framework at 16.2.10, dev flag dropped, `next l
 gone, Turbopack build qualified across two engines, Node/browser policy verified,
 audit/lockfile delta explained (audit-neutral), PostCSS residual dispositioned,
 docs truthful.
+
+## SPIR Review phase (R) — review doc + governance updates
+Porch advanced to `review`. Authored `codev/reviews/12-migrate-the-application-to-nex.md`
+(Summary, FR1–FR13 compliance table + issue acceptance criteria, Deviations,
+Lessons Learned, Technical Debt, full per-phase/round/model Consultation Feedback,
+mandatory Architecture Updates + Lessons Learned Updates, Flaky Tests = none,
+Follow-ups). Routed governance updates by tier via the update-arch-docs skill:
+- arch.md (cold): +"Framework and Bundler Baseline" (Next 16/Turbopack/next-lint-
+  gone/Node+browser floors/nested-postcss residual). arch-critical.md (hot): +1 map
+  line (2 topics, within cap; no new hot fact).
+- lessons-learned.md (cold): +"Toolchain and Worktree Hygiene" (env-artifact-vs-gate
+  + lockfile-name contamination). lessons-critical.md (hot): +1 lesson (env-artifact
+  vs gate; 5 total, within cap) +1 map line.
+npm test still 21/21. Next: commit review+governance+thread, push, open the single
+PR (Closes #12), run porch review checks (pr_exists/arch/lessons/e2e), `porch done`,
+notify architect PR-ready.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -453,3 +453,23 @@ e2e_tests skipped ✓). Architect notified PR-ready. Running PR 3-way consult ne
 then the `pr` gate awaits human approval (I do NOT approve gates). After merge →
 verify phase (pull integration branch, `porch done 12`, architect approves
 verify-approval).
+
+### PR #26 — 3-way `--type pr` consult (Round 1): 2 APPROVE + 1 COMMENT (no blockers)
+Gemini APPROVE (high), Claude APPROVE (high), Codex COMMENT (high). No
+REQUEST_CHANGES. Addressed the non-blocking points to strengthen the deliverable:
+- **Claude (verified catch):** `baseline-browser-mapping@2.10.43` flipped dev→prod
+  scope (next@16.2.10 declares it a direct dep `^2.9.19`; baseline didn't). My
+  earlier lockfile diff compared version/resolved/install-script but not the `dev`
+  flag, so "0 added/removed" missed this scope flip. VERIFIED it's the ONLY flip;
+  same version, registry.npmjs.org, Apache-2.0, no advisory, production audit still
+  5 → audit-neutral. Documented in review FR11 row + here.
+- **Codex nit 1 (plan stale):** updated plan `Status: draft`→`complete`, Phase
+  Status table pending→complete (×3), and the 13 Success Metrics checkboxes.
+  (Granular per-phase deliverable checkboxes left as plan-detail; authoritative
+  completion is status.yaml + the review doc. Verify-phase item stays unchecked —
+  genuinely not done until after merge.)
+- **Codex nit 2 (porch commit noise):** rebutted/N/A — `chore(porch): …` are
+  machine-generated state commits, not builder commits; force-push blocked (GH013);
+  squash/integration is the architect's call. Builder commits follow `[Spec 12]…`.
+Recorded in review Consultation Feedback → "PR Review (Round 1)". Committing the
+improvements; then `porch next 12` (advance to pr gate / verify).

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -70,3 +70,13 @@ rollback unit, phase commits within one PR):
 Design note: no infra-first phase (unlike plan 11) — the matrix/Firefox infra
 already exists from #11; this reuses it unchanged. Porch plan checks pass
 (plan_exists, has_phases_json, min_two_phases=3). Committed initial plan draft.
+
+### Plan iteration 1 — 3-way consult (2026-07-20)
+Gemini APPROVE (high), Claude APPROVE (high), Codex COMMENT (high). No
+REQUEST_CHANGES. Applied all feedback:
+- Fixed Phase 2 error-budget label FR11 → FR9 (FR11 = supply-chain, stays Phase 3).
+- Phase 3 FR12: explicit refresh of stale README line 6 ("React 19 and Next 15").
+- Phase 1 FR4: named the exact eslint plugin config accesses to re-verify under
+  16.x (`nextPlugin.configs.recommended.rules`, `configs['core-web-vitals'].rules`).
+Committed "Plan with multi-agent review". Next: porch → plan-approval GATE →
+notify architect and STOP.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -488,3 +488,10 @@ phase: pull the integration branch (main) into the worktree, `porch done 12` to
 signal verification ready, architect approves `verify-approval`. If verify is
 unneeded: `porch verify 12 --skip "reason"`. NOTE: builder branches block
 force-push (GH013); merge via the PR, not a local rewrite.
+
+**CI GREEN (architect's approval condition met).** Architect posted their 3-way
+integration review on PR #26 (unanimous APPROVE) and said they'll approve the pr
+gate once Validation is green on head `fa4bced` — **hold merge until then**.
+Validation run 29763803502 = `success` (15m39s) on fa4bced; Vercel pass; PR
+MERGEABLE/CLEAN. Notified architect. STILL HOLDING — merge only AFTER the pr gate is
+approved by the architect. Not self-approving, not merging.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -414,3 +414,18 @@ evidence, not committed.
 next. (The formal review doc `codev/reviews/12-*.md` is authored in the SPIR Review
 phase that porch drives after Implement; this phase assembles the tables above for
 it.)
+
+### Phase 3 iter1 — 3-way consult → UNANIMOUS APPROVE (first iteration)
+Gemini APPROVE (high), Codex APPROVE (high), Claude APPROVE (high). No issues from
+any reviewer. Claude verified all four acceptance criteria (audit exit codes
+preserved + path-by-path delta; nested PostCSS dispositioned; supply-chain clean +
+npm ci no-op; README truthful + npm test 21/21) and grep-confirmed no `--turbopack`
+/`next lint` remnants anywhere. Committed `1bf5163`.
+
+**Phase 3 DONE. ALL THREE IMPLEMENT PHASES COMPLETE.** Advancing to SPIR **Review**
+phase (porch authors/guides `codev/reviews/12-*.md`), then the single PR (all phase
+commits on `builder/spir-12`), architect review, merge, verify. Next 16 migration
+implementation is code-complete: framework at 16.2.10, dev flag dropped, `next lint`
+gone, Turbopack build qualified across two engines, Node/browser policy verified,
+audit/lockfile delta explained (audit-neutral), PostCSS residual dispositioned,
+docs truthful.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -345,3 +345,72 @@ commits. Advancing to Phase 3 `evidence_disposition_and_docs` (FR10 audit/lockfi
 delta, FR11 supply-chain, FR6/FR10 PostCSS disposition, FR12 docs). Ph3 will need
 the audit counts captured here: full {mod 7, high 4, total 11}; production {mod 5,
 high 0, total 5}.
+
+## Implement Phase 3 — evidence_disposition_and_docs (COMPLETE)
+Evidence + docs phase. Baseline = merge-base with main `58f04bb` (next 15.5.20).
+Real source change this phase: `README.md` line 6 only. Evidence (FR10/FR11) is
+destined for the review; captured here.
+
+**FR10 lockfile delta — CLEAN, framework-only.** `git diff 58f04bb HEAD`:
+package.json (next 15.5.20→16.2.10 deps, plugin 15.5.20→16.2.10 devDeps, `dev`
+drops `--turbopack`), package-lock.json, tests/toolchain.test.mjs (Ph1 pin),
+tsconfig.json (Ph1 jsx/dev-types deviation). Structured lockfile `packages`-map
+diff (baseline vs HEAD): **11 changed, 0 added, 0 removed**, lockfileVersion stays
+3. Every changed entry is Next-owned, all 15.5.20→16.2.10:
+`next`, `@next/env`, `@next/eslint-plugin-next`, and 8× `@next/swc-*` platform
+binaries (darwin-arm64/x64, linux-arm64-gnu/musl, linux-x64-gnu/musl,
+win32-arm64-msvc/x64-msvc). React/DOM (19.2.7), three (0.185.1), and all other
+transitives UNCHANGED. Framework changes relevant to this app: bundler default
+(Turbopack for dev+build), `next lint` removed, Node floor >=20.9.0, browser floor
+Chrome/Edge/FF 111 + Safari 16.4 (all FR7).
+
+**FR10 audit delta — BYTE-IDENTICAL before/after (upgrade is audit-neutral).**
+`npm audit --package-lock-only` on baseline (15.5.20) vs HEAD (16.2.10), full &
+production, original exit codes preserved (both exit 1 = advisories present, not a
+zero-gate):
+- FULL: baseline {mod 7, high 4, total 11} == HEAD {mod 7, high 4, total 11}; same
+  11 advisory names (@vercel/analytics, @vercel/speed-insights, brace-expansion,
+  flatted, geist, glob, minimatch, next, picomatch, postcss, yaml).
+- PRODUCTION: baseline {mod 5, high 0, total 5} == HEAD {5}; same names
+  (@vercel/analytics, @vercel/speed-insights, geist, next, postcss).
+- Advisory paths **resolved by upgrade: 0 · introduced: 0 · unchanged: all**.
+- The `next` (moderate, `via: postcss`) and `postcss`
+  (GHSA-qx2v-qp2m-jg93, XSS via unescaped `</style>` in CSS stringify, range
+  `<8.5.10`) advisories BOTH trace to the Next-bundled nested postcss (below); npm's
+  only offered "fix" is a bogus `next@9.3.3` MAJOR DOWNGRADE (`isSemVerMajor`) — no
+  forward fix, i.e. not app-fixable. @vercel/analytics/@vercel/speed-insights/geist
+  = pre-existing app-dep advisories (unchanged). Dev-only (full∖prod):
+  brace-expansion, flatted, glob, minimatch, picomatch, yaml (pre-existing
+  toolchain, unchanged).
+
+**Nested PostCSS disposition (FR10) — Next-owned residual, carried forward.**
+`node_modules/next/node_modules/postcss@8.4.31` is present in BOTH baseline and
+HEAD (identical); `next@16.2.10` still pins it. It is Next-owned (nested under
+`next/`), NOT app-controllable in this stage. The app's OWN top-level
+`postcss@8.5.19` is patched (≥8.5.10, not in the advisory range) — so the postcss
+advisory path is solely the Next-bundled 8.4.31. Disposition: documented build-time
+residual, neither a new nor a closed finding; unchanged by this upgrade; identical
+to the pre-upgrade state. Not app-fixable without an out-of-scope override.
+
+**FR11 supply-chain — CLEAN.** For all 11 changed entries: `resolved` →
+`registry.npmjs.org` ONLY (no git/tarball/alt-registry). Install-script deltas:
+0 changed entries gained an install script; 0 added entries (none added) → no new
+install scripts introduced. Pre-existing unchanged install scripts in the subgraph:
+the `@next/swc-*` binaries carry none (`hasInstallScript:false` both versions), so
+nothing to re-enumerate. `npm ci` at HEAD = perfect no-op: exit 0, lock md5
+`b2cc530…` identical before/after, name stays `primary`, zero manifest/lock git
+diff.
+
+**FR12 docs/enumerations.** README line 6 updated: "Updated for React 19 and Next
+15…" → "React 19 and Next 16 Active LTS; production builds (`npm run build`) use the
+default Turbopack bundler…" (was not asserted by `automation.test.mjs` but would
+otherwise be false). No `--turbopack` dev flag or `next lint` mention existed in the
+README to remove. `tests/toolchain.test.mjs` next/plugin pins already moved
+15.5.20→16.2.10 in Ph1. `npm test` = **21/21** (automation.test.mjs README/script/CI
+enumerations + toolchain + audit-report all green). Raw audit JSON stays local/CI
+evidence, not committed.
+
+**Phase 3 commit contents:** README.md (line 6) + this thread evidence. Consult
+next. (The formal review doc `codev/reviews/12-*.md` is authored in the SPIR Review
+phase that porch drives after Implement; this phase assembles the tables above for
+it.)

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -34,3 +34,16 @@ Started specify. No pre-existing spec — authoring from the issue + Stage 3 res
 No "Baked Decisions" heading in the issue; scope/acceptance-criteria text
 treated as fixed. Elections (Turbopack-by-default, exact pins) flagged in the
 spec's Confirmed Decisions, overridable at the spec gate.
+
+### Specify iteration 1 — 3-way consult (2026-07-20)
+Gemini APPROVE (high), Claude APPROVE (high), Codex COMMENT (high). No
+REQUEST_CHANGES. Incorporated all feedback (minor/clarifying):
+- FR5: explicit repo-local evidence method for the no-Node-import check
+  (scan `.next/static/` emitted client assets) + `npm ls three`.
+- FR9: named the exact #11 suites (matrix.spec.ts, smoke.spec.ts,
+  graph-handle.ts, focus-graph-lifecycle.test.mjs) + review 11 §FR9.
+- FR11: install-script listing scope (new ones called out; pre-existing
+  unchanged only confirmed).
+- FR2: `next.config.js` → `.ts`/ESM noted as a reviewed codemod surface.
+Committed as "Specification with multi-agent review". Next: porch drives to the
+spec-approval GATE → notify architect and STOP for human approval.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -174,3 +174,112 @@ fixes"), the fix lands as a **follow-up content commit on top of `aae97b8`**
 (`[Spec 12][Phase: framework_upgrade] fix: restore lockfile name …`). The
 cumulative branch content is correct (name=primary); the eventual PR diff (branch
 vs main) is clean. Re-consult next.
+
+### Phase 1 iter2 — 3-way consult → UNANIMOUS APPROVE
+Gemini APPROVE (high), Codex APPROVE (high), Claude APPROVE (high). Claude
+re-verified the lockfile name=primary fix, all 458 resolved URLs =
+registry.npmjs.org, no app/config/eslint changes, tsconfig deviation justified.
+No issues. porch advanced framework_upgrade → COMPLETE and moved to Phase 2
+(turbopack_behavioral_qualification, iter1).
+
+**Phase 1 done.** Branch commits on origin: aae97b8 (upgrade) + 114cc66 (name fix)
++ porch state commits. Lesson recorded for Ph2/Ph3: commit content BEFORE the
+consult cycle; NEVER rewrite pushed history (remote blocks force-push on builder
+branches, GH013) — post-consult fixes go as follow-up commits.
+
+## Implement Phase 2 — turbopack_behavioral_qualification (STARTING)
+Scope: FR5 (client-bundle integrity: single three + no Node-only imports in
+.next/static), FR6 (preserved semantics), FR7 (Node/browser policy), FR8
+(aggregate validate gate), FR9 (full two-engine matrix+smoke vs Turbopack build,
+error budget). This is the large browser-qualification phase (Playwright
+Chromium+Firefox). Known environmental watch-items entering Ph2:
+- `npm run validate` includes `npm run lint`, which fails ONLY on the untracked
+  harness file `.claude/hooks/worktree-write-guard.cjs` (absent in CI). Need an
+  honest strategy so the gate reflects project source, not the harness artifact.
+- Playwright browser availability / GPU (Firefox WebGL) in this worktree TBD —
+  #11 split is Chromium-required (SwiftShader) + Firefox local qualification.
+Per porch's own guidance ("Run /compact before starting each new phase") + the
+size of Ph2, this is a natural checkpoint.
+
+## Implement Phase 2 — turbopack_behavioral_qualification (QUALIFICATION COMPLETE)
+Pure qualification phase: re-run the #11 suites UNCHANGED against the now-default
+Turbopack production build, scan the shipped client bundle, verify Node/browser
+policy. **Zero source/test/config changes** — the correct outcome (plan: "Files:
+expected none in app/"). Environment: Node 22.23.1 / npm 10.9.8, next+plugin
+16.2.10, lockfile name=`primary`. All commands run in-worktree.
+
+**FR5 client-bundle integrity — PASS.**
+- Single Three runtime: `npm ls three` → one `three@0.185.1` (deduped across
+  react-force-graph-3d → 3d-force-graph → three-forcegraph/three-render-objects,
+  all `deduped`); no nested `node_modules/**/node_modules/three`. Also enforced by
+  the FR12 contract test.
+- No Node-only imports in shipped client chunks. After a clean `rm -rf .next &&
+  next build` (Turbopack), scanned `.next/static/` (14 files, 11 `.js`):
+  - `node:` scheme scan (fs/path/crypto/os/stream/util/process/module/
+    child_process/net/tls/http/https/zlib/events/buffer/assert/url/querystring/
+    worker_threads/dns/readline/vm/perf_hooks) → **0 matches**.
+  - Bare-builtin **import/require-form** scan (`(require\(|from|import)…"builtin"`)
+    → **0 matches** (authoritative proof).
+  - Broad quoted-token scan surfaced only 3 innocuous NON-import usages, each
+    inspected: `"path"` = SVG `<path>` tag + cookie `Path=` attr; `"module"` =
+    `type:"module"` script attr; `"process"` = `"process"===E(i.process)` runtime
+    env-sniff (`typeof process` isomorphic detection). None are Node-builtin
+    imports. Client bundle clean.
+
+**FR6 preserved semantics — PASS.** `git status`/`git diff --stat` after build:
+zero tracked source changes. No graph prop/handler/timer/camera/control edit;
+`app/` diff = none. Build is BUILD-STABLE (unlike Ph1, `next build` did NOT
+re-touch tsconfig — the react-jsx/dev-types change landed in Ph1 and holds). `.next`
+is gitignored (confirmed). Only uncommitted tracked file = this thread.
+
+**FR7 Node/browser policy — PASS (no declaration required).**
+- Node floor: `next@16.2.10` declares `engines.node: ">=20.9.0"`; repo pins
+  `22.23.1` (`.nvmrc` + `engines.node`, CI/contract-enforced) → satisfied with a
+  full-major margin. Matches spec §2. No Node change permitted/needed.
+- Browser policy (reverified from the official Next 16.2.10 doc
+  `nextjs.org/docs/architecture/supported-browsers`, lastUpdated 2025-10-01):
+  **Chrome 111+ / Edge 111+ / Firefox 111+ / Safari 16.4+**, zero-config. Next's
+  default browserslist = `["chrome 111","edge 111","firefox 111","safari 16.4"]`.
+  All four floor browsers ship WebGL2 (Safari since 15.0; others long before 111),
+  so the Next 16 floor is compatible with the app's WebGL2 requirement. Next works
+  zero-config and does NOT require an app-level `browserslist` → **none added**
+  (spec FR7: "otherwise record that no declaration is required"). Adding one would
+  be out-of-scope noise. `package.json` has no `browserslist` (unchanged).
+
+**FR8 aggregate gate — PASS (honest env-artifact caveat).**
+- `npm run typecheck` (tsc --noEmit) → exit 0.
+- `npm run lint` (`eslint .`) → exit 1, but ALL 18 errors are in ONE file:
+  the untracked builder-harness artifact `.claude/hooks/worktree-write-guard.cjs`
+  (not tracked, NOT in HEAD, absent from any clean CI `actions/checkout`). Project
+  source lints CLEAN: `eslint . --ignore-pattern ".claude/**"` → exit 0. Did NOT
+  edit `eslint.config.mjs` (FR4 forbids new suppressions; out-of-scope env noise).
+  In CI (`E2E_ENGINES=chromium npm run validate` over the committed tree) the lint
+  stage is green because the artifact isn't checked out.
+- `npm run test:smoke` (build + Playwright) → see FR9.
+- Audit pipeline intact + exit codes preserved (delta/disposition is Ph3/FR10):
+  full = {mod 7, high 4, total 11} exit 1; production = {mod 5, high 0, total 5}
+  exit 1. Existing advisories are not a zero-findings gate (arch-critical).
+
+**FR9 behavioral qualification + error budget — PASS.** `npm test`
+(node --test, incl. `focus-graph-lifecycle.test.mjs`) = **21/21**. Full two-engine
+Playwright matrix+smoke against the Turbopack `next start` = **20/20** (11.9m):
+- Chromium (SwiftShader, the required CI gate `E2E_ENGINES=chromium`): 10/10.
+- Firefox (local qualification gate): 10/10.
+- Covered: initial force layout, auto-rotate pause/resume, delayed pointer enable,
+  wheel zoom-out, wheel zoom-in + background-drag rotate, click-to-focus + camera
+  animate + reset, axes toggle, resize consistency, unmount/remount, and smoke
+  (canvas/WebGL2 readiness + core controls + STRICT error budget). Smoke green in
+  BOTH engines ⇒ zero unexpected page/console/hydration/timer/WebGL-context/GPU
+  errors. Re-run, not re-authored (#11 suites unchanged).
+
+**FR13 regression semantics:** no baseline divergence observed ⇒ no baseline
+replay needed; nothing to escalate.
+
+**Env-only warnings (NOT project issues, NOT silenced):** `next build`/`next start`
+warn about "multiple lockfiles / inferred workspace root" (parent main-checkout +
+nested worktree) — nested-worktree topology artifact, absent in clean CI. Did NOT
+add `turbopack.root`/`outputFileTracingRoot` (spec keeps config empty; out of
+scope). Same disposition as Ph1.
+
+**Phase 2 commit contents:** thread evidence only (zero source diff is the correct,
+plan-anticipated outcome for a qualify-existing-behavior phase). Consult next.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -152,5 +152,25 @@ Next 16 build → belongs in this rollback unit.
 **Phase 1 gates:** lint (project source exit 0) ✓ · typecheck exit 0 ✓ · npm test
 21/21 ✓ · Turbopack build exit 0 ✓ · next start root `/` HTTP 200 ✓ · npm ci no-op ✓.
 Files changed: package.json, package-lock.json (48/48 framework-only delta,
-registry URLs), tests/toolchain.test.mjs, tsconfig.json. Next: commit phase →
-`porch done 12` (checks + 3-way consult on the committed diff).
+registry URLs), tests/toolchain.test.mjs, tsconfig.json. Committed aae97b8;
+`porch done 12` checks passed (build ✓ tests ✓).
+
+### Phase 1 iter1 — 3-way consult
+Gemini APPROVE (high), Codex APPROVE (high), Claude REQUEST_CHANGES (high).
+Claude's finding is VALID: my worktree `npm install` rewrote package-lock.json
+top-level `"name": "primary"` → `"spir-12"` (npm derives it from the containing
+dir since package.json has no `name`). Canonical baseline (parent, merge-base,
+main) is all `"primary"`; the change was worktree contamination, not a framework
+delta. (My first self-check was fooled by diffing working-tree-vs-own-commit;
+diffing my commit vs its parent confirmed the change.) FIXED: restored line 2 to
+`"name": "primary"`. Verified npm ci exit 0 keeps name=primary (ci never rewrites
+the lock), no name delta vs parent, build ✓, tests 21/21 ✓.
+
+Delivery of the fix: I first tried to fold it into the phase commit via amend +
+restructure, but the remote enforces a **no-force-push rule** on builder branches
+(GH013 repo rule), so rewriting the already-pushed `aae97b8` is impossible. Per
+the SPIR guidance ("if changes are needed after commit, create a new commit with
+fixes"), the fix lands as a **follow-up content commit on top of `aae97b8`**
+(`[Spec 12][Phase: framework_upgrade] fix: restore lockfile name …`). The
+cumulative branch content is correct (name=primary); the eventual PR diff (branch
+vs main) is clean. Re-consult next.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -323,3 +323,25 @@ action.
 
 Re-consult (iter2) with rebuttal in context. No code change; thread carries the
 clean-tree validate evidence for on-disk re-verification.
+
+### Phase 2 iter2 — 3-way consult → UNANIMOUS APPROVE
+Gemini APPROVE (high), Codex APPROVE (high), Claude APPROVE (high). Codex flipped
+REQUEST_CHANGES → APPROVE: "the prior validate concern is credibly rebutted against
+the actual worktree state, and no phase-scoped fixes are needed." Gemini: handling
+of the harness-artifact lint failure "exactly right"; clean-`git worktree`
+verification proves the aggregate gate passes for real project code; correct not to
+mutate status.yaml. Claude independently re-verified both concerns as non-issues
+(confirmed `.claude/hooks/…cjs` "not in HEAD"; status.yaml `in_progress` +
+`build_complete:true` + `iteration:2` = correct porch review-cycle position) and
+all five FRs (FR5–FR9). No code change across iter1→iter2; the "fix" was a rebuttal
++ committed clean-tree evidence.
+
+**Phase 2 DONE.** Zero-source-diff qualification: FR5 (single Three + no client-side
+Node imports), FR6 (no app/ change), FR7 (Node floor + Chrome/Edge/FF 111 / Safari
+16.4 browser policy, no browserslist), FR8 (validate green on shipping tree), FR9
+(two-engine matrix+smoke 20/20 vs Turbopack, strict error budget clean). Branch
+commits: c1d85cd (qualification) + fb7bacc (clean-tree evidence) + porch state
+commits. Advancing to Phase 3 `evidence_disposition_and_docs` (FR10 audit/lockfile
+delta, FR11 supply-chain, FR6/FR10 PostCSS disposition, FR12 docs). Ph3 will need
+the audit counts captured here: full {mod 7, high 4, total 11}; production {mod 5,
+high 0, total 5}.

--- a/codev/state/spir-12_thread.md
+++ b/codev/state/spir-12_thread.md
@@ -283,3 +283,43 @@ scope). Same disposition as Ph1.
 
 **Phase 2 commit contents:** thread evidence only (zero source diff is the correct,
 plan-anticipated outcome for a qualify-existing-behavior phase). Consult next.
+
+### Phase 2 iter1 — 3-way consult
+Gemini APPROVE (high), Claude APPROVE (high), Codex REQUEST_CHANGES (high).
+Both approvers explicitly validated the lint-artifact handling ("honest env
+documentation, not a hidden failure"; "not touching eslint.config.mjs is correct").
+Codex raised 2 points, neither needing a code change:
+
+**Codex #1 — `npm run validate` not green locally (lint exits 1).** Root cause: the
+ONLY 18 `eslint .` errors are in `.claude/hooks/worktree-write-guard.cjs` — an
+untracked builder-harness artifact (+ its `.claude/settings.local.json` hook
+registration), NOT project source. Within `.claude/`, only `skills/**` is tracked;
+`hooks/` + `settings.local.json` are untracked → absent from any `git clone`/CI
+checkout. To answer the "local qualification" framing with evidence (not just "CI is
+clean"), I reproduced a clean checkout ON THIS MACHINE and ran the literal aggregate
+command:
+- `git worktree add --detach <tmp> HEAD` → clean committed tree (has tracked
+  `.claude/skills/`, NO `.claude/hooks/`, NO `settings.local.json`).
+- Bare `eslint .` there → **exit 0** (harness file was the sole cause).
+- `npm ci` (real node_modules; lockfile name stays `primary`) + literal
+  **`npm run validate`** (lint && typecheck && test:smoke, BOTH engines, no
+  `E2E_ENGINES` filter) → **exit 0** end-to-end; Playwright **20/20** (Chromium 10 +
+  Firefox 10). (First try symlinked node_modules → Turbopack "symlink out of fs
+  root" panic = rig artifact; redone with real `npm ci`.) Clean tree also emits NO
+  "multiple lockfiles" warning (not nested under the main checkout).
+- Did NOT edit `eslint.config.mjs`: FR4 forbids new suppressions + out-of-scope. So
+  the gate IS green locally (both engines) on the shipping tree; the failure is an
+  instrumentation artifact only. Rebuttal:
+  `12-turbopack_behavioral_qualification-iter1-rebuttals.md`.
+
+**Codex #2 — status.yaml shows phase `in_progress`, not `complete`.** Working as
+designed: porch owns status.yaml in strict mode; a phase stays `in_progress` through
+the review/iterate cycle and flips to `complete` only after unanimous approval, when
+porch advances. Current file is self-consistent: `in_progress` + `build_complete:
+true` + `iteration: 1` = checks passed, in review sub-stage. Thread's "QUALIFICATION
+COMPLETE" = the WORK is done/ready-for-review, a different thing from the porch state
+field. Strict-mode rule forbids me editing status.yaml; porch will advance it. No
+action.
+
+Re-consult (iter2) with rebuttal in context. No code change; thread carries the
+clean-tree validate evidence for on-disk re-verification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "spir-12",
+  "name": "primary",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "primary",
+  "name": "spir-12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
         "@vercel/analytics": "~1.4.1",
         "@vercel/speed-insights": "~1.1.0",
         "geist": "~1.3.1",
-        "next": "15.5.20",
+        "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-force-graph-3d": "1.29.1",
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "~9.39.5",
-        "@next/eslint-plugin-next": "15.5.20",
+        "@next/eslint-plugin-next": "16.2.10",
         "@playwright/test": "1.61.1",
         "@types/node": "~22.20.1",
         "@types/react": "19.2.17",
@@ -1105,15 +1105,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.20.tgz",
-      "integrity": "sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1151,9 +1151,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -1183,9 +1183,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -1199,9 +1199,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -1215,9 +1215,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -1231,9 +1231,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -1247,9 +1247,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -1263,9 +1263,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -2109,7 +2109,6 @@
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
       "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4426,13 +4425,14 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.20",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -4441,18 +4441,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.20",
-        "@next/swc-darwin-x64": "15.5.20",
-        "@next/swc-linux-arm64-gnu": "15.5.20",
-        "@next/swc-linux-arm64-musl": "15.5.20",
-        "@next/swc-linux-x64-gnu": "15.5.20",
-        "@next/swc-linux-x64-musl": "15.5.20",
-        "@next/swc-win32-arm64-msvc": "15.5.20",
-        "@next/swc-win32-x64-msvc": "15.5.20",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "packageManager": "npm@10.9.8",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
@@ -21,7 +21,7 @@
     "@vercel/analytics": "~1.4.1",
     "@vercel/speed-insights": "~1.1.0",
     "geist": "~1.3.1",
-    "next": "15.5.20",
+    "next": "16.2.10",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-force-graph-3d": "1.29.1",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "~9.39.5",
-    "@next/eslint-plugin-next": "15.5.20",
+    "@next/eslint-plugin-next": "16.2.10",
     "@playwright/test": "1.61.1",
     "@types/node": "~22.20.1",
     "@types/react": "19.2.17",

--- a/tests/toolchain.test.mjs
+++ b/tests/toolchain.test.mjs
@@ -16,12 +16,12 @@ const expectedGeneratedIgnores = [
 ];
 const expectedDependencyBaseline = {
     dependencies: {
-        next: "15.5.20",
+        next: "16.2.10",
         react: "19.2.7",
         "react-dom": "19.2.7",
     },
     devDependencies: {
-        "@next/eslint-plugin-next": "15.5.20",
+        "@next/eslint-plugin-next": "16.2.10",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -23,6 +23,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Migrate the framework from the qualified **Next 15.5.20** baseline to **Next 16.2.10 (Active LTS)** as a single revertible unit, on the already-qualified **React 19.2.7** line. Turbopack is now the default bundler for both `dev` and `build`, `next lint` is gone (explicit `eslint .` path), and the production Turbopack build + client WebGL bundle are behaviorally qualified across the two-engine interaction matrix.

Zero `app/` source changes — the framework delta touches only `package.json`, `package-lock.json`, `tests/toolchain.test.mjs`, `tsconfig.json`, and `README.md`.

Closes #12

## Changes

- **Framework pin**: `next` and `@next/eslint-plugin-next` → exact `16.2.10`; contract test re-pinned (string-equality preserved). React/DOM unchanged at `19.2.7`.
- **Obsolete idioms removed**: dropped the redundant `--turbopack` dev flag (`dev` → `next dev`); no `next lint` anywhere; `lint` stays `eslint .`.
- **Codemod curation**: dry-ran every official transform (0 modifications); reverted the self-installing `next-lint-to-eslint-cli` orchestrator (out-of-scope 15.x dep + config broadening). Net accepted codemod source/config change: none.
- **Turbopack qualification (FR5/FR9)**: `.next/static/` scan shows no `node:`/bare Node-builtin imports; single `three@0.185.1` deduped; two-engine Playwright matrix + smoke **20/20** (Chromium SwiftShader 10, Firefox 10) against the Turbopack `next start`; strict error budget clean.
- **Policy (FR7)**: Node `22.23.1` ≥ Next 16 floor `>=20.9.0`; browser floor Chrome/Edge/Firefox 111 + Safari 16.4 (WebGL2-compatible, zero-config — no `browserslist` needed).
- **Evidence (FR10/FR11)**: lockfile delta = 11 Next-owned entries 15.5.20→16.2.10, 0 added/removed; audit byte-identical before/after (0 resolved / 0 introduced / all unchanged); all changed entries resolve to `registry.npmjs.org` with no install-script deltas; `npm ci` clean no-op. Nested Next-owned `postcss@8.4.31` dispositioned as a carried-forward build-time residual.
- **Docs (FR12)**: README updated to Next 16 Active LTS + default Turbopack note; governance docs (arch/lessons, hot + cold tiers) updated.

## Testing

- `npm test` — 21/21 (toolchain, automation, audit-report, focus-graph-lifecycle contracts)
- `npm run typecheck` — exit 0
- `npm run build` — Turbopack production build exit 0
- Two-engine Playwright matrix + smoke — 20/20 (Chromium + Firefox) against `next start`
- Full `npm run validate` — exit 0 on a clean checkout of the committed tree (both engines). Note: locally `eslint .` flags only the untracked builder-harness file `.claude/hooks/worktree-write-guard.cjs`, which is absent from any clean checkout/CI — project source lints clean.
- `npm ci` — clean no-op (lockfile stable, `name=primary`)

## Rollback

Manifest + lockfile + config + contract tests + docs are one revertible unit; a single revert restores the qualified `next@15.5.20` baseline (never `15.1.11`).

## Spec / Plan / Review

- Spec: `codev/specs/12-migrate-the-application-to-nex.md`
- Plan: `codev/plans/12-migrate-the-application-to-nex.md`
- Review: `codev/reviews/12-migrate-the-application-to-nex.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)