### PR TITLE
[Bugfix #27] Fix node-drag drift during auto-rotation (drift-free orbit)

### DIFF
--- a/app/components/FocusGraph.tsx
+++ b/app/components/FocusGraph.tsx
@@ -9,6 +9,7 @@ import ForceGraph3D, {
 import {AxesHelper, PerspectiveCamera} from "three";
 import {TrackballControls} from 'three/addons/controls/TrackballControls.js';
 import {createFocusGraphResources} from "./focusGraphResources";
+import {orbitCameraStep} from "./orbitCamera";
 
 function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: number }) {
     const fgRef = useRef<ForceGraphMethods>(undefined);
@@ -45,9 +46,11 @@ function FocusGraph({data, enableDelay=4000}: { data: string, enableDelay?: numb
             }
 
             const currentCamera = currentGraph.camera() as PerspectiveCamera;
-            const up = currentCamera.up.clone();
-            currentCamera.position.applyAxisAngle(up, -Math.PI / 300);
-            currentCamera.rotateOnAxis(up, -Math.PI / 300);
+            const currentControls = currentGraph.controls() as TrackballControls;
+            // Re-aim at the controls' orbit target every tick so the rotation
+            // stays centered without relying on TrackballControls.update()
+            // (skipped while controls are disabled during a node drag) — issue #27.
+            orbitCameraStep(currentCamera, currentControls.target, -Math.PI / 300);
         });
     }, [resources]);
 

--- a/app/components/orbitCamera.ts
+++ b/app/components/orbitCamera.ts
@@ -1,0 +1,28 @@
+import type {Camera, Vector3} from "three";
+
+/**
+ * Advances a turntable-style orbit by one step: rotate the camera's position
+ * around its up axis by `angle`, then re-aim the camera at `target`.
+ *
+ * Re-asserting `lookAt(target)` every step keeps the orbit drift-free and
+ * independent of `TrackballControls.update()`. Previously the tick paired
+ * `applyAxisAngle` with `rotateOnAxis`, an only-approximate re-aim that
+ * accumulates orientation error whenever the camera sits off the equatorial
+ * plane (its local up diverges from world up). That error stayed invisible
+ * only because `TrackballControls.update()` runs `camera.lookAt(target)` every
+ * frame — a correction that `three-render-objects` >= 1.42 skips while controls
+ * are disabled (e.g. during a node drag), which surfaced the drift and the
+ * snap-back-to-origin on release (issue #27).
+ *
+ * `target` is expected to be the controls' orbit target (the origin in this
+ * app), i.e. the world-space point the position is orbiting about.
+ */
+export function orbitCameraStep(
+    camera: Camera,
+    target: Vector3,
+    angle: number,
+): void {
+    const up = camera.up.clone();
+    camera.position.applyAxisAngle(up, angle);
+    camera.lookAt(target);
+}

--- a/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
+++ b/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-27
 title: node-drag-during-auto-rotation
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T19:50:29.273Z'
-updated_at: '2026-07-20T19:58:29.624Z'
+updated_at: '2026-07-20T20:08:54.401Z'

--- a/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
+++ b/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-27
 title: node-drag-during-auto-rotation
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T19:50:29.273Z'
-updated_at: '2026-07-20T19:50:29.273Z'
+updated_at: '2026-07-20T19:58:29.624Z'

--- a/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
+++ b/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-27
+title: node-drag-during-auto-rotation
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-20T19:50:29.273Z'
+updated_at: '2026-07-20T19:50:29.273Z'

--- a/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
+++ b/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-20T20:14:40.593Z'
+    approved_at: '2026-07-20T20:21:43.884Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T19:50:29.273Z'
-updated_at: '2026-07-20T20:14:40.594Z'
-pr_ready_for_human: true
+updated_at: '2026-07-20T20:21:43.884Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
+++ b/codev/projects/bugfix-27-node-drag-during-auto-rotation/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-20T20:14:40.593Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T19:50:29.273Z'
-updated_at: '2026-07-20T20:08:54.401Z'
+updated_at: '2026-07-20T20:14:40.594Z'
+pr_ready_for_human: true

--- a/codev/state/bugfix-27_thread.md
+++ b/codev/state/bugfix-27_thread.md
@@ -1,0 +1,66 @@
+# bugfix-27 — node-drag-during-auto-rotation
+
+Issue #27: Node drag during auto-rotation drifts the camera center, then snaps back to origin on release.
+
+## Investigate
+
+**Confirmed the regression source from the lockfile:**
+- `3d-force-graph@1.80.0`, `three-render-objects@1.42.0`, `react-force-graph-3d@1.29.1`, `three@0.185.1`, `next@16.2.10`.
+- These match the issue exactly (three-render-objects 1.37.0 → 1.42.0 added the `state.controls.enabled &&` guard to the per-frame tick, so `TrackballControls.update()` no longer runs while controls are disabled — and `3d-force-graph` disables controls during a node drag).
+
+**Root cause (app-side):** `FocusGraph.tsx` auto-rotation tick (`startRotation` callback, lines 47-50) orbits the camera with
+`position.applyAxisAngle(up, -π/300)` + `rotateOnAxis(up, -π/300)`. That pair is only an *approximate* "orbit while fixating origin"
+and accumulates orientation error whenever the camera is off the equatorial plane (its local up ≠ world up). Pre-upgrade,
+`TrackballControls.update()` ran every frame and ended with `camera.lookAt(target=origin)`, silently re-centering — including mid-drag.
+Post-upgrade, a node drag disables controls → the per-frame `lookAt` correction stops → the tick's error becomes visible drift,
+and re-enabling on release snaps back.
+
+**Fix direction chosen:** make the tick drift-free and self-sufficient — re-assert `camera.lookAt(controls.target)` each tick so it
+never depends on `TrackballControls.update()` running. This restores the exact pre-upgrade visual behavior (camera keeps orbiting
+during drag, view stays centered on origin) rather than changing behavior (pausing rotation during drag). Minimal, root-cause fix.
+
+**Regression test plan:** extract the per-tick camera step into a pure, exported helper and unit-test it with a real three.js
+`PerspectiveCamera` started OFF the equatorial plane (where the bug reproduces): after many ticks the view direction must keep
+pointing at the origin. Fails on the bugged (`rotateOnAxis`-only) code, passes on the fixed (`lookAt`) code. This is deterministic
+and is exercised by porch's `checks` block (`npm run build` + `npm test`), unlike an E2E which the software-rendered CI runner makes
+flaky for real node-grabs (see existing matrix.spec.ts notes).
+
+**Empirical confirmation** (real three.js `PerspectiveCamera`, 100 ticks ≈ 2s of drag at 20ms/tick, max angle between
+camera forward and direction-to-origin):
+- Equatorial start (0,0,300): bugged 0.00° / fixed 0.00° — bug does NOT show from a perfectly equatorial camera.
+- Off-equatorial (120,90,200) [focused-node-like]: bugged **10.85°** / fixed **0.00°**.
+- Steep off-equatorial (60,150,60): bugged **36.03°** / fixed **0.00°**.
+Confirms drift arises only off the equatorial plane (local up ≠ world up) and the `lookAt` fix is exactly drift-free.
+
+**Scope:** 1 new ~15-line helper (`app/components/orbitCamera.ts`) + ~3-line change in FocusGraph.tsx + a unit regression
+test. Net well under 300 LOC, single area (rotation) → BUGFIX-appropriate.
+
+→ investigate complete; transitioning to fix.
+
+## Fix
+
+**Change (net ~small, single area):**
+- New `app/components/orbitCamera.ts` — pure `orbitCameraStep(camera, target, angle)`: `applyAxisAngle` to orbit the
+  position, then `camera.lookAt(target)` to re-aim exactly each tick (drift-free, independent of `TrackballControls.update()`).
+- `FocusGraph.tsx` — rotation tick now calls `orbitCameraStep(currentCamera, currentControls.target, -π/300)` instead of the
+  `applyAxisAngle` + `rotateOnAxis` pair. Aims at the live controls target (origin here) rather than hardcoding.
+- `tests/orbit-camera.test.mjs` — deterministic unit regression test (real three.js `PerspectiveCamera`), 3 cases.
+
+**Regression test verified rigorously:** swapped the helper back to the pre-fix `rotateOnAxis` line → both drift tests FAIL
+(10.85° / 36° drift); restored `lookAt` → all pass (float noise ~1.2e-6°, threshold 1e-3°). Third test guards that rotation is
+still applied (position moves, radius preserved).
+
+**End-to-end browser verification** (real Chromium/SwiftShader, driving the real FocusGraph via a throwaway Playwright script,
+reproducing the exact node-drag mechanism: off-equatorial camera + `controls.enabled=false` while rotating):
+- Fixed build: world-origin distance from screen-center = 8.1px before / during-drag / after → view stays centered, no snap.
+- Pre-fix build (rebuilt): 698.9px → view thrown to the screen edge.
+Scratch script deleted (not committed) — the committed guard is the deterministic unit test (gated by porch `checks`).
+
+**Manual test instructions** sent to architect for the human-in-the-loop browser confirmation (repro needs tilting the view
+first to get off-equatorial, then dragging a node while auto-rotation stays on).
+
+Gates: porch `check` PASSED (build ✓ 5.9s, tests ✓ — 24 unit tests). Lint noise (18 errors) is entirely from the untracked
+`.claude/hooks/worktree-write-guard.cjs` harness file (unknown to git); my three source files lint clean (exit 0). Per
+lessons-critical, that's environment noise, not suppressed in committed config.
+
+→ fix complete; committing, then transitioning to pr.

--- a/codev/state/bugfix-27_thread.md
+++ b/codev/state/bugfix-27_thread.md
@@ -64,3 +64,22 @@ Gates: porch `check` PASSED (build ✓ 5.9s, tests ✓ — 24 unit tests). Lint 
 lessons-critical, that's environment noise, not suppressed in committed config.
 
 → fix complete; committing, then transitioning to pr.
+
+## PR
+
+- Commit `cbfa504` pushed on `builder/bugfix-27`.
+- **PR #29** opened against `main`: https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/pull/29
+  (body: Summary / Root Cause / Fix / Test Plan, closes #27).
+- Manual browser-test steps sent to architect for the human-in-the-loop confirmation.
+- 3-way CMAP review (gemini/codex/claude, `--protocol bugfix --type pr --project-id bugfix-27`) — the `--project-id`
+  flag was required because the shared worktree exposes all historical `codev/projects/*` (ambiguous auto-detect).
+  **All three APPROVE, no blocking issues:**
+  - gemini: APPROVE (HIGH) — no key issues.
+  - codex: APPROVE (MEDIUM) — no key issues; couldn't rerun build/typecheck in its read-only sandbox and saw the
+    audit-report validator test fail there — an environment artifact, NOT PR-introduced (local `npm test` = 24/24 green).
+  - claude: APPROVE (HIGH) — confirmed math correctness, scope discipline, cleanliness; non-blocking notes only
+    (the defensive `up.clone()`; no `describe()` grouping — both consistent with existing code).
+- No REQUEST_CHANGES → nothing to address. CMAP summary posted as a PR comment.
+
+→ requesting the `pr` gate via `porch done`; then WAIT for human approval (builders never self-approve).
+

--- a/tests/orbit-camera.test.mjs
+++ b/tests/orbit-camera.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {PerspectiveCamera, Vector3} from "three";
+
+import {orbitCameraStep} from "../app/components/orbitCamera.ts";
+
+// One auto-rotation step, matching FocusGraph.tsx's 20 ms interval.
+const STEP = -Math.PI / 300;
+// ~100 ticks ≈ 2 s, a representative node-drag duration at 20 ms/tick.
+const DRAG_TICKS = 100;
+// The drift-free step leaves only quaternion float noise (~1e-6°). The pre-fix
+// tick drifts > 10° over this many ticks, so this ceiling sits ~800× above the
+// noise floor and ~10000× below the regression it guards against.
+const MAX_DRIFT_DEG = 1e-3;
+
+/**
+ * Angle (degrees) between the camera's forward vector and the direction from
+ * the camera to `target`. Zero means the camera looks exactly at the target;
+ * a growing value is the "center of view wanders" drift from issue #27.
+ */
+function lookAtErrorDeg(camera, target) {
+    const forward = camera.getWorldDirection(new Vector3());
+    const toTarget = target.clone().sub(camera.position).normalize();
+    const dot = Math.max(-1, Math.min(1, forward.dot(toTarget)));
+    return (Math.acos(dot) * 180) / Math.PI;
+}
+
+test("orbit keeps the camera locked on the target from an off-equatorial start (issue #27)", () => {
+    // A focused/reset camera commonly sits off the equatorial plane, where the
+    // camera's local up diverges from world up. The pre-fix tick
+    // (applyAxisAngle + rotateOnAxis) accumulated orientation error there and
+    // relied on TrackballControls.update()'s per-frame lookAt to hide it — a
+    // correction that stops during a node drag (controls disabled) with
+    // three-render-objects >= 1.42. With the pre-fix tick this start drifts
+    // > 10° over the drag; the fixed step must stay numerically pinned.
+    const target = new Vector3(0, 0, 0);
+    const camera = new PerspectiveCamera(40, 1, 1, 200);
+    camera.position.set(120, 90, 200);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(target);
+
+    let maxError = 0;
+    for (let i = 0; i < DRAG_TICKS; i += 1) {
+        orbitCameraStep(camera, target, STEP);
+        maxError = Math.max(maxError, lookAtErrorDeg(camera, target));
+    }
+
+    assert.ok(
+        maxError < MAX_DRIFT_DEG,
+        `camera view drifted ${maxError.toFixed(4)}° from the target during a ${DRAG_TICKS}-tick orbit`,
+    );
+});
+
+test("orbit keeps the camera locked on the target from a steep off-equatorial start (issue #27)", () => {
+    // A steeper vantage (mostly overhead) diverges local-up from world-up even
+    // more; the pre-fix tick drifts > 35° here.
+    const target = new Vector3(0, 0, 0);
+    const camera = new PerspectiveCamera(40, 1, 1, 200);
+    camera.position.set(60, 150, 60);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(target);
+
+    let maxError = 0;
+    for (let i = 0; i < DRAG_TICKS; i += 1) {
+        orbitCameraStep(camera, target, STEP);
+        maxError = Math.max(maxError, lookAtErrorDeg(camera, target));
+    }
+
+    assert.ok(
+        maxError < MAX_DRIFT_DEG,
+        `camera view drifted ${maxError.toFixed(4)}° from the target during a ${DRAG_TICKS}-tick orbit`,
+    );
+});
+
+test("orbit still advances the camera around the target (rotation preserved)", () => {
+    // Guard that the fix re-aims *and* keeps orbiting: the position must move
+    // while the orbit radius (distance to target at the origin) is preserved.
+    const target = new Vector3(0, 0, 0);
+    const camera = new PerspectiveCamera(40, 1, 1, 200);
+    camera.position.set(0, 0, 300);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(target);
+
+    const before = camera.position.clone();
+    orbitCameraStep(camera, target, STEP);
+
+    assert.ok(
+        Math.abs(camera.position.length() - before.length()) < 1e-9,
+        "orbit radius must be preserved",
+    );
+    assert.ok(
+        camera.position.distanceTo(before) > 1e-3,
+        "the camera position must actually rotate each step",
+    );
+    // And it is still aimed at the target after moving.
+    assert.ok(
+        lookAtErrorDeg(camera, target) < MAX_DRIFT_DEG,
+        "camera must aim at target",
+    );
+});


### PR DESCRIPTION
## Summary

Fixes the regression where, with auto-rotation active, dragging a node made the camera's center-of-view drift for the duration of the drag and then snap back to the origin on release. The auto-rotation tick is now exactly drift-free and no longer depends on `TrackballControls.update()` running.

Fixes #27

## Root Cause

The auto-rotation tick in `FocusGraph.tsx` orbited the camera with:

```ts
position.applyAxisAngle(up, -π/300);
rotateOnAxis(up, -π/300);
```

That pair is only an **approximate** "orbit while fixating the origin". It accumulates orientation error whenever the camera sits **off the equatorial plane** (its local up diverges from world up). The error stayed invisible because `TrackballControls.update()` ends every frame with `camera.lookAt(target)` (target = origin), silently re-centering the view.

Spec 11 (#11 / PR #25) upgraded `three-render-objects` 1.37.0 → 1.42.0, which changed the per-frame tick from `state.controls.update && …` to `state.controls.enabled && state.controls.update && …`. Since `3d-force-graph` sets `controls.enabled = false` on node-drag start, `update()` — and therefore the per-frame `lookAt` correction — no longer runs during a node drag. The tick's accumulated drift then becomes visible, and re-enabling controls on release runs `lookAt(target)` once, snapping the view back to the origin.

Empirically (real three.js camera, ~100 ticks ≈ a 2 s drag): from a focused-node-like start `(120, 90, 200)` the pre-fix tick drifts **10.85°** off the origin; from a steep vantage `(60, 150, 60)`, **36°**. A perfectly equatorial camera does not drift — which is why the drag-while-rotating path was never noticed and why the repro needs the view tilted first.

## Fix

Extract the per-tick orbit into a pure helper `app/components/orbitCamera.ts`:

```ts
export function orbitCameraStep(camera, target, angle) {
    const up = camera.up.clone();
    camera.position.applyAxisAngle(up, angle); // orbit the position
    camera.lookAt(target);                     // re-aim exactly, every step
}
```

Re-asserting `lookAt(target)` each step makes the orbit exactly drift-free and independent of `TrackballControls.update()`. `FocusGraph.tsx` calls it with the live `controls.target` (the origin here) instead of the previous `applyAxisAngle`+`rotateOnAxis` pair. This **restores the pre-upgrade behavior** — the camera keeps orbiting smoothly during a node drag while the view stays centered — rather than changing it (e.g. pausing rotation during drag).

Net change is small and contained to the rotation path: a ~28-line helper, a 3-line swap in `FocusGraph.tsx`, plus tests.

## Test Plan

**Automated (added, gated by porch `checks` = `npm run build` + `npm test`):**
`tests/orbit-camera.test.mjs` drives a real three.js `PerspectiveCamera` from off-equatorial starts through ~100 orbit steps and asserts the view stays locked on the target (< 1e-3° drift; the fixed step leaves only ~1e-6° float noise). Verified as a genuine regression guard: swapping the helper back to the pre-fix `rotateOnAxis` line makes both drift cases **fail** (10.85° / 36°); the `lookAt` fix makes them **pass**. A third case guards that the step still actually rotates (position moves, orbit radius preserved).

- `npm run build` ✓
- `npm test` ✓ (24 unit tests, incl. 3 new)
- `npm run typecheck` ✓
- `npm run lint` ✓ on the changed source files (the repo-wide `eslint .` errors are entirely from the untracked `.claude/hooks/worktree-write-guard.cjs` builder-harness file, which is not part of the repo)

**End-to-end (real Chromium / SwiftShader, driving the real app, reproducing the exact mechanism — off-equatorial camera + `controls.enabled = false` while rotating):** the world origin's distance from screen-center held at **8.1 px** before / during-drag / after on the fixed build, vs **698.9 px** (view thrown to the screen edge) on the pre-fix build. This was a throwaway verification script, not committed — the committed guard is the deterministic unit test, since real node-grabs under software rendering are unreliable (see `tests/e2e/matrix.spec.ts` notes).

**Manual (human-in-the-loop):** step-by-step browser instructions relayed via the architect — with auto-rotation on, tilt the view by dragging empty space, then drag a node and confirm the view stays centered with no snap on release.

## Why qualification missed it originally

The Spec 11 E2E matrix covered auto-rotation, background-drag, zoom, and reset, but had **no node-drag scenario**, so the drag-while-rotating combination was never exercised. This PR adds a deterministic regression test for the underlying drift.
