### PR TITLE
[Experiment 14] ESLint 10 migration trial → DEFER (blocker: eslint-plugin-react)

### DIFF
--- a/codev/projects/14-experiment-with-a-clean-suppor/status.yaml
+++ b/codev/projects/14-experiment-with-a-clean-suppor/status.yaml
@@ -1,0 +1,14 @@
+id: '14'
+title: experiment-with-a-clean-suppor
+protocol: experiment
+phase: hypothesis
+plan_phases: []
+current_plan_phase: null
+gates:
+  experiment-complete:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-20T22:07:34.781Z'
+updated_at: '2026-07-20T22:07:34.782Z'

--- a/codev/state/experiment-14_thread.md
+++ b/codev/state/experiment-14_thread.md
@@ -1,0 +1,75 @@
+# experiment-14 thread — Clean ESLint 10 migration experiment (issue #14)
+
+Protocol: EXPERIMENT (soft mode). Porch project `14`. Driving issue: #14
+"Experiment with a clean, supported ESLint 10 migration". Depends on merged #13
+(TS 6.0.3 + finalized ESLint 9 flat config). Track under #6.
+
+## Architect context (2026-07-20)
+- Baseline before/after on `main` post-#13: typescript 6.0.3, native React flat
+  config, scoped globals, coverage-preserving Hooks.
+- MID-FLIGHT CI CHANGE: PR #32 (another architect's builder) replaces the single
+  `validation` job with a 4-shard e2e matrix + quality/gate jobs;
+  `automation.test.mjs` will assert the new workflow structure. If my outcome is
+  "adopt" with config changes, rebase/re-verify against the new CI shape. Architect
+  will ping before #32 merges.
+- Hard rules: EXPERIMENT protocol, documented defer is a valid success; never
+  `--force`/`--legacy-peer-deps`/overrides; production deps must not change merely
+  to satisfy the experiment.
+
+## Hypothesis phase (started 2026-07-20)
+Question (from #14): can the repo adopt a current ESLint 10 release with a clean
+supported peer tree and equivalent intentional lint coverage, or must it wait for
+React-plugin support / approve a rule-set replacement?
+
+## Registry evidence gathered (no install needed) — the crux
+Current published support matrix (queried 2026-07-20):
+
+| Package | Installed | Latest | eslint peer | Admits ESLint 10? |
+|---|---|---|---|---|
+| eslint | ~9.39.5 | 10.7.0 | (self); node `^20.19.0 \|\| ^22.13.0 \|\| >=24` | Node 22.23.1 OK |
+| @eslint/js | ~9.39.5 | 10.0.1 | — | yes (10.x line exists) |
+| **eslint-plugin-react** | ~7.37.5 | **7.37.5** | `^3..^8 \|\| ^9.7` | **NO — caps at ^9.7** |
+| eslint-plugin-react (next tag) | — | 7.8.0-rc.0 (stale/ancient) | — | no prerelease adds 10 |
+| eslint-plugin-react-hooks | 7.1.1 | 7.1.1 | `...^9.0.0 \|\| ^10.0.0` | yes |
+| typescript-eslint | ~8.64.0 | 8.65.0 | `^8.57 \|\| ^9 \|\| ^10` (locked 8.64.0 too) | yes |
+| @next/eslint-plugin-next | 16.2.10 | — | (no eslint peer) | no constraint |
+| globals | ~17.7.0 | 17.7.0 | — | no constraint |
+| @eslint-react/eslint-plugin (alt) | — | 5.17.3 | `eslint: *` | yes (replacement candidate) |
+
+**Single blocker = `eslint-plugin-react`.** Everything else already admits ESLint 10.
+This confirms the issue's premise; the clean-install trial should ERESOLVE solely on
+eslint-plugin-react. Decision is trending toward DEFER (or replace-with-approval),
+pending the clean-install proof + rule-coverage delta + viability of the replace path.
+
+## Execute + Analyze phases — DONE (2026-07-21)
+Sandbox = clean detached worktree (`git worktree add --detach HEAD`) in scratchpad —
+no `.claude/hooks`, never touches committed package.json/lockfile/tests.
+
+- **Baseline (ESLint 9):** tracked-source lint exit 0, typecheck exit 0. eslint-plugin-react
+  flat.recommended = 22 rules present / **19 active**.
+- **Trial A (clean-install eslint→10, fresh resolve, NO flags):** `ERESOLVE`, sole blocker
+  `eslint-plugin-react@7.37.5` peer `…^9.7` vs `eslint@10.7.0`. Hypothesis confirmed.
+- **Trial B (ESLint 10 minus eslint-plugin-react, NO flags):** install exit 0, clean peer tree
+  (all dedupe to eslint@10.7.0), lint 0, typecheck 0, build 0, chromium e2e 10/10.
+  Coverage 107→91: −19 react rules (0 non-react lost), **+3 new core rules** from 9→10
+  recommended (no-unassigned-vars, no-useless-assignment, preserve-caught-error), 0 severity changes.
+
+## DECISION: DEFER (approval-gated REPLACE alternative documented)
+Keep ESLint 9.39.5 + full eslint-plugin-react coverage. No production dep/config change.
+- ADOPT-with-equivalent-coverage is impossible today without forbidden --force/--legacy-peer-deps.
+- REPLACE (remove plugin → −19 rules, or substitute @eslint-react/eslint-plugin) is viable+green
+  but a deliberate coverage change requiring architect approval.
+- Unblock: eslint-plugin-react ships an `^10` peer → then straight ADOPT (re-run this experiment).
+- Follow-on if adopting: update tests/toolchain.test.mjs `~9.` pin; reconcile eslint.config.mjs/
+  .gitignore + automation.test.mjs against post-#32 main; re-run full 4-shard gate.
+
+## CI / PR #32 interplay
+Architect (00:23Z): #32 (CI sharding) merging to main now — quality + 4-shard e2e matrix +
+merge-reports + hardened Validation-gate job; automation.test.mjs now asserts workflow structure +
+playwright.config contracts (fullyParallel:true, workers:1, retries CI?2:0); eslint.config.mjs +
+.gitignore gained blob-report ignores; new flakes #33 (Firefox pointer-inert), #34 (SwiftShader
+click-to-focus). Instruction: merge main into branch before further qualification.
+→ Because outcome is DEFER, I make NO production config change, so the flagged eslint.config.mjs
+  conflict does not arise. Only deliverable = experiments/14_eslint10_migration/ + this thread.
+  Will merge main once architect confirms #32 landed, re-confirm baseline lint/typecheck against
+  new main, then open the experiment PR (Refs #14 — defer, not Closes).

--- a/experiments/14_eslint10_migration/data/output/trialA-eslint10-clean-install-ERESOLVE.log
+++ b/experiments/14_eslint10_migration/data/output/trialA-eslint10-clean-install-ERESOLVE.log
@@ -1,0 +1,21 @@
+npm error code ERESOLVE
+npm error ERESOLVE unable to resolve dependency tree
+npm error
+npm error While resolving: undefined@undefined
+npm error Found: eslint@10.7.0
+npm error node_modules/eslint
+npm error   dev eslint@"10.7.0" from the root project
+npm error
+npm error Could not resolve dependency:
+npm error peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" from eslint-plugin-react@7.37.5
+npm error node_modules/eslint-plugin-react
+npm error   dev eslint-plugin-react@"~7.37.5" from the root project
+npm error
+npm error Fix the upstream dependency conflict, or retry
+npm error this command with --force or --legacy-peer-deps
+npm error to accept an incorrect (and potentially broken) dependency resolution.
+npm error
+npm error
+npm error For a full report see:
+npm error /home/user/.npm/_logs/2026-07-20T22_14_24_900Z-eresolve-report.txt
+npm error A complete log of this run can be found in: /home/user/.npm/_logs/2026-07-20T22_14_24_900Z-debug-0.log

--- a/experiments/14_eslint10_migration/data/output/trialB-eslint10-replace-install.log
+++ b/experiments/14_eslint10_migration/data/output/trialB-eslint10-replace-install.log
@@ -1,0 +1,12 @@
+
+added 273 packages, and audited 274 packages in 14s
+
+59 packages are looking for funding
+  run `npm fund` for details
+
+5 moderate severity vulnerabilities
+
+To address all issues (including breaking changes), run:
+  npm audit fix --force
+
+Run `npm audit` for details.

--- a/experiments/14_eslint10_migration/data/output/trialB-replace-build.log
+++ b/experiments/14_eslint10_migration/data/output/trialB-replace-build.log
@@ -1,0 +1,25 @@
+
+> build
+> next build
+
+▲ Next.js 16.2.10 (Turbopack)
+
+  Creating an optimized production build ...
+✓ Compiled successfully in 2.8s
+  Running TypeScript ...
+  Finished TypeScript in 1966ms ...
+  Collecting page data using 5 workers ...
+  Generating static pages using 5 workers (0/4) ...
+  Generating static pages using 5 workers (1/4) 
+  Generating static pages using 5 workers (2/4) 
+  Generating static pages using 5 workers (3/4) 
+✓ Generating static pages using 5 workers (4/4) in 309ms
+  Finalizing page optimization ...
+
+Route (app)
+┌ ○ /
+└ ○ /_not-found
+
+
+○  (Static)  prerendered as static content
+

--- a/experiments/14_eslint10_migration/data/output/trialB-replace-smoke-chromium.log
+++ b/experiments/14_eslint10_migration/data/output/trialB-replace-smoke-chromium.log
@@ -1,0 +1,25 @@
+[WebServer] 
+[WebServer] > start
+[WebServer] > next start --hostname 127.0.0.1 --port 3000
+[WebServer] 
+[WebServer] ▲ Next.js 16.2.10
+[WebServer] - Local:         http://127.0.0.1:3000
+[WebServer] - Network:       http://127.0.0.1:3000
+[WebServer] ✓ Ready in 114ms
+
+Running 10 tests using 1 worker
+
+  ✓   1 [chromium] › tests/e2e/matrix.spec.ts:52:5 › settles an initial force layout with positioned nodes (7.2s)
+  ✓   2 [chromium] › tests/e2e/matrix.spec.ts:81:5 › rotates the camera automatically until paused, then resumes (31.5s)
+  ✓   3 [chromium] › tests/e2e/matrix.spec.ts:111:5 › keeps pointer navigation inert until the enable delay elapses (44.0s)
+  ✓   4 [chromium] › tests/e2e/matrix.spec.ts:160:5 › zooms out with the wheel (46.4s)
+  ✓   5 [chromium] › tests/e2e/matrix.spec.ts:190:5 › zooms in with the wheel and rotates with a background drag (1.4m)
+  ✓   6 [chromium] › tests/e2e/matrix.spec.ts:235:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (1.1m)
+  ✓   7 [chromium] › tests/e2e/matrix.spec.ts:393:5 › toggles AxesHelper visibility through the axes control (29.5s)
+  ✓   8 [chromium] › tests/e2e/matrix.spec.ts:426:5 › keeps the canvas consistent and interactive across a resize (39.1s)
+  ✓   9 [chromium] › tests/e2e/matrix.spec.ts:487:5 › remounts a fresh working canvas on re-navigation (54.5s)
+  ✓  10 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (58.5s)
+
+  Slow test file: [chromium] › tests/e2e/matrix.spec.ts (6.7m)
+  Consider running tests from slow files in parallel. See: https://playwright.dev/docs/test-parallel
+  10 passed (8.1m)

--- a/experiments/14_eslint10_migration/notes.md
+++ b/experiments/14_eslint10_migration/notes.md
@@ -1,0 +1,240 @@
+# Experiment 14: Clean, supported ESLint 10 migration
+
+**Status**: Complete — **Disposition: DEFER** (hypothesis confirmed)
+
+**Date**: 2026-07-20
+
+Driving issue: [#14 — Experiment with a clean, supported ESLint 10 migration](https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/issues/14).
+Depends on merged #13 (TypeScript 6.0.3 + finalized ESLint 9 flat config). Tracked under #6.
+Protocol: EXPERIMENT (soft mode). A documented **defer** is a valid successful outcome.
+
+## Goal
+
+**Question (from #14):** Can this repository adopt a current ESLint 10 release with a
+*clean, supported peer tree* and *equivalent intentional lint coverage* — or must it
+wait for React-plugin support / approve a rule-set replacement?
+
+**Hypothesis (falsifiable):** ESLint 10 cannot be adopted today with a clean supported
+peer tree while keeping `eslint-plugin-react`, because that plugin's newest published
+peer range still ends at ESLint 9. Adoption therefore requires either (a) waiting for
+`eslint-plugin-react` to publish ESLint 10 support, or (b) an approved removal/replacement
+of its rule set.
+
+**Success / decision criteria (defined upfront):**
+- **ADOPT** — only if `eslint`→10.x installs with **no `--force` / `--legacy-peer-deps` /
+  overrides**, no unsupported-peer or parser warnings, and lint coverage is intentionally
+  equivalent or improved, with build/typecheck unchanged.
+- **REPLACE (with approval)** — if a clean ESLint 10 tree is only achievable by removing
+  `eslint-plugin-react` and either dropping or substituting its 19 active rules; this is a
+  deliberate coverage change requiring architect approval.
+- **DEFER** — if a clean supported tree with equivalent coverage is not achievable within
+  the timebox without a rule-set change; record the single blocker and precise unblock
+  condition.
+
+**Stop conditions (from #14, honored):** no `--force`, `--legacy-peer-deps`, unsupported
+peer combinations, or package-manager overrides to manufacture success. Production
+dependencies are **not** changed merely to satisfy the experiment.
+
+## Effort
+
+**Approximate time spent**: ~2 hours (registry investigation, isolated install trials,
+rule-coverage diff, write-up).
+
+## Approach
+
+1. **Registry-only support matrix** — query current published versions, `eslint` peer
+   ranges, and Node `engines` for the whole lint stack. No install needed; this is the
+   crux evidence.
+2. **Baseline (ESLint 9)** — `npm ci` the committed tree; confirm `lint`/`typecheck` clean
+   on tracked source; enumerate the effective `react/*` rule coverage that
+   `eslint-plugin-react` contributes (the coverage a removal would cost).
+3. **Trial A — clean-install ESLint 10 (isolation, no flags)** — in a clean detached
+   worktree, bump `eslint`→10.7.0 / `@eslint/js`→10.0.1, run `npm install` with **no**
+   peer-override flags; capture the resolver outcome.
+4. **Trial B — viable "replace" config** — remove `eslint-plugin-react`, adjust the flat
+   config, install ESLint 10 cleanly, and record the rule-coverage delta plus
+   lint/typecheck/build/smoke. Establishes whether the replace path is technically real,
+   so a defer is a *choice* with a defined unblock condition, not a dead end.
+
+**Why a clean detached worktree as sandbox:** the builder worktree carries an untracked
+`.claude/hooks/worktree-write-guard.cjs` (harness file, absent from clean checkouts) that
+`eslint .` flags — documented environment noise (`lessons-critical.md`). A
+`git worktree add --detach HEAD` checkout has no such file, so it gives both a
+noise-free baseline and an isolation boundary that never touches the committed
+`package.json` / lockfile / contract tests.
+
+## Environment & Reproduction
+
+**Toolchain (reproducibility contract):** Node `22.23.1`, npm `10.9.8`, lockfile v3, `npm ci`.
+
+**Baseline install (committed ESLint 9 tree):**
+```bash
+npm ci
+# tracked-source lint is clean; .claude/** is harness noise, excluded:
+npx eslint . --ignore-pattern ".claude/**"   # exit 0
+npm run typecheck                             # exit 0
+```
+
+**Isolated ESLint 10 trials (never mutates the committed tree):**
+```bash
+git worktree add --detach "$SANDBOX" HEAD
+cd "$SANDBOX" && npm ci
+# Trial A — clean install, NO flags:
+npm pkg set devDependencies.eslint=10.7.0 devDependencies.@eslint/js=10.0.1
+npm install            # expect ERESOLVE from eslint-plugin-react (peer caps at ^9.7)
+```
+
+## Support matrix (current published, queried 2026-07-20)
+
+Registry `npm view` results for the lint stack:
+
+| Package | Manifest (main) | Latest published | Declared `eslint` peer | Admits ESLint 10? |
+|---|---|---|---|---|
+| `eslint` | `~9.39.5` | **10.7.0** | — (Node `engines`: `^20.19.0 \|\| ^22.13.0 \|\| >=24`) | Node 22.23.1 satisfies ✓ |
+| `@eslint/js` | `~9.39.5` | **10.0.1** | — | 10.x line exists ✓ |
+| **`eslint-plugin-react`** | `~7.37.5` | **7.37.5** (unchanged) | `^3 \|\| … \|\| ^8 \|\| ^9.7` | **NO — caps at `^9.7`** ✗ |
+| `eslint-plugin-react` `next` tag | — | `7.8.0-rc.0` (ancient/stale) | — | no prerelease adds 10 ✗ |
+| `eslint-plugin-react-hooks` | `7.1.1` | `7.1.1` | `… \|\| ^9.0.0 \|\| ^10.0.0` | yes ✓ |
+| `typescript-eslint` | `~8.64.0` | `8.65.0` | `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` (locked 8.64.0 too) | yes ✓ |
+| `@next/eslint-plugin-next` | `16.2.10` | — | (no `eslint` peer declared) | unconstrained ✓ |
+| `globals` | `~17.7.0` | `17.7.0` | — | unconstrained ✓ |
+| `@eslint-react/eslint-plugin` (alt) | — | `5.17.3` | `eslint: '*'` | yes — replacement candidate ✓ |
+
+**Single blocker = `eslint-plugin-react`.** Every other stack member already admits
+ESLint 10; the currently-locked `typescript-eslint@8.64.0` does too (no bump required).
+The `eslint-plugin-react` `next` dist-tag points at an ancient `7.8.0-rc.0`, so there is
+no forthcoming ESLint 10 support even in prerelease.
+
+## Baseline results (ESLint 9, committed tree)
+
+- `lint` (tracked source, `.claude/**` excluded): **clean, exit 0**.
+- `typecheck`: **clean, exit 0**.
+- Effective `react/*` coverage from `eslint-plugin-react` flat.recommended on `app/page.tsx`:
+  **22 rules present, 19 active (error)**. The three non-active are the deliberate JSX-transform
+  offs (`react/react-in-jsx-scope`, `react/jsx-uses-react`) plus one recommended default.
+  These **19 active rules are exactly what a removal of `eslint-plugin-react` would drop.**
+
+Active `react/*` rules that removal would cost:
+`display-name, jsx-key, jsx-no-comment-textnodes, jsx-no-duplicate-props,
+jsx-no-target-blank, jsx-no-undef, jsx-uses-vars, no-children-prop,
+no-danger-with-children, no-deprecated, no-direct-mutation-state, no-find-dom-node,
+no-is-mounted, no-render-return-value, no-string-refs, no-unescaped-entities,
+no-unknown-property, prop-types, require-render-return`.
+
+## Trial A — clean-install ESLint 10 (isolation, no flags)
+
+**Method:** in the clean detached worktree, bump `eslint`→10.7.0 / `@eslint/js`→10.0.1,
+then a **fresh resolve from the manifest** (`rm -rf node_modules package-lock.json && npm install`)
+with **no** `--force` / `--legacy-peer-deps` / overrides.
+
+> A fresh resolve (not an in-place bump on top of the ESLint 9 lockfile) is the honest
+> test: an in-place `npm install` first surfaces a *stale-lockfile* artifact (old
+> `eslint@9.39.5` subtree vs new `@eslint/js@10.0.1`), which masks the real constraint.
+
+**Result: `npm error code ERESOLVE` (exit 1).** The sole binding conflict:
+
+```
+Could not resolve dependency:
+peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" from eslint-plugin-react@7.37.5
+node_modules/eslint-plugin-react
+  dev eslint-plugin-react@"~7.37.5" from the root project
+```
+
+No other package conflicts. This confirms the hypothesis: **ESLint 10 cannot be installed
+with `eslint-plugin-react` present without a forbidden override flag.**
+
+## Trial B — viable "replace" config (ESLint 10 minus eslint-plugin-react)
+
+**Method:** remove `eslint-plugin-react` from the manifest and from the flat config (its
+import, `pluginReact.configs.flat.recommended`, the `react` settings block, and the two now-orphan
+`react/*` off-rules), keeping `eslint`@10.7.0 / `@eslint/js`@10.0.1 and the rest of the stack;
+fresh install with **no** flags.
+
+**Result — a clean, working ESLint 10 tree:**
+
+| Check | Result |
+|---|---|
+| `npm install` (no flags) | **exit 0** — clean resolve |
+| `npm ls eslint` | every consumer dedupes to `eslint@10.7.0`; no `invalid`/non-optional `UNMET` (only benign `peerOptional` svelte/vue/remix/fsevents) |
+| `eslint .` (lint) | **exit 0** — flat config loads on ESLint 10; tracked source clean |
+| `tsc --noEmit` (typecheck) | **exit 0** |
+| `next build` | **exit 0** — compiled + TS in ~5s, static pages generated |
+| Chromium e2e smoke | **10/10 passed** — incl. timing-sensitive auto-rotate & pointer-inert-delay tests (runtime is unaffected by lint tooling; app code byte-identical to main) |
+
+**Effective rule-coverage delta (`--print-config app/page.tsx`, ESLint 9 baseline vs ESLint 10 replace path):**
+
+| | ESLint 9 (with react plugin) | ESLint 10 (replace path) |
+|---|---|---|
+| Active rules | **107** | **91** |
+| React rules (`react/*`) | 19 | **0 (−19)** |
+| Non-react rules lost | — | **0** |
+| New from 9→10 `@eslint/js` recommended | — | **+3**: `no-unassigned-vars`, `no-useless-assignment`, `preserve-caught-error` |
+| Severity changes on shared rules | — | **0** |
+
+Removing `eslint-plugin-react` costs **exactly its 19 React rules and nothing else**; ESLint
+10's own recommended set is **purely additive** (adds 3 core rules, removes/downgrades none).
+`react-hooks` (2), `@typescript-eslint` (19), and `@next` (21) coverage is fully retained on ESLint 10.
+
+## Decision: **DEFER** (with an approval-gated REPLACE alternative)
+
+**Keep ESLint `9.39.5` + full `eslint-plugin-react` coverage for now.** Do not change any
+production dependency or config as a result of this experiment.
+
+**Rationale**
+1. **ESLint 10 itself is ready and desirable.** Node 22.23.1 satisfies its engines; `@eslint/js@10`,
+   `typescript-eslint` (even the *currently-locked* 8.64.0), `eslint-plugin-react-hooks@7.1.1`, and
+   `@next/eslint-plugin-next` all already admit `^10`. The 9→10 recommended change is purely additive
+   (+3 rules, 0 removed, 0 downgraded).
+2. **The sole blocker is `eslint-plugin-react`.** Its newest published release is still 7.37.5 with an
+   `eslint` peer capped at `^9.7`; the `next` dist-tag is an ancient `7.8.0-rc.0`, so no ESLint 10
+   support exists even in prerelease. A fresh, flagless resolve ERESOLVEs on exactly this (Trial A).
+3. **Adopting with *equivalent* coverage — the issue's ADOPT bar — is impossible today** without
+   `--force` / `--legacy-peer-deps`, which the stop conditions forbid.
+4. **The only clean ESLint 10 tree is the REPLACE path** (Trial B): drop `eslint-plugin-react`, which
+   deletes 19 intentional React rules. That is technically viable and fully green, but it is a
+   deliberate coverage *reduction* requiring architect approval — an ADOPT it is not.
+5. Per the EXPERIMENT protocol and issue #14, **a documented defer is a valid successful outcome**.
+
+**Unblock conditions (adopt cleanly when *any* one holds):**
+- **[Preferred] `eslint-plugin-react` publishes a release whose `eslint` peer includes `^10`.** Then
+  ADOPT directly: bump `eslint` + `@eslint/js` to 10.x, keep the plugin, re-run this experiment's
+  clean-install + coverage diff, then `validate`.
+- **OR the architect approves a REPLACE:** either (a) **remove** `eslint-plugin-react` and accept the
+  −19 React rules (Hooks + typescript-eslint + Next coverage retained), or (b) **substitute**
+  `@eslint-react/eslint-plugin@^5` (peer `eslint: '*'`), restoring React linting under a different,
+  modern rule set/IDs — which then needs its own coverage qualification.
+
+**Follow-on implementation scope (whenever adoption is triggered):**
+- Update `tests/toolchain.test.mjs` — the `"aligns eslint and @eslint/js on the same ESLint 9 line"`
+  contract asserts `/^~9\./`; adoption must move that pin to the 10.x line intentionally.
+- Reconcile `eslint.config.mjs` and `.gitignore` against post-#32 `main` (blob-report ignores) and
+  re-satisfy `automation.test.mjs` (workflow + `playwright.config` contracts).
+- Re-run the full gate (lint + typecheck + build + e2e) under the new 4-shard CI shape.
+
+## Reconciliation with post-#32 `main` (CI sharding)
+
+This experiment was finalized after PR #32 (CI e2e sharding) merged to `main` (`a693dc79`).
+`main` was merged into this branch and reconciled:
+- **No production change from this experiment** (disposition is DEFER), so #32's `eslint.config.mjs`
+  edit created **no conflict**. The merge simply adopted #32's added `"blob-report/**"` global-ignore.
+- That added ignore is a *file-selection* pattern, **not a rule**, so it does **not** affect the
+  107↔91 effective rule-coverage comparison above (which is measured via `--print-config`, i.e. the
+  resolved rule set, independent of ignore globs).
+- **Post-merge gate re-confirmed against the new `main`:** `eslint . --ignore-pattern ".claude/**"`
+  exit 0; `tsc --noEmit` exit 0; `npm test` **30/30 pass** (includes #32's new
+  `automation.test.mjs` workflow + `playwright.config` contract assertions — untouched by this
+  experiment). `.claude/**` is excluded as documented untracked-harness noise.
+- Follow-on scope for a future adoption is unchanged and already lists the `tests/toolchain.test.mjs`
+  `~9.` pin and the #32 `automation.test.mjs`/`playwright.config` contracts to reconcile.
+
+## Status update
+
+**Status → Complete (Disposition: DEFER).** Hypothesis **confirmed**: a clean, supported ESLint 10
+peer tree with equivalent React coverage is not achievable today; the single blocker and its precise
+unblock condition are recorded above.
+
+## References
+
+- Issue #14; research doc Stage 4 (`codev/research/architecture-dependency-modernization.md`).
+- `lessons-critical.md` — untracked-harness lint noise; clean-checkout gate proof.
+- `tests/toolchain.test.mjs` — contract pinning `eslint`/`@eslint/js` to the `~9.` line.


### PR DESCRIPTION
## Experiment: clean, supported ESLint 10 migration (issue #14)

**Protocol:** EXPERIMENT (soft mode). **Disposition: DEFER** — a documented defer is a valid
successful outcome per #14. **No production dependency or config file is changed by this PR** — the
only additions are the experiment record and thread. Baseline is post-#13 `main`, reconciled with
post-#32 `main` (CI sharding) — see below.

Full write-up + committed evidence logs: [`experiments/14_eslint10_migration/notes.md`](experiments/14_eslint10_migration/notes.md).

### Question
Can the repo adopt a current ESLint 10 release with a *clean, supported peer tree* and *equivalent
intentional lint coverage*, or must it wait for React-plugin support / approve a rule-set replacement?

### Method (isolation)
All install trials ran in a clean detached worktree (`git worktree add --detach HEAD`) — no
`.claude/**` harness noise, and it never touches the committed `package.json` / lockfile / contract
tests. **No `--force` / `--legacy-peer-deps` / overrides were used** (a stop condition).

### Findings
- **Support matrix (queried 2026-07-20):** ESLint `10.7.0` (Node `^20.19.0 || ^22.13.0 || >=24` → our
  22.23.1 OK). `@eslint/js@10`, `typescript-eslint` (even the *locked* 8.64.0), `eslint-plugin-react-hooks@7.1.1`,
  and `@next/eslint-plugin-next` **all already admit `^10`.**
- **Sole blocker = `eslint-plugin-react`.** Its newest published release is still `7.37.5` with an
  `eslint` peer capped at `^9.7`; the `next` dist-tag is an ancient `7.8.0-rc.0`, so no ESLint 10
  support exists even in prerelease.
- **Trial A — clean install `eslint`→10 (no flags):** `ERESOLVE`, conflicting solely on
  `eslint-plugin-react@7.37.5` peer `…^9.7` vs `eslint@10.7.0`.
- **Trial B — viable "replace" config (ESLint 10 minus `eslint-plugin-react`):** installs clean; peer
  tree fully dedupes to `eslint@10.7.0`; **lint ✓ / typecheck ✓ / build ✓ / Chromium e2e 10/10 ✓**.
  Coverage delta: **107 → 91 active rules = −19 React rules, 0 non-react lost, +3 new core rules**
  from ESLint 10's recommended (`no-unassigned-vars`, `no-useless-assignment`, `preserve-caught-error`),
  0 severity changes.

### Decision — DEFER
Adopting with *equivalent* coverage is impossible today without a forbidden override flag; the only
clean ESLint 10 tree drops 19 intentional React rules (an approval-gated REPLACE, not an ADOPT).
Keep ESLint `9.39.5` + full coverage.

**Unblock (adopt cleanly when any holds):**
- **[Preferred]** `eslint-plugin-react` publishes a release whose `eslint` peer includes `^10` → ADOPT
  directly (bump `eslint`/`@eslint/js` to 10.x, keep the plugin, re-run this experiment, then `validate`).
- **OR** architect approves a REPLACE: (a) remove `eslint-plugin-react` (−19 React rules; Hooks +
  typescript-eslint + Next retained), or (b) substitute `@eslint-react/eslint-plugin@^5` (peer
  `eslint: '*'`) under a new coverage qualification.

**Follow-on for a future adoption:** update the `tests/toolchain.test.mjs` `~9.` pin; reconcile the
post-#32 `eslint.config.mjs` / `.gitignore` blob-report ignores + `automation.test.mjs` /
`playwright.config` contracts; re-run the full 4-shard gate.

### Post-#32 reconciliation
`main` (`a693dc79`, PR #32 CI sharding) merged into this branch with no conflict (this experiment
changes no production file). Post-merge gate re-confirmed: `eslint . --ignore-pattern ".claude/**"`
exit 0, `tsc --noEmit` exit 0, `npm test` **30/30** (incl. #32's new workflow/playwright assertions).

Refs #14