### PR TITLE
[Bugfix #34] Fix flaky click-to-focus e2e: hover-first click under SwiftShader

### DIFF
--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-34
 title: flaky-ci-e2e-click-to-focus-ma
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T01:59:23.907Z'
-updated_at: '2026-07-21T02:41:28.186Z'
+updated_at: '2026-07-21T02:52:33.036Z'

--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-21T02:57:51.484Z'
+    approved_at: '2026-07-21T03:05:35.259Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T01:59:23.907Z'
-updated_at: '2026-07-21T02:57:51.484Z'
-pr_ready_for_human: true
+updated_at: '2026-07-21T03:05:35.260Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-21T02:57:51.484Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T01:59:23.907Z'
-updated_at: '2026-07-21T02:52:33.036Z'
+updated_at: '2026-07-21T02:57:51.484Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-34
 title: flaky-ci-e2e-click-to-focus-ma
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T01:59:23.907Z'
-updated_at: '2026-07-21T03:05:35.260Z'
+updated_at: '2026-07-21T03:05:43.949Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-34
+title: flaky-ci-e2e-click-to-focus-ma
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-21T01:59:23.907Z'
+updated_at: '2026-07-21T01:59:23.908Z'

--- a/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
+++ b/codev/projects/bugfix-34-flaky-ci-e2e-click-to-focus-ma/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-34
 title: flaky-ci-e2e-click-to-focus-ma
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T01:59:23.907Z'
-updated_at: '2026-07-21T01:59:23.908Z'
+updated_at: '2026-07-21T02:41:28.186Z'

--- a/codev/state/bugfix-34_thread.md
+++ b/codev/state/bugfix-34_thread.md
@@ -91,4 +91,11 @@ CI-only flake at native speed — expected).
   (per lessons-critical). My files lint clean in isolation.
 - Scratch files deleted; not committed.
 
-## Status: advancing to PR (porch done → pr gate). Next: push, gh pr create, CMAP.
+## PR phase
+- PR #39 opened → main. Body: Summary / Root Cause / Fix / Test Plan, `Fixes #34`.
+- CMAP (bugfix/pr): **gemini=APPROVE(HIGH), codex=APPROVE(HIGH), claude=APPROVE(HIGH)**;
+  unanimous, zero KEY_ISSUES, no REQUEST_CHANGES. Codex flagged only a
+  review-sandbox `/tmp` read-only failure of the unrelated `audit-report` test
+  (not PR breakage; matches clean-checkout proof). Posted CMAP table as PR comment.
+- Requesting `pr` gate via `porch done`; STOP and wait for human approval.
+  Builder must NOT self-approve or merge until the gate is human-approved.

--- a/codev/state/bugfix-34_thread.md
+++ b/codev/state/bugfix-34_thread.md
@@ -1,0 +1,94 @@
+# bugfix-34 — Flaky CI e2e: click-to-focus (matrix.spec.ts:235) on SwiftShader
+
+Protocol: BUGFIX (strict). Issue #34.
+
+## Investigate phase
+
+**Symptom**: `click-to-focus fixes the node…` test (matrix.spec.ts:235) flakes ~50%
+on GitHub Actions Chromium+SwiftShader. Predates sharding (#30/#32). Different
+assertions fail across runs; the dominant one is "a real node click should
+register and fix the node" (matrix.spec.ts:341-344).
+
+**Root cause traced through the library** (`three-render-objects` +
+`3d-force-graph`, both stock — the two repo patches are `.d.ts`-only):
+
+- Hover is resolved in the render loop `tick()`
+  (`three-render-objects.mjs:262-296`): each animation frame runs
+  `controls.update()` → `renderer.render()` (EXPENSIVE under SwiftShader) → a
+  raycast **throttled to `pointerRaycasterThrottleMs` = 50** that updates
+  `state.hoverObj` from `state.pointerPos`.
+- A click's decision is deferred: the `pointerup` handler
+  (`three-render-objects.mjs:552-570`) does
+  `requestAnimationFrame(() => onClick(state.hoverObj || null, …))` — it reads
+  `hoverObj` one frame **after** pointerup ("to allow hoverObj to be set on
+  frame").
+- `page.mouse.click(x,y)` fires move→down→up in one burst. If no raycast tick
+  has run at the new `pointerPos` before the click's rAF fires, `hoverObj` is
+  stale/null → `onNodeClick` never fires → no node fixed → assertion fails.
+  Under software WebGL, `renderer.render()` dominates the frame and the
+  raycast-vs-click ordering/throttle becomes nondeterministic.
+
+**Fix direction (test/harness-side; app is not at fault — issue says so)**:
+Make the click hover-first — move to the target, wait for real animation frames
+so a raycast registers the node under the pointer, THEN issue pointerdown/up so
+the click's rAF reads an already-set `hoverObj`. Frame-based waiting auto-scales
+to render speed and does NOT trim any qualified wait, does NOT touch `workers`
+(constraints from #30).
+
+Constraints honored: no app-code change, no trimming qualified waits, no raising
+workers.
+
+## Ground truth from the failing CI run (29782250395, shard 2)
+
+Downloaded the Playwright trace of the failing attempt. Decisive facts:
+- All **4** aimed clicks were at the **identical** coord (351.87, 296.28) — i.e.
+  the camera was perfectly stable and `pickNodeScreenPoint` returned the same
+  valid projection each time. (Attempts 5–6 got a null pick → `waitForTimeout`.)
+- The failure page snapshot shows the node tooltip "Pablissimo" set ⇒ the hover
+  raycast DID resolve a node at that point. Hover works; the click does not fix.
+- ⇒ The click's deferred `onClick(hoverObj || null)` read a **null/stale** hover
+  at the rAF moment even though a node was hittable there. This is the
+  aim-to-raycast / deferred-click ordering race the issue predicted.
+
+Local slow-frame emulation (busy-wait inside a wrapped rAF; JS speed untouched,
+mirrors GPU-less SwiftShader far better than CDP CPU throttling which also slows
+the force-sim warmup) reproduces the race: a bare `page.mouse.click` occasionally
+misses; a hover-first click (move → wait real animation frames → down/up) is
+robust. Locally at full render speed the real test passes 5/5 (can't repro the
+CI-only flake at native speed — expected).
+
+## Investigate → conclusion
+- **Root cause**: harness-side click-delivery race vs the library's
+  throttled-raycast hover + one-frame-deferred click. NOT an app logic bug
+  (issue concurs).
+- **Fix**: make the aimed click hover-first — `move` → wait N real animation
+  frames (auto-scales to render speed) → `down`/`up` — so a committed hover
+  raycast has registered the node BEFORE the deferred click resolves. New helper
+  `tests/e2e/pointer.ts`; matrix.spec.ts:235 click loop uses it (keeps its
+  6-attempt retry). No app change; no trimmed waits; `workers` untouched.
+- **Regression test**: deterministic real-browser synthetic page modelling the
+  documented mechanism (throttled-raycast hover latency + rAF-deferred click) —
+  bare click misses, hover-first registers. Fast, no WebGL, CI-safe.
+- **Size**: well under 300 LOC. BUGFIX-appropriate.
+
+## Fix phase — done
+- New helper `tests/e2e/pointer.ts`: `settleHoverThenClick` (move → wait N real
+  animation frames → down/up) + `waitForAnimationFrames`. Default 5 frames.
+- `matrix.spec.ts:235` click loop now uses `settleHoverThenClick` (keeps the
+  6-attempt retry). No app change.
+- Regression test `tests/click-registration.test.mjs` (node:test, deterministic,
+  CI-safe): bare click misses / hover-first registers / too-few-frames misses.
+  Proven to FAIL when the fix is reverted (settleFrames=0 → subtest 2 not ok).
+- Committed 607ba1c. Net diff ~228 LOC excl. thread (< 300).
+
+## Validation
+- `npm test` 36/36 ✓ (was 33). typecheck ✓. build ✓.
+- Real matrix `click-to-focus` e2e: 3/3 green with the fix (no regression).
+- Local lint shows 21 errors — ALL from untracked
+  `.claude/hooks/worktree-write-guard.cjs` (builder harness, absent from clean
+  checkouts). Proven noise: clean detached worktree + real `npm ci` →
+  lint EXIT 0, typecheck EXIT 0, tests 36/36. Not suppressed in committed config
+  (per lessons-critical). My files lint clean in isolation.
+- Scratch files deleted; not committed.
+
+## Status: advancing to PR (porch done → pr gate). Next: push, gh pr create, CMAP.

--- a/tests/click-registration.test.mjs
+++ b/tests/click-registration.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {settleHoverThenClick} from "./e2e/pointer.ts";
+
+// Deterministic regression harness for issue #34: the intermittent
+// "a real node click should register and fix the node" failure under software
+// WebGL (Chromium + SwiftShader on CI).
+//
+// It reproduces the exact library mechanism that races, in plain JS, with no
+// browser or WebGL:
+//   - three-render-objects resolves the hovered node only inside the render
+//     loop, via a raycast throttled to ~50 ms. The node under the pointer
+//     therefore becomes `hoverObj` only after a few frames of "aim-to-raycast"
+//     latency (modelled by HOVER_LATENCY_FRAMES).
+//   - The click is deferred one animation frame past pointerup:
+//     `requestAnimationFrame(() => onClick(hoverObj || null, ...))`. It fixes a
+//     node only if `hoverObj` is that node at the frame it resolves.
+//
+// A fake `page` drives this model through the SAME `settleHoverThenClick`
+// helper the suite ships, and through a bare move+down+up (the pre-fix code).
+// The bare sequence resolves its deferred click before any raycast has
+// committed the hover → no fix. Moving first and waiting real frames lets the
+// hover commit → fix. If the fix is reverted (or its settle-frame count drops
+// below the modelled latency) the "registers" assertion fails.
+
+const HOVER_LATENCY_FRAMES = 3; // frames the raycast needs to commit the hover
+const TARGET = {x0: 100, y0: 100, x1: 300, y1: 300};
+const TARGET_CENTER = {x: 200, y: 200};
+
+function createFakeGraph() {
+    const model = {
+        frame: 0,
+        overSinceFrame: null, // frame the pointer entered the node, else null
+        pressed: false,
+        hoverObj: null, // "node" only after the raycast commits it
+        pendingClickFrame: null, // frame of pointerup; click resolves next frame
+        fixedCount: 0,
+    };
+
+    const overTarget = (x, y) =>
+        x >= TARGET.x0 && x <= TARGET.x1 && y >= TARGET.y0 && y <= TARGET.y1;
+
+    // One render-loop frame: commit the throttled hover raycast, then resolve
+    // any deferred click reading that hover (mirrors three-render-objects).
+    const tickFrame = () => {
+        model.frame += 1;
+        model.hoverObj =
+            model.overSinceFrame !== null &&
+            model.frame - model.overSinceFrame >= HOVER_LATENCY_FRAMES
+                ? "node"
+                : null;
+        if (model.pendingClickFrame !== null && model.frame > model.pendingClickFrame) {
+            if (model.hoverObj === "node") {
+                model.fixedCount += 1;
+            }
+            model.pendingClickFrame = null;
+        }
+    };
+
+    const setPointer = (x, y) => {
+        if (overTarget(x, y)) {
+            if (model.overSinceFrame === null) {
+                model.overSinceFrame = model.frame;
+            }
+        } else {
+            model.overSinceFrame = null;
+            model.hoverObj = null;
+        }
+    };
+
+    const page = {
+        mouse: {
+            async move(x, y) {
+                setPointer(x, y);
+            },
+            async down() {
+                model.pressed = true;
+            },
+            async up() {
+                if (!model.pressed) {
+                    return;
+                }
+                model.pressed = false;
+                model.pendingClickFrame = model.frame; // deferred to next frame
+            },
+        },
+        // Run the helper's real page-context frame loop against the model clock:
+        // its `requestAnimationFrame(cb)` advances exactly one render frame.
+        async evaluate(fn, arg) {
+            const realRaf = globalThis.requestAnimationFrame;
+            globalThis.requestAnimationFrame = (cb) => {
+                tickFrame();
+                cb(model.frame);
+                return model.frame;
+            };
+            try {
+                return await fn(arg);
+            } finally {
+                globalThis.requestAnimationFrame = realRaf;
+            }
+        },
+    };
+
+    // Advance the render loop after a click is issued (in the browser the loop
+    // never stops; the deferred click resolves on a following frame).
+    const runRenderLoop = (frames) => {
+        for (let i = 0; i < frames; i += 1) {
+            tickFrame();
+        }
+    };
+
+    return {page, model, runRenderLoop};
+}
+
+async function bareClick(page, x, y) {
+    // The pre-fix sequence: move then immediately press/release, with no frames
+    // in between for the hover raycast to commit.
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.up();
+}
+
+test("a bare click loses the hover race and fixes no node (the #34 bug)", async () => {
+    const {page, model, runRenderLoop} = createFakeGraph();
+    await bareClick(page, TARGET_CENTER.x, TARGET_CENTER.y);
+    runRenderLoop(HOVER_LATENCY_FRAMES + 3); // give the loop ample time
+    assert.equal(
+        model.fixedCount,
+        0,
+        "a bare move+down+up should resolve its deferred click before the hover " +
+            "raycast commits — reproducing the intermittent no-fix failure",
+    );
+});
+
+test("settleHoverThenClick registers the fix by letting the hover commit first", async () => {
+    const {page, model, runRenderLoop} = createFakeGraph();
+    await settleHoverThenClick(page, TARGET_CENTER.x, TARGET_CENTER.y);
+    runRenderLoop(2); // resolve the deferred click
+    assert.equal(
+        model.fixedCount,
+        1,
+        "moving first and waiting real animation frames must let the hover " +
+            "raycast commit the node before the deferred click resolves",
+    );
+});
+
+test("too few settle frames still lose the race (the frames are the fix)", async () => {
+    // Guards against the fix degrading to a token wait: the settle must clear
+    // the aim-to-raycast latency, so a count below it must still miss. This is
+    // what makes the default (> the modelled latency) load-bearing.
+    const {page, model, runRenderLoop} = createFakeGraph();
+    await settleHoverThenClick(page, TARGET_CENTER.x, TARGET_CENTER.y, 1);
+    runRenderLoop(2);
+    assert.equal(
+        model.fixedCount,
+        0,
+        "one settle frame is below the modelled hover latency and must not fix",
+    );
+});

--- a/tests/e2e/matrix.spec.ts
+++ b/tests/e2e/matrix.spec.ts
@@ -13,6 +13,7 @@ import {
     waitForStableCameraDistance,
     type GraphSnapshot,
 } from "./graph-handle";
+import {settleHoverThenClick} from "./pointer";
 
 // Camera-position deltas: rotation moved the camera ~440 units per 0.8 s in
 // prior qualifications, while a paused camera measured exactly 0. The floor
@@ -313,6 +314,12 @@ test("click-to-focus fixes the node, animates the camera, and reset restores the
     // resolution runs a render frame after pointerup, and dispatching the
     // next attempt's pointerdown would cancel a focus tween the previous
     // click already started.
+    //
+    // The click is issued hover-first (`settleHoverThenClick`): the library
+    // resolves the hovered node only in the render loop's throttled raycast and
+    // defers onClick a frame past pointerup, so under software WebGL a bare
+    // click can resolve against a not-yet-committed hover and fix nothing. See
+    // tests/e2e/pointer.ts for the mechanism (issue #34).
     let clickRegistered = false;
     let preClick: GraphSnapshot | null = null;
     for (let attempt = 0; attempt < 6 && !clickRegistered; attempt += 1) {
@@ -323,7 +330,7 @@ test("click-to-focus fixes the node, animates the camera, and reset restores the
         }
 
         preClick = await snapshotOrFail(page);
-        await page.mouse.click(point.x, point.y);
+        await settleHoverThenClick(page, point.x, point.y);
         try {
             await expect
                 .poll(

--- a/tests/e2e/pointer.ts
+++ b/tests/e2e/pointer.ts
@@ -1,0 +1,59 @@
+import type {Page} from "@playwright/test";
+
+/**
+ * Awaits `frames` real animation frames in page context.
+ *
+ * Frame-based waiting self-scales to render speed: under GPU-less software
+ * WebGL (SwiftShader/llvmpipe on CI runners) a single frame can take far longer
+ * than on local hardware, so the same frame count buys proportionally more
+ * wall-clock exactly where the rendering is slow — without hard-coding an
+ * environment-specific millisecond timeout.
+ */
+export async function waitForAnimationFrames(
+    page: Page,
+    frames: number,
+): Promise<void> {
+    await page.evaluate(async (count) => {
+        const nextFrame = () =>
+            new Promise<void>((resolve) =>
+                requestAnimationFrame(() => resolve()),
+            );
+        for (let i = 0; i < count; i += 1) {
+            await nextFrame();
+        }
+    }, frames);
+}
+
+/**
+ * Clicks a graph node hover-first to defeat a software-WebGL timing race.
+ *
+ * react-force-graph-3d (three-render-objects) resolves the hovered node only
+ * inside the render loop — a raycast throttled to ~50 ms (`pointerRaycaster
+ * ThrottleMs`) — and defers the click itself one animation frame past
+ * pointerup: `requestAnimationFrame(() => onClick(hoverObj || null, ...))`. A
+ * bare move+down+up can therefore resolve its deferred click before any raycast
+ * has committed the node under the pointer as `hoverObj`, so `onNodeClick`
+ * fires with a null hover and no node is fixed. Under GPU-less software
+ * rendering, where a single frame dominates the throttle window, this surfaces
+ * as the intermittent "a real node click should register and fix the node"
+ * failure (issue #34): the CI trace of a failing run shows repeated clicks at
+ * one stable, hittable node projection that never register a fix.
+ *
+ * Moving first and letting real animation frames elapse forces a committed
+ * hover raycast to register the node BEFORE pointerdown/up, so the deferred
+ * click reads a resolved hover. This only ADDS frame-based (self-scaling)
+ * waits — it trims none, and it does not touch worker concurrency.
+ */
+export async function settleHoverThenClick(
+    page: Page,
+    x: number,
+    y: number,
+    settleFrames = 5,
+): Promise<void> {
+    await page.mouse.move(x, y);
+    // Let committed hover raycasts run at the new pointer position before the
+    // click is dispatched — so the deferred onClick reads a resolved hover.
+    await waitForAnimationFrames(page, settleFrames);
+    await page.mouse.down();
+    await page.mouse.up();
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure of the `click-to-focus …` e2e test
(`tests/e2e/matrix.spec.ts`) on Chromium + SwiftShader, which fails ~50% with
**"a real node click should register and fix the node"**. The failure is a
harness/library **timing race**, not an app logic bug — consistent with the
issue's own diagnosis — so the fix is entirely test-side: the aimed click is now
issued **hover-first**. No application code changes; no qualified waits trimmed;
`workers` untouched (constraints from #30 respected).

Fixes #34.

## Root Cause

Traced through the stock library (`three-render-objects` / `3d-force-graph`; the
repo's two patches are `.d.ts`-only):

- **Hover is resolved only in the render loop.** Each animation-loop `tick`
  (`three-render-objects` `tick()`) runs `controls.update()` → `renderer.render()`
  → a raycast **throttled to `pointerRaycasterThrottleMs` = 50 ms** that updates
  `state.hoverObj` from the pointer position.
- **The click is deferred one frame past pointerup.** The `pointerup` handler
  does `requestAnimationFrame(() => onClick(state.hoverObj || null, …))`
  ("trigger click events asynchronously, to allow hoverObj to be set on frame").

A bare `page.mouse.click` fires move→down→up in one burst. Under GPU-less
software rendering a single `renderer.render()` dominates the frame, so the
deferred click can resolve **before any raycast has committed the aimed node as
`hoverObj`** — `onNodeClick` then fires with a null hover and fixes nothing.

**Ground truth from the failing CI run** (29782250395, shard 2; trace
downloaded): all four aimed clicks were at the *identical, stable* coordinate
`(351.87, 296.28)` — a valid node projection (the failure snapshot shows the
node tooltip "Pablissimo", proving the hover raycast *did* resolve a node there)
— yet **zero** fixes registered. Hover works; the deferred click read a
null/stale hover.

Reproduced locally by emulating slow software-render frames (a fixed busy-wait
inside a wrapped `requestAnimationFrame`, leaving JS speed untouched — a far
truer model of GPU-less SwiftShader than CDP CPU throttling, which also slows
the force-sim warmup): a bare click intermittently misses; a hover-first click
is robust. At native render speed the test passes locally (the flake is
CI-render-latency-specific).

## Fix

New helper `tests/e2e/pointer.ts` → `settleHoverThenClick(page, x, y)`:

```
move(x, y) → waitForAnimationFrames(n) → down() → up()
```

Letting **real animation frames** elapse after the move forces a committed hover
raycast to register the node *before* pointerdown/up, so the deferred click
reads a resolved hover. Frame-based waiting **self-scales to render speed** —
the same frame count buys proportionally more wall-clock exactly where the
rasterizer is slow, with no environment-specific millisecond timeout. The
`matrix.spec.ts` click loop now calls it (keeping its existing 6-attempt retry).

This only **adds** waits; it trims none, and does not touch worker concurrency.

## Test Plan

- **Regression test** `tests/click-registration.test.mjs` (`node --test`,
  deterministic, no browser/WebGL — in the style of the issue-#27 regression in
  `orbit-camera.test.mjs`). It models the exact mechanism (throttled-raycast
  hover latency + rAF-deferred click) and drives the **real** helper:
  - a bare click misses (reproduces the #34 bug),
  - `settleHoverThenClick` registers the fix,
  - too few settle frames still miss (the frames are the operative fix).
  Verified it **fails when the fix is reverted** (`settleFrames = 0` → the
  "registers" assertion goes `not ok`) and passes when restored.
- `npm test` → **36/36 pass** (33 prior + 3 new). `typecheck` clean, `build`
  clean.
- Real `matrix.spec.ts` `click-to-focus` e2e under SwiftShader: **3/3 green**
  with the fix (no regression).
- **Clean-checkout gate proof:** the only local lint failures come from an
  untracked builder-harness file (`.claude/hooks/*`, absent from clean
  checkouts). On a fresh `git worktree --detach` + real `npm ci`: `lint`,
  `typecheck`, and unit tests are all green — the failures are environment
  noise, not suppressed in committed config (per repo lessons).

## Scope

BUGFIX-appropriate: substantive change is ~228 LOC (helper + regression test +
a one-line call swap), no app-code change, contained to test infrastructure.
