### PR TITLE
[Issue #30] CI: shard Playwright e2e to cut Validation wall clock (~15m → ~5-6m)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -226,7 +226,19 @@ jobs:
   gate:
     name: Validation gate
     needs: [quality, e2e]
+    # Always run, then FAIL unless both upstreams succeeded. A plain
+    # `needs:`-only gate is SKIPPED when an upstream fails/cancels, and a skipped
+    # required check can be misread as passing — this makes the gate go actively
+    # red on any failed, skipped, or cancelled upstream job. For the matrix `e2e`
+    # job, `needs.e2e.result` is `success` only when every shard passed.
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Confirm the validation decomposition passed
-        run: echo "quality + full sharded e2e passed — contract-equivalent to npm run validate"
+      - name: Require quality and e2e to have succeeded
+        shell: bash
+        run: |
+          echo "quality result: ${{ needs.quality.result }}"
+          echo "e2e result:     ${{ needs.e2e.result }}"
+          test "${{ needs.quality.result }}" = "success"
+          test "${{ needs.e2e.result }}" = "success"
+          echo "quality + full sharded e2e passed — contract-equivalent to npm run validate"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,10 +9,22 @@ on:
 permissions:
   contents: read
 
+# CI runs a decomposition of `npm run validate` that is contract-equivalent to
+# the single-command local gate: the `quality` job enforces lint + typecheck +
+# unit contracts + audit evidence, and the sharded `e2e` matrix enforces the
+# production build + the FULL Chromium (SwiftShader) e2e suite (no test dropped,
+# engine pinned via E2E_ENGINES=chromium). The `gate` job is the single stable
+# green status. `npm run validate` remains the one-command local gate.
+# See codev/resources/arch.md ("Validation Baseline").
+env:
+  NODE_VERSION: 22.23.1
+  NPM_VERSION: 10.9.8
+
 jobs:
-  validation:
+  quality:
+    name: Quality (lint, typecheck, unit, audit)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
@@ -27,29 +39,20 @@ jobs:
       - name: Verify toolchain
         shell: bash
         run: |
-          test "$(node --version)" = "v22.23.1"
-          test "$(npm --version)" = "10.9.8"
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "${NPM_VERSION}"
 
       - name: Install locked dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test baseline contracts
         run: npm test
-
-      - name: Install Chromium and system dependencies
-        run: npm exec -- playwright install --with-deps chromium
-
-      # Chromium (bundled SwiftShader) is a deterministic software-WebGL
-      # rasterizer and is the required CI gate. The Firefox arm of the
-      # two-engine matrix stays a documented LOCAL qualification gate: Firefox
-      # has no SwiftShader equivalent and cannot create a WebGL context on
-      # GPU-less GitHub Actions runners ("Exhausted GL driver options"). See
-      # codev/reviews/11-upgrade-and-behaviorally-quali.md
-      # ("CI enforcement vs. local qualification").
-      - name: Validate
-        env:
-          E2E_ENGINES: chromium
-        run: npm run validate
 
       - name: Capture full audit evidence
         if: always()
@@ -93,6 +96,125 @@ jobs:
           path: audit-results/production/
           if-no-files-found: error
 
+  e2e:
+    name: E2E (Chromium shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up exact Node baseline
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "${NPM_VERSION}"
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Resolve Playwright version
+        id: playwright
+        shell: bash
+        run: |
+          version="$(node -p "require('@playwright/test/package.json').version")"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      # Chromium (bundled SwiftShader) is a deterministic software-WebGL
+      # rasterizer and is the required CI gate. The Firefox arm of the
+      # two-engine matrix stays a documented LOCAL qualification gate: Firefox
+      # has no SwiftShader equivalent and cannot create a WebGL context on
+      # GPU-less GitHub Actions runners ("Exhausted GL driver options"). See
+      # codev/reviews/11-upgrade-and-behaviorally-quali.md
+      # ("CI enforcement vs. local qualification"). The browser binary is
+      # cached above; --with-deps still installs OS libraries each run and the
+      # install is a no-op download on a cache hit.
+      - name: Install Chromium and system dependencies
+        run: npm exec -- playwright install --with-deps chromium
+
+      - name: Build production application
+        run: npm run build
+
+      # The FULL e2e suite, split at the test level across 4 shards (config sets
+      # fullyParallel: true). Each shard runs strictly serially (workers: 1). No
+      # test is dropped — the union of the four shards is the whole suite. Blob
+      # reports are stitched back together by the merge-reports job.
+      - name: Run e2e shard
+        env:
+          E2E_ENGINES: chromium
+          PLAYWRIGHT_BLOB_REPORT: "1"
+        run: npm exec -- playwright test --shard=${{ matrix.shard }}/4
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-test-results-${{ matrix.shard }}
+          path: test-results/
+          if-no-files-found: ignore
+
+  merge-reports:
+    name: Merge Playwright reports
+    needs: e2e
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up exact Node baseline
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "${NPM_VERSION}"
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npm exec -- playwright merge-reports --reporter html ./all-blob-reports
+
       - name: Upload Playwright HTML report
         if: always()
         uses: actions/upload-artifact@v7
@@ -101,10 +223,10 @@ jobs:
           path: playwright-report/
           if-no-files-found: ignore
 
-      - name: Upload Playwright test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-test-results
-          path: test-results/
-          if-no-files-found: ignore
+  gate:
+    name: Validation gate
+    needs: [quality, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm the validation decomposition passed
+        run: echo "quality + full sharded e2e passed — contract-equivalent to npm run validate"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /coverage
 /playwright-report/
 /test-results/
+/blob-report/
+/all-blob-reports/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -89,22 +89,37 @@ valid advisory evidence.
 ### Continuous integration
 
 GitHub Actions runs on pull requests and pushes to `main` using the same exact
-Node/npm contract, `npm ci`, `npm test`, and `npm run validate`. CI enforces the
-Chromium (SwiftShader) WebGL arm as the deterministic gate — it installs Chromium
-plus its Linux dependencies with:
+Node/npm contract and `npm ci`. Locally, `npm run validate` is the one-command
+green gate; in CI that gate is run as a **contract-equivalent decomposition**
+across parallel jobs to cut wall clock (~15 min → ~5–6 min) without dropping any
+check:
+
+- **`quality`** — `npm run lint`, `npm run typecheck`, `npm test`, and both
+  audit captures.
+- **`e2e`** — the production build plus the full Playwright suite, split at the
+  test level across four Chromium shards (`--shard=1/4 … 4/4`). Each shard runs
+  strictly serially (`workers: 1`); `playwright.config.ts` sets
+  `fullyParallel: true` so `--shard` splits per test rather than per file.
+- **`merge-reports`** — stitches the per-shard blob reports into one HTML report.
+- **`gate`** — a single required status that succeeds only when `quality` and
+  `e2e` both pass.
+
+CI enforces the Chromium (SwiftShader) WebGL arm as the deterministic gate — each
+shard installs Chromium plus its Linux dependencies with:
 
 ```sh
 npm exec -- playwright install --with-deps chromium
 ```
 
-and runs the Validate step with `E2E_ENGINES=chromium`. Firefox has no
-SwiftShader equivalent and cannot create a WebGL context on GPU-less runners, so
-the Firefox arm of the two-engine matrix stays a documented **local**
+(the browser download is cached at `~/.cache/ms-playwright`, keyed on the
+Playwright version) and runs its shard with `E2E_ENGINES=chromium`. Firefox has
+no SwiftShader equivalent and cannot create a WebGL context on GPU-less runners,
+so the Firefox arm of the two-engine matrix stays a documented **local**
 qualification gate: `npm run browser:install` and `npm run validate` (with
 `E2E_ENGINES` unset) exercise both engines locally. See
 `codev/reviews/11-upgrade-and-behaviorally-quali.md` ("CI Enforcement vs. Local
 Qualification").
 
 On every run it uploads the two audit artifacts. When Playwright produces
-diagnostics, the workflow also uploads stable `playwright-report` and
-`playwright-test-results` artifacts.
+diagnostics, the workflow also uploads the merged `playwright-report` and the
+per-shard `playwright-test-results-<n>` artifacts.

--- a/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
+++ b/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
@@ -1,0 +1,14 @@
+id: '30'
+title: ci-validation-workflow-takes-1
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-20T20:50:14.315Z'
+updated_at: '2026-07-20T20:50:14.316Z'

--- a/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
+++ b/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
@@ -1,7 +1,7 @@
 id: '30'
 title: ci-validation-workflow-takes-1
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T20:50:14.315Z'
-updated_at: '2026-07-20T20:50:14.316Z'
+updated_at: '2026-07-20T21:23:55.318Z'

--- a/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
+++ b/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-20T21:29:25.218Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T20:50:14.315Z'
-updated_at: '2026-07-20T21:23:55.318Z'
+updated_at: '2026-07-20T21:29:25.218Z'
+pr_ready_for_human: true

--- a/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
+++ b/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-20T21:29:25.218Z'
+    approved_at: '2026-07-21T00:22:41.618Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T20:50:14.315Z'
-updated_at: '2026-07-20T21:29:25.218Z'
-pr_ready_for_human: true
+updated_at: '2026-07-21T00:22:41.619Z'
+pr_ready_for_human: false

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -6,14 +6,24 @@ of any work that introduces or changes architectural patterns.
 ## Validation Baseline
 
 The repository's reproducibility contract is Node.js `22.23.1`, npm `10.9.8`,
-lockfile v3, and clean `npm ci`. GitHub Actions runs contract tests plus the
-shared `npm run validate` gate, whose real production-server two-engine
-(Chromium and Firefox) smoke checks WebGL and the core controls in both engines. Full and production npm audits are separate
-evidence: CI validates their JSON/original status and uploads them without
-turning existing advisory totals into a zero-findings gate. Contributor commands
-and artifact names live in `README.md`; implementation details live in
-`.github/workflows/validation.yml`, `playwright.config.ts`, and
-`scripts/validate-audit-report.mjs`.
+lockfile v3, and clean `npm ci`. `npm run validate` is the single-command local
+green gate, whose real production-server two-engine (Chromium and Firefox) smoke
+checks WebGL and the core controls in both engines. GitHub Actions does **not**
+run that one command; it runs a **contract-equivalent decomposition** of it,
+parallelized to cut wall clock (~15 min → ~5–6 min): a `quality` job (lint +
+typecheck + `npm test` + audit evidence) and an `e2e` matrix that builds and
+runs the FULL Playwright suite split at the test level across four Chromium
+shards (`playwright.config.ts` sets `fullyParallel: true` while keeping
+`workers: 1`, so each shard is strictly serial). The decomposition drops no
+check: lint, typecheck, build, and every e2e test still run, the Chromium engine
+gate is pinned via `E2E_ENGINES=chromium`, and a `gate` job gives a single
+required status. Do not raise `workers` or trim the qualified per-test waits —
+the SwiftShader timing environment (one test at a time) is what the decomposition
+preserves. Full and production npm audits are separate evidence: CI validates
+their JSON/original status and uploads them without turning existing advisory
+totals into a zero-findings gate. Contributor commands and artifact names live in
+`README.md`; implementation details live in `.github/workflows/validation.yml`,
+`playwright.config.ts`, and `scripts/validate-audit-report.mjs`.
 
 ## Dependency Classification and Lint Config
 

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -90,3 +90,13 @@ Human gate decision: approve AFTER hardening. Applied:
 - Two prior PR #32 runs already completed **success in 6m13s / 6m10s** wall clock
   (down from ~15m) — sharded design proven on CI, target ≤~6m met.
 - Watching the post-hardening run 29781097474 to green, then re-request the pr gate.
+
+### Post-hardening run 29781194428: shard 2 flaked (re-running)
+- Shard 2/4 failed on `matrix.spec.ts:235` click-to-focus: camera-motion predicate
+  `toBeGreaterThan(MOTION_FLOOR)` timed out (10s poll) — documented SwiftShader
+  timing flakiness, NOT a regression. Same test passed in the two prior CI runs
+  (6m10s/6m13s) and locally (1.8m). `retries: 0` (unchanged from original) means
+  one flake fails the shard. Gate correctly went RED — hardening confirmed working.
+- Sharding improves flake recovery: re-run one ~5.6m shard, not the whole 14m suite.
+- Action: `gh run rerun 29781194428 --failed` (shard 2 + dependent gate). If it
+  flakes again → escalate to architect (per "2 failures, get outside perspective").

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -75,3 +75,18 @@ README updates. Local gate: `npm test` 29/29, typecheck clean, `npm run build` c
   `porch approve` (human-only). Architect notified via `afx send`. STOPPING here.
 - Reviewer note in PR: if branch protection pins the old `validation` check name,
   repoint it at the new `gate` job (needs quality + e2e).
+
+## Architect follow-up #1 — gate hardening (2026-07-20T21:38Z)
+Human gate decision: approve AFTER hardening. Applied:
+- `gate` job now `if: always()` + explicit `test "${{ needs.quality.result }}" =
+  success` and same for `e2e`. Without this, a needs-only gate is SKIPPED on
+  upstream failure/cancel, and a skipped required check can be misread as passing.
+  Now the gate goes actively RED on any failed/skipped/cancelled upstream. (Matrix
+  e2e aggregate result is success only when all 4 shards pass.)
+- automation.test.mjs asserts the hardened gate (if: always + both result checks).
+- Committed 88d4e45, pushed. `npm test` 29/29.
+
+### CI evidence (real GitHub runners)
+- Two prior PR #32 runs already completed **success in 6m13s / 6m10s** wall clock
+  (down from ~15m) — sharded design proven on CI, target ≤~6m met.
+- Watching the post-hardening run 29781097474 to green, then re-request the pr gate.

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -1,0 +1,56 @@
+# air-30 thread — Issue #30: shard Playwright e2e to cut CI wall clock
+
+Protocol: AIR (strict). Phase: implement.
+
+## Goal
+Validation workflow ~15 min → ~5-6 min by sharding the e2e suite. `npm run validate`
+stays the single-command local gate; CI runs a **contract-equivalent decomposition**.
+
+## Plan (from issue #30 recommended approach + governance)
+1. `playwright.config.ts`: `fullyParallel: true`, keep `workers: 1` (per-test shardable,
+   still serial within a job). Add env-gated `blob` reporter for shard merging (local
+   behavior unchanged — `list` + `html` when env unset).
+2. `.github/workflows/validation.yml`: decompose the single job into
+   - `quality` job: lint, typecheck, `npm test` (unit), both audits (full + production,
+     validate-audit-report + upload). ~1.5 min.
+   - `e2e` job: matrix `shard: [1,2,3,4]`, `--shard=N/4`, `E2E_ENGINES=chromium`,
+     build per shard, Playwright browser cache (`~/.cache/ms-playwright`, keyed on
+     resolved Playwright version). Blob report per shard.
+   - `merge-reports` job (`if: always()`): merge blob reports → one `playwright-report`.
+   - `gate` job (`needs: [quality, e2e]`): single stable green status for branch protection.
+   - Every dep-installing job re-verifies Node 22.23.1 / npm 10.9.8 + `npm ci`.
+3. Update `tests/automation.test.mjs` to encode the NEW decomposed contract (old test
+   asserts the single "Validate" step — must be rewritten to the equivalence invariants).
+4. Update `codev/resources/arch.md` Validation Baseline: CI decomposition is
+   contract-equivalent to `npm run validate`.
+5. Update `README.md` CI section to describe sharding.
+6. Add `blob-report/**` to `.gitignore` + eslint ignores (+ toolchain test expected list).
+
+## Governance guardrails honored
+- Full e2e set preserved (no test dropped); Chromium engine gate via `E2E_ENGINES=chromium`.
+- Audit evidence (full + production) capture/validate/upload preserved.
+- Exact Node/npm baseline + `npm ci` in every dep-installing job.
+- Do NOT touch per-test waits / camera-settle polls / `workers: 1` / CI timeouts.
+
+## Notes
+- 10 e2e tests total: 9 in `tests/e2e/matrix.spec.ts` + 1 in `tests/e2e/smoke.spec.ts`.
+
+## Implementation status (implement phase)
+Done: playwright.config (`fullyParallel: true`), workflow decomposition (quality /
+e2e matrix / merge-reports / gate), automation.test rewrite to the decomposed
+contract, toolchain.test + eslint + gitignore blob-report ignores, arch.md +
+README updates. Local gate: `npm test` 29/29, typecheck clean, `npm run build` clean.
+
+### Verification findings
+- `--shard=N/4 --list` confirms clean test-level partition (3+3+2+2 = 10, no drop/dup)
+  once `fullyParallel: true` is set. Mechanism works.
+- Lint: the ONLY 18 errors are in untracked `.claude/hooks/worktree-write-guard.cjs`
+  (builder-harness file, absent from clean checkouts) — environment noise per
+  lessons-critical. None of my changed files lint-fail. Proving on clean checkout.
+- Full local chromium e2e (shared port 3000) came back 8 passed / 2 failed, BUT the
+  2 failures are `net::ERR_CONNECTION_REFUSED` at `page.goto`, i.e. the Next server
+  vanished mid-run — NOT assertion failures. Root cause: sibling builder **spir-13**
+  is running its own e2e on the same hardcoded port 3000 (`clean-13-rematrix`); the
+  two runs raced for the port. Reordered-schedule tests that actually executed all
+  passed. Re-verifying on an isolated port (31730) via a throwaway scratchpad config
+  to get an uncontended clean pass. (Did NOT kill spir-13's active server.)

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -100,3 +100,34 @@ Human gate decision: approve AFTER hardening. Applied:
 - Sharding improves flake recovery: re-run one ~5.6m shard, not the whole 14m suite.
 - Action: `gh run rerun 29781194428 --failed` (shard 2 + dependent gate). If it
   flakes again → escalate to architect (per "2 failures, get outside perspective").
+
+### BLOCKER: click-to-focus (matrix:235) is ~50% flaky on CI SwiftShader
+Run history (all on the sharded workflow):
+- 29780379868 — all green (6m10s)
+- 29780412864 — all green (6m13s)
+- 29781194428 — shard 2 FAIL (camera-motion predicate `>MOTION_FLOOR` 10s timeout);
+  re-ran → green. Gate went red then green (hardening confirmed working).
+- 29782250395 — shard 2 FAIL again on the SAME test, DIFFERENT assertion
+  ("a real node click should register and fix the node").
+Failing on different timing assertions across runs = SwiftShader rendering
+nondeterminism, not a logic bug. matrix:235 is the test the issue flags as
+SwiftShader-flaky (it carries its own 240s override). `retries: 0` (original
+config, unchanged) means one flake reds the gate. Sharding may raise its
+frequency: it now runs 3rd-of-3 in a fresh browser vs 6th-of-10 warmed-up before.
+**Held: NOT re-running to a lucky green (would hide durable flakiness). Notified
+architect; recommended CI-only retries `retries: process.env.CI ? 2 : 0`
+(honors all issue constraints: no trimmed waits, no raised workers). Awaiting
+guidance before re-requesting the pr gate.** CI currently red on head 022f78f.
+
+### Architect decision (2026-07-20T22:09Z): APPROVED CI retries, count 2
+Architect confirmed the flake is PRE-EXISTING, not from sharding: the same test
+(same click-registration assertion) also failed the OLD single-job workflow twice
+today (runs 29775364675, 29775316520). Tracking: **issue #34**.
+Applied:
+- `playwright.config.ts`: `retries: process.env.CI ? 2 : 0` with a comment citing
+  #34. Local stays 0 (flakes surface immediately); CI self-heals a single flake.
+- `automation.test.mjs`: asserts the CI-gated retries contract. `npm test` 29/29.
+- Passed-on-retry is reported as "flaky" in the merged HTML report — visibility
+  kept intentionally, NOT suppressed (per architect).
+- #34 cited in a PR comment too.
+Next: push, wait for CI green, then re-request the pr gate.

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -54,3 +54,13 @@ README updates. Local gate: `npm test` 29/29, typecheck clean, `npm run build` c
   two runs raced for the port. Reordered-schedule tests that actually executed all
   passed. Re-verifying on an isolated port (31730) via a throwaway scratchpad config
   to get an uncontended clean pass. (Did NOT kill spir-13's active server.)
+
+### Verification COMPLETE (all green)
+- Isolated-port (31730) full chromium e2e: **10/10 passed (11.4m)** with
+  `fullyParallel: true` — tests still ran serially (workers:1), test independence
+  intact. Confirms the earlier 2 failures were the spir-13 shared-port-3000 race,
+  not my change. Throwaway config torn down; port freed cleanly.
+- Clean detached-checkout gate (real `npm ci`, no `.claude/hooks`): lint exit 0,
+  typecheck exit 0, `npm test` 29/29. Proves the 18 local lint errors were purely
+  the untracked harness file (environment noise), not committed code.
+- Committed as 66b3ccb on builder/air-30. Proceeding to PR (porch flow).

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -64,3 +64,14 @@ README updates. Local gate: `npm test` 29/29, typecheck clean, `npm run build` c
   typecheck exit 0, `npm test` 29/29. Proves the 18 local lint errors were purely
   the untracked harness file (environment noise), not committed code.
 - Committed as 66b3ccb on builder/air-30. Proceeding to PR (porch flow).
+
+## PR phase
+- **PR #32** opened → main (review embedded in body per AIR).
+  https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/pull/32
+- porch PR-phase checks: `pr_exists` ✓, `e2e_tests` ✓ (the check runs
+  `npm run test:e2e || echo skipped`; no such script → skip echo, and it's
+  optional — the real e2e was verified manually above, not by this check).
+- `porch gate 30` → **GATE: pr requested, waiting for human approval.** Did NOT
+  `porch approve` (human-only). Architect notified via `afx send`. STOPPING here.
+- Reviewer note in PR: if branch protection pins the old `validation` check name,
+  repoint it at the new `gate` job (needs quality + e2e).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [
             "next-env.d.ts",
             "playwright-report/**",
             "test-results/**",
+            "blob-report/**",
         ],
     },
     {settings: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,15 +70,30 @@ export default defineConfig({
     // headroom over the local budget; local timing is unchanged. (The
     // click-to-focus test keeps its own explicit 240 s override either way.)
     timeout: process.env.CI ? 240_000 : 120_000,
-    fullyParallel: false,
+    // `fullyParallel` marks every test as an independently schedulable unit so
+    // `--shard` splits the suite at the TEST level (not the file level). With
+    // `workers: 1` still pinned, execution within any single job stays strictly
+    // serial — one test at a time, no SwiftShader CPU contention — so the
+    // qualified timing environment is unchanged. CI fans the shards out across
+    // parallel jobs; local `npm run validate` still runs one worker start to
+    // finish. Do NOT raise `workers`: in-job parallelism reintroduces the
+    // contention these timing-sensitive assertions were qualified against.
+    fullyParallel: true,
     workers: 1,
     retries: 0,
     forbidOnly: Boolean(process.env.CI),
     outputDir: "test-results",
-    reporter: [
-        ["list"],
-        ["html", {outputFolder: "playwright-report", open: "never"}],
-    ],
+    // Local/default: human-readable `list` + a self-contained HTML report.
+    // Sharded CI sets PLAYWRIGHT_BLOB_REPORT so each shard emits a machine
+    // `blob` report that the `merge-reports` job stitches into one HTML report;
+    // `list` is kept for live per-shard console output. Env unset ⇒ behavior is
+    // byte-for-byte the previous local contract.
+    reporter: process.env.PLAYWRIGHT_BLOB_REPORT
+        ? [["list"], ["blob"]]
+        : [
+              ["list"],
+              ["html", {outputFolder: "playwright-report", open: "never"}],
+          ],
     use: {
         baseURL,
         trace: "retain-on-failure",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,7 +80,14 @@ export default defineConfig({
     // contention these timing-sensitive assertions were qualified against.
     fullyParallel: true,
     workers: 1,
-    retries: 0,
+    // CI-only retries absorb SwiftShader rendering nondeterminism. The
+    // click-to-focus test (matrix.spec.ts) intermittently misses a camera-motion
+    // or node-click timing predicate; this predates sharding — it also flaked the
+    // old single-job workflow (tracking: issue #34). Local runs keep retries: 0 so
+    // flakes surface immediately. A test that only passes on retry is reported as
+    // "flaky" in the merged HTML report — that visibility is intentional, not a
+    // pass to be hidden.
+    retries: process.env.CI ? 2 : 0,
     forbidOnly: Boolean(process.env.CI),
     outputDir: "test-results",
     // Local/default: human-readable `list` + a self-contained HTML report.

--- a/tests/automation.test.mjs
+++ b/tests/automation.test.mjs
@@ -158,9 +158,15 @@ test("merges sharded reports into one HTML report and keeps diagnostics", () => 
     assert.match(step(merge, "Upload Playwright HTML report"), /name: playwright-report/);
 });
 
-test("exposes a single stable validation gate over quality and e2e", () => {
+test("exposes a hardened single validation gate over quality and e2e", () => {
     const gate = jobBlock("gate");
     assert.match(gate, /needs: \[quality, e2e\]/);
+    // Hardening: the gate must ALWAYS run and explicitly assert both upstream
+    // jobs succeeded. Without this, a failed/skipped/cancelled upstream leaves
+    // the gate skipped, which a required-status check can misread as passing.
+    assert.match(gate, /if: always\(\)/);
+    assert.match(gate, /test "\$\{\{ needs\.quality\.result \}\}" = "success"/);
+    assert.match(gate, /test "\$\{\{ needs\.e2e\.result \}\}" = "success"/);
 });
 
 test("documents every direct package command and CI artifact", () => {

--- a/tests/automation.test.mjs
+++ b/tests/automation.test.mjs
@@ -88,6 +88,9 @@ test("shards the full Chromium e2e suite at the test level", () => {
     // execution within a shard is strictly serial (no SwiftShader contention).
     assert.match(playwrightConfig, /fullyParallel: true/);
     assert.match(playwrightConfig, /workers: 1/);
+    // CI-only retries (count 2) absorb pre-existing SwiftShader flake (issue #34)
+    // so a single flaky attempt can't red the gate; local stays 0 so flakes show.
+    assert.match(playwrightConfig, /retries: process\.env\.CI \? 2 : 0/);
 
     const e2e = jobBlock("e2e");
     // Four shards, and a failing shard must not cancel its siblings.

--- a/tests/automation.test.mjs
+++ b/tests/automation.test.mjs
@@ -11,52 +11,115 @@ const readme = await readFile(
     new URL("../README.md", import.meta.url),
     "utf8",
 );
+const playwrightConfig = await readFile(
+    new URL("../playwright.config.ts", import.meta.url),
+    "utf8",
+);
 const packageJson = JSON.parse(
     await readFile(new URL("../package.json", import.meta.url), "utf8"),
 );
 
-function workflowStep(name) {
-    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+// The CI workflow is a multi-job decomposition of `npm run validate`. Extract a
+// single job's YAML block (2-space-indented key under `jobs:` up to the next
+// job key or EOF) so assertions target the right job rather than the first
+// same-named step across jobs.
+function jobBlock(name) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const match = workflow.match(
-        new RegExp(
-            `      - name: ${escapedName}\\n([\\s\\S]*?)(?=\\n      - name:|$)`,
-        ),
+        new RegExp(`\\n {2}${escaped}:\\n([\\s\\S]*?)(?=\\n {2}[A-Za-z]|$)`),
     );
-
-    assert.notEqual(match, null, `workflow step "${name}" should exist`);
+    assert.notEqual(match, null, `workflow job "${name}" should exist`);
     return match[0];
 }
 
-test("runs the exact locked validation path in GitHub Actions", () => {
+// Extract a named step's block from within a job block.
+function step(block, name) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = block.match(
+        new RegExp(
+            `\\n {6}- name: ${escaped}\\n([\\s\\S]*?)(?=\\n {6}- name:|\\n {2}[A-Za-z]|$)`,
+        ),
+    );
+    assert.notEqual(match, null, `step "${name}" should exist in job`);
+    return match[0];
+}
+
+const depInstallingJobs = ["quality", "e2e", "merge-reports"];
+
+test("triggers on the same events with least-privilege permissions", () => {
     assert.match(workflow, /pull_request:/);
     assert.match(workflow, /push:\n {4}branches:\n {6}- main/);
     assert.match(workflow, /permissions:\n {2}contents: read/);
-    assert.match(workflow, /node-version: 22\.23\.1/);
-    assert.match(workflowStep("Verify toolchain"), /10\.9\.8/);
-    assert.match(workflowStep("Install locked dependencies"), /run: npm ci/);
-    assert.match(workflowStep("Test baseline contracts"), /run: npm test/);
+});
 
-    // CI enforces the Chromium (SwiftShader) WebGL arm as the deterministic
-    // gate: it installs Chromium only, and the Firefox arm of the two-engine
-    // matrix stays a documented LOCAL qualification gate (Firefox cannot bring
-    // up a WebGL context on GPU-less runners). See
-    // codev/reviews/11-upgrade-and-behaviorally-quali.md.
-    const browserInstall = workflowStep("Install Chromium and system dependencies");
+test("verifies the exact Node/npm baseline and npm ci in every install job", () => {
+    // The reproducibility contract must hold in EVERY job that installs
+    // dependencies, not just the first one.
+    assert.match(workflow, /NODE_VERSION: 22\.23\.1/);
+    assert.match(workflow, /NPM_VERSION: 10\.9\.8/);
+
+    for (const jobName of depInstallingJobs) {
+        const block = jobBlock(jobName);
+        assert.match(
+            block,
+            /node-version: 22\.23\.1/,
+            `${jobName} pins the Node baseline`,
+        );
+        const verify = step(block, "Verify toolchain");
+        assert.match(verify, /v\$\{NODE_VERSION\}/);
+        assert.match(verify, /\$\{NPM_VERSION\}/);
+        assert.match(
+            step(block, "Install locked dependencies"),
+            /run: npm ci/,
+            `${jobName} installs via npm ci`,
+        );
+    }
+});
+
+test("enforces lint, typecheck, and unit contracts in the quality job", () => {
+    const quality = jobBlock("quality");
+    assert.match(step(quality, "Lint"), /run: npm run lint/);
+    assert.match(step(quality, "Typecheck"), /run: npm run typecheck/);
+    assert.match(step(quality, "Test baseline contracts"), /run: npm test/);
+});
+
+test("shards the full Chromium e2e suite at the test level", () => {
+    // fullyParallel makes --shard split at the TEST level; workers stays 1 so
+    // execution within a shard is strictly serial (no SwiftShader contention).
+    assert.match(playwrightConfig, /fullyParallel: true/);
+    assert.match(playwrightConfig, /workers: 1/);
+
+    const e2e = jobBlock("e2e");
+    // Four shards, and a failing shard must not cancel its siblings.
+    assert.match(e2e, /fail-fast: false/);
+    assert.match(e2e, /shard: \[1, 2, 3, 4\]/);
+
+    // Build is preserved (was inside `npm run validate`).
+    assert.match(step(e2e, "Build production application"), /run: npm run build/);
+
+    // The Chromium engine gate is pinned via E2E_ENGINES, and the full suite is
+    // split across shards — no test is dropped.
+    const run = step(e2e, "Run e2e shard");
+    assert.match(run, /E2E_ENGINES: chromium/);
+    assert.match(run, /--shard=\$\{\{ matrix\.shard \}\}\/4/);
+    assert.doesNotMatch(e2e, /continue-on-error/);
+
+    // CI installs Chromium only; the Firefox arm stays a LOCAL qualification
+    // gate. See codev/reviews/11-upgrade-and-behaviorally-quali.md.
+    const browserInstall = step(e2e, "Install Chromium and system dependencies");
     assert.match(browserInstall, /playwright install --with-deps chromium$/m);
     assert.doesNotMatch(browserInstall, /firefox/);
 
-    const validation = workflowStep("Validate");
-    assert.match(validation, /run: npm run validate/);
-    // The Chromium-only gate is pinned via E2E_ENGINES, not by dropping the
-    // Firefox project — playwright.config.ts still defines both engines so the
-    // local (unset) run is the full two-engine matrix.
-    assert.match(validation, /E2E_ENGINES: chromium/);
-    assert.doesNotMatch(validation, /continue-on-error/);
+    // Cheap add-on: cache the browser download, keyed on the Playwright version.
+    const cache = step(e2e, "Cache Playwright browsers");
+    assert.match(cache, /~\/\.cache\/ms-playwright/);
+    assert.match(cache, /steps\.playwright\.outputs\.version/);
 });
 
 test("keeps audit evidence separate without weakening validation", () => {
-    const fullAudit = workflowStep("Capture full audit evidence");
-    const productionAudit = workflowStep("Capture production audit evidence");
+    const quality = jobBlock("quality");
+    const fullAudit = step(quality, "Capture full audit evidence");
+    const productionAudit = step(quality, "Capture production audit evidence");
 
     for (const auditStep of [fullAudit, productionAudit]) {
         assert.match(auditStep, /if: always\(\)/);
@@ -66,14 +129,38 @@ test("keeps audit evidence separate without weakening validation", () => {
     assert.match(fullAudit, /npm audit --json/);
     assert.match(productionAudit, /npm audit --omit=dev --json/);
 
-    for (const artifactName of [
-        "audit-full",
-        "audit-production",
-        "playwright-report",
-        "playwright-test-results",
-    ]) {
-        assert.match(workflow, new RegExp(`name: ${artifactName}`));
+    for (const artifactName of ["audit-full", "audit-production"]) {
+        assert.match(quality, new RegExp(`name: ${artifactName}`));
     }
+});
+
+test("merges sharded reports into one HTML report and keeps diagnostics", () => {
+    const e2e = jobBlock("e2e");
+    // Each shard emits a machine-readable blob report and its own diagnostics.
+    assert.match(step(e2e, "Upload blob report"), /name: blob-report-/);
+    assert.match(
+        step(e2e, "Upload Playwright test results"),
+        /name: playwright-test-results-/,
+    );
+
+    const merge = jobBlock("merge-reports");
+    assert.match(merge, /needs: e2e/);
+    assert.match(merge, /if: always\(\)/);
+    assert.match(
+        step(merge, "Download blob reports"),
+        /pattern: blob-report-\*/,
+    );
+    assert.match(
+        step(merge, "Merge into HTML report"),
+        /merge-reports --reporter html/,
+    );
+    // The combined report keeps the stable `playwright-report` artifact name.
+    assert.match(step(merge, "Upload Playwright HTML report"), /name: playwright-report/);
+});
+
+test("exposes a single stable validation gate over quality and e2e", () => {
+    const gate = jobBlock("gate");
+    assert.match(gate, /needs: \[quality, e2e\]/);
 });
 
 test("documents every direct package command and CI artifact", () => {
@@ -97,5 +184,5 @@ test("documents every direct package command and CI artifact", () => {
     assert.match(readme, /E2E_ENGINES=chromium/);
     assert.match(readme, /Audits are evidence snapshots, not a zero-finding green gate/);
     assert.match(readme, /`audit-full` and `audit-production` artifacts/);
-    assert.match(readme, /`playwright-report` and\s+`playwright-test-results` artifacts/);
+    assert.match(readme, /`playwright-report`/);
 });

--- a/tests/toolchain.test.mjs
+++ b/tests/toolchain.test.mjs
@@ -13,6 +13,7 @@ const expectedGeneratedIgnores = [
     "next-env.d.ts",
     "playwright-report/**",
     "test-results/**",
+    "blob-report/**",
 ];
 const expectedDependencyBaseline = {
     dependencies: {


### PR DESCRIPTION
## Summary

Closes #30. The Validation workflow spent ~14m14s of its ~15-min wall clock in a
single serial Playwright e2e step. This shards that suite across parallel jobs to
bring a green run to ~5–6 min, while keeping CI **contract-equivalent** to the
single-command local gate `npm run validate`.

The whole change is a CI/config decomposition — no product code, no test logic, and
no test dropped.

## What changed

**`playwright.config.ts`**
- `fullyParallel: true` (keeping `workers: 1`). This is the load-bearing change:
  with `fullyParallel: false`, `--shard` splits at the *file* level, and 9 of 10
  tests live in `matrix.spec.ts`, so sharding barely helps. With `fullyParallel:
  true`, `--shard` splits at the *test* level, yet `workers: 1` keeps every job
  strictly serial — one test at a time, no SwiftShader CPU contention. Local
  `npm run validate` still runs one worker start-to-finish.
- Reporter is env-gated (`PLAYWRIGHT_BLOB_REPORT`): unset ⇒ the previous
  `list` + `html`; set (CI shards only) ⇒ `list` + `blob` so per-shard reports can
  be merged. Local behavior is byte-for-byte unchanged.

**`.github/workflows/validation.yml`** — one job → four:
- **`quality`** — `npm run lint`, `npm run typecheck`, `npm test`, and both audit
  captures (full + production, each validated by `scripts/validate-audit-report.mjs`
  and uploaded as `audit-full` / `audit-production`).
- **`e2e`** — matrix over `--shard=1/4 … 4/4`, `E2E_ENGINES=chromium`, production
  build per shard, and a cached Playwright browser download
  (`~/.cache/ms-playwright`, keyed on the resolved Playwright version — every shard
  otherwise re-pays the ~25s install).
- **`merge-reports`** (`if: always()`) — stitches the per-shard blob reports into
  one HTML report, preserving the stable `playwright-report` artifact.
- **`gate`** (`needs: [quality, e2e]`) — a single stable status so branch
  protection keeps one required check.

Every dependency-installing job re-verifies the exact `22.23.1` / `10.9.8` baseline
and installs via `npm ci`.

**Tests / hygiene**
- `tests/automation.test.mjs` rewritten to assert the *decomposed* contract:
  baseline + `npm ci` in every install job, lint/typecheck/unit in `quality`,
  test-level sharding with the Chromium engine gate and no `continue-on-error`,
  browser caching, audit evidence, blob→HTML merge, and the single `gate` job.
- `blob-report/**` added to eslint ignores + `.gitignore` (+ `toolchain.test.mjs`
  expected-ignores list).

**Docs** — `codev/resources/arch.md` (Validation Baseline) and `README.md` now state
that CI runs a contract-equivalent decomposition of `npm run validate`, which
remains the one-command local gate.

## Governance / acceptance criteria

- [x] Full e2e set preserved — the four shards partition all 10 tests exactly
      (`--shard --list` shows 3+3+2+2, no drop/dup). Chromium engine gate kept via
      `E2E_ENGINES=chromium`.
- [x] `npm run validate` unchanged as the single-command local gate.
- [x] arch.md Validation Baseline updated to declare the decomposition
      contract-equivalent.
- [x] Audit evidence (full + production) capture/validate/upload preserved.
- [x] Exact Node/npm baseline verification + `npm ci` preserved in **every**
      dep-installing job.
- [x] Load-bearing constraints respected: per-test waits, camera-settle polls, CI
      timeouts, and `workers: 1` are untouched.
- [x] Runner-minutes rise modestly (repeated `npm ci`/build per shard) — the
      accepted trade for wall clock.

## Test plan / verification

- **Sharding partition** — `E2E_ENGINES=chromium playwright test --shard=N/4 --list`
  confirms a clean test-level split (3+3+2+2 = 10, no overlap, no drop); the heavy
  240s click-to-focus test lands in its own shard.
- **`fullyParallel` doesn't break independence** — full Chromium e2e on an
  **isolated port**: **10/10 passed (11.4m)**, still running serially under
  `workers: 1`. (A first shared-port run showed 8/10; the 2 failures were
  `net::ERR_CONNECTION_REFUSED` from a concurrent sibling builder holding the
  hardcoded port 3000, not assertion failures — reproduced and ruled out on the
  isolated port.)
- **Clean-checkout gate** — `git worktree add --detach HEAD` + real `npm ci`:
  `lint` exit 0, `typecheck` exit 0, `npm test` 29/29. (In this builder worktree,
  `eslint .` reports 18 errors, all inside the untracked harness file
  `.claude/hooks/worktree-write-guard.cjs`, which is absent from clean checkouts —
  environment noise, not committed code.)
- **Workflow** — parses as valid YAML; job graph is `quality`, `e2e` (matrix ×4),
  `merge-reports` (needs e2e, always), `gate` (needs quality+e2e).

## Note for the reviewer

If branch protection currently requires the old `validation` check name, point it at
the new **`gate`** job (or at `quality` + `e2e`) so the required status still gates
merges. `gate` succeeds only when both `quality` and every `e2e` shard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
