### PR TITLE
[Issue #30] chore: land air-30 post-merge protocol bookkeeping

### DIFF
--- a/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
+++ b/codev/projects/30-ci-validation-workflow-takes-1/status.yaml
@@ -1,7 +1,7 @@
 id: '30'
 title: ci-validation-workflow-takes-1
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-20T20:50:14.315Z'
-updated_at: '2026-07-21T00:22:41.619Z'
+updated_at: '2026-07-21T00:31:01.644Z'
 pr_ready_for_human: false

--- a/codev/state/air-30_thread.md
+++ b/codev/state/air-30_thread.md
@@ -131,3 +131,17 @@ Applied:
   kept intentionally, NOT suppressed (per architect).
 - #34 cited in a PR comment too.
 Next: push, wait for CI green, then re-request the pr gate.
+
+## Merged — and an accuracy correction on "green"
+- pr gate human-approved by architect → porch created `chore(porch): 30 pr
+  gate-approved` (784de81) → CI re-ran on that commit.
+- **Merge-commit run 29790108219 (784de81) was GREEN VIA RETRY, not clean:**
+  click-to-focus (matrix:235) FAILED attempt 1 ("a real node click should
+  register and fix the node"), PASSED retry #1 → reported **"1 flaky"**, job green.
+  This is retries:2 working + flaky visibility preserved (per architect). Merged
+  PR #32 → merge commit a693dc79. Protocol 30 COMPLETE (porch).
+- Correction: earlier run 29782955443 (9656345) was actually clean (attempt-1
+  pass); my "retries absorbed the flake" note applied to the LATER merge-commit
+  run, not that one. Flaky pass is real, visible, and tracked in **#34**.
+- Post-merge: architect drives `afx cleanup` (not me). Their #14 builder will
+  rebase against the new CI shape.


### PR DESCRIPTION
Two post-merge bookkeeping commits from the air-30 builder that were committed after PR #32 merged and would otherwise be stranded on the builder branch:

- `chore(porch): 30 protocol complete` — final porch status flip for project 30
- `[Issue #30] docs: record flaky-via-retry merge outcome (refs #34)` — the builder thread's final addendum, keeping `codev/state/air-30_thread.md` on `main` complete per the codev convention

No workflow, config, test, or product code changes — `codev/` state files only. Low-risk per triage; merge or close at your discretion (the addendum's content is also mirrored in the #34 comment trail, so closing loses nothing essential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)