### PR TITLE
[Bugfix #33] De-flake Firefox 'pointer nav inert' test: decouple from camera-settle

### DIFF
--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-33
+title: firefox-local-gate-flake-point
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-21T03:14:15.336Z'
+updated_at: '2026-07-21T03:14:15.337Z'

--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-33
 title: firefox-local-gate-flake-point
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T03:14:15.336Z'
-updated_at: '2026-07-21T04:06:21.046Z'
+updated_at: '2026-07-21T04:06:29.210Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-21T03:58:03.757Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T03:14:15.336Z'
-updated_at: '2026-07-21T03:39:28.740Z'
+updated_at: '2026-07-21T03:58:03.757Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-33
 title: firefox-local-gate-flake-point
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T03:14:15.336Z'
-updated_at: '2026-07-21T03:14:15.337Z'
+updated_at: '2026-07-21T03:28:12.304Z'

--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-33
 title: firefox-local-gate-flake-point
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T03:14:15.336Z'
-updated_at: '2026-07-21T03:28:12.304Z'
+updated_at: '2026-07-21T03:39:28.740Z'

--- a/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
+++ b/codev/projects/bugfix-33-firefox-local-gate-flake-point/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-21T03:58:03.757Z'
+    approved_at: '2026-07-21T04:06:21.046Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T03:14:15.336Z'
-updated_at: '2026-07-21T03:58:03.757Z'
-pr_ready_for_human: true
+updated_at: '2026-07-21T04:06:21.046Z'
+pr_ready_for_human: false

--- a/codev/state/bugfix-33_thread.md
+++ b/codev/state/bugfix-33_thread.md
@@ -149,3 +149,11 @@ untouched:
   strict improvement over both the old 3000 floor and the *flaky* original assertion, catches
   grossly-premature enablement, and the actual #33 defect (the camera-settle race) is fully
   eliminated. Flagged for the architect's judgement at the `pr` gate.
+
+### CMAP resolution
+
+- **codex re-review** (commit `089d4d2`): **REQUEST_CHANGES -> COMMENT (HIGH)** — "the code change
+  is focused, the race explanation matches the actual helper/app code, and the test remains
+  deterministic." Only remaining ask: sync the PR body to the 3500 ms floor -> done via `gh pr edit`.
+- **Final CMAP: gemini APPROVE, claude APPROVE, codex COMMENT** — all non-blocking.
+- Commit `089d4d2` pushed; PR #40 body updated. -> requesting the `pr` gate; awaiting human approval.

--- a/codev/state/bugfix-33_thread.md
+++ b/codev/state/bugfix-33_thread.md
@@ -110,3 +110,42 @@ untouched:
   together cover premature enablement).
 - App reverted to `enableDelay=4000` and rebuilt; `git diff` touches only
   `tests/e2e/matrix.spec.ts`. → fix complete; committing, then transitioning to pr.
+
+## PR
+
+- Commit `6484fda` on `builder/bugfix-33`.
+- **PR #40** opened against `main`: https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/pull/40
+  (Summary / Root Cause / Fix / Test Plan, `Fixes #33`).
+- 3-way CMAP review (gemini/codex/claude, `--protocol bugfix --type pr --project-id bugfix-33`):
+  - **gemini: APPROVE (HIGH)** — no key issues; "correctly decouples the inertness assertion
+    from the camera-settle waiter."
+  - **claude: APPROVE (HIGH)** — no key issues; "race-free by construction… minimal scope,
+    thorough evidence, no app code touched." Non-blocking note: `ENABLE_DELAY_MS` duplicates the
+    app default (deemed a reasonable trade-off vs importing app internals into the test).
+  - **codex: REQUEST_CHANGES (HIGH)** — the floor is measured from `navigationStart` (before the
+    mount that schedules the timer), so the ~0.7 s mount offset is folded into the measurement and
+    a *moderately* early enable (e.g. delay 4000→3100) can still read >3000 ms from nav and pass.
+    Wanted the check anchored to the mount/timer-scheduling instant, or tightened toward the real
+    4000 ms boundary.
+
+### Response to codex REQUEST_CHANGES (partial-address + rebuttal)
+
+- **Addressed**: raised `INERT_FLOOR_MS` from `ENABLE_DELAY_MS - 1000` (3000) to
+  `ENABLE_DELAY_MS - 500` (**3500**) — as tight to the 4000 ms boundary as the race-free
+  guarantee allows (enablement is structurally observed ≥ 4000 ms from navigation, so any floor
+  < 4000 never races). Re-validated **6/6** at real `enableDelay=4000` (3× Chromium + 3× Firefox);
+  still catches premature enablement (`enableDelay=2000` → 3/3 fail; `enableDelay=2500` Firefox →
+  3/3 fail).
+- **Rebuttal (residual gap is inherent to harness-only observation)**: the mount/timer-scheduling
+  instant (~0.7 s Firefox, ~1.0 s Chromium after navigation) is **not observable** through the
+  probe — the canvas, and thus every `readGraphSnapshot`, first appears ~2.7 s in, *after*
+  scheduling, and any canvas-relative anchor races the timer. So `navigationStart` is the only
+  race-free anchor, and the engine-dependent mount offset is folded into the floor's detection
+  threshold (empirically confirmed: `enableDelay=2500` **passes** on Chromium because its ~1.0 s
+  offset lifts enable-from-nav to ~3.5 s). Closing the 2500–4000 ms detection gap would require
+  adding a test-only timestamp hook to production `FocusGraph.tsx` — which violates this repo's
+  explicit "the app is never modified; harness-side observation only" discipline
+  (`graph-handle.ts` header) and the fix's harness-vs-app ownership call. The raised floor is a
+  strict improvement over both the old 3000 floor and the *flaky* original assertion, catches
+  grossly-premature enablement, and the actual #33 defect (the camera-settle race) is fully
+  eliminated. Flagged for the architect's judgement at the `pr` gate.

--- a/codev/state/bugfix-33_thread.md
+++ b/codev/state/bugfix-33_thread.md
@@ -1,0 +1,112 @@
+# bugfix-33 — firefox-local-gate-flake-point
+
+Issue #33: Firefox local-gate flake — `matrix.spec.ts:112` "keeps pointer navigation
+inert until the enable delay elapses" intermittently fails on the Firefox **local**
+qualification arm (Chromium CI gate is deterministic 10/10). Surfaced during #13's
+merge-integration re-qualification, plausibly nudged by bugfix-27's drift-free orbit.
+
+## Investigate
+
+Failure mode (from #13 review `## Flaky Tests`): `waitForStableCameraDistance` occasionally
+settles *after* the 4000 ms pointer-enable timer, so `controlsEnabled` is already `true`
+when the "still disabled after camera placement" assertion (matrix.spec.ts:131-135) runs.
+
+Reading of the code so far:
+- App (`FocusGraph.tsx`): `enableDelay=4000` default; `scheduleInteraction(() => setClickEnabled(true), 4000)`
+  in the mount `useEffect`. Deterministic 4 s from mount → controls enable. No app bug in the timing.
+- Orbit (`orbitCamera.ts`, bugfix-27): `orbitCameraStep` = `position.applyAxisAngle(up, angle)` +
+  `lookAt(target)`. `applyAxisAngle` rotates position about the world origin → preserves
+  distance-from-origin EXACTLY. So auto-rotation does NOT change `cameraDistance`; the
+  drift-free change is orientation-only and cannot itself keep camera-distance unsettled.
+- Harness (`graph-handle.ts`): `waitForStableCameraDistance` polls every 250 ms, needs two
+  consecutive `cameraDistance` reads within 0.05, timeout 15 s. It is UNRELATED to the 4 s
+  enable timer — the coupling of assertion-2 to this waiter is the spurious race.
+
+Working hypothesis: this is a **harness/test defect**, not an app defect. The app keeps
+controls disabled for exactly 4 s (deterministic); the E2E's second "still disabled"
+assertion gates on an unrelated camera-settle event whose completion can fall on either
+side of the 4 s boundary. Need to instrument on Firefox to confirm (camera-settle wall
+time vs enable-timer) before choosing the fix.
+
+### Characterization (Firefox software-WebGL, delay=4000, 10 iterations)
+
+Instrumented a throwaway spec measuring wall-clock timelines from `page.goto`:
+
+| metric | range (ms from goto) |
+|---|---|
+| first handle reachable (`waitForGraphHandle`) | 2475 – 3029 |
+| camera-settle complete (`waitForStableCameraDistance`) | 3211 – 3859 |
+| controls enable (real transition) | 4597 – 8325 |
+
+- `controlsEnabled` was `false` at first-handle **and** after camera-settle in all 10 runs
+  (no flake caught in this small sample — it's a tail event).
+- **Margin between camera-settle-complete and enablement was as small as ~880 ms** (iter 0:
+  settle 3859 vs enable 4739). Camera settle (~3.2–3.9 s) and enablement (~4.6 s) are two
+  independent timelines separated by < 1 s — a scheduling spike / GC pause on the settle
+  side, or an early-ish enable, flips the order.
+- `settleMs` itself was tight (710–831 ms): the camera distance settles fast and stays
+  settled, confirming auto-rotation does NOT keep `cameraDistance` moving.
+
+### bugfix-27 attribution — NOT implicated
+
+`orbitCameraStep` = `position.applyAxisAngle(up, angle)` (rotates the position vector about
+the **world origin** → preserves |position| = distance-from-origin exactly) + `lookAt(target)`
+(orientation only). So the drift-free orbit change is **orientation-only** and cannot affect
+`cameraDistance` settle timing. The #13 reviewer's "plausibly nudged by bugfix-27" was
+n=3 speculation; the race is a **pre-existing harness-design coupling** present regardless of
+the orbit math (the same ~800 ms two-timeline proximity exists on the pre-bugfix-27 base).
+
+### Root cause (CONFIRMED, deterministic repro)
+
+`matrix.spec.ts:112`'s second assertion (lines 131–135, "navigation controls should still be
+disabled after camera placement") gates on `waitForStableCameraDistance(page)` — a camera
+waiter with **no ordering relationship** to the 4000 ms enable timer. When settle lands after
+enablement, the snapshot reads `controlsEnabled === true` → spurious failure.
+
+Deterministic reproduction: temporarily set the app default `enableDelay=2700` (lands
+enablement between handle-reachable ~2.7 s and settle-complete ~3.5 s), rebuild, run the
+**unmodified** target test on Firefox → **3/3 FAIL** at `matrix.spec.ts:135` with the exact
+message *"navigation controls should still be disabled after camera placement" — Received: true*.
+(App reverted to `enableDelay=4000` immediately after; working tree clean.) This is the exact
+failure mode #13's review documented.
+
+### Fix ownership & scope → HARNESS, BUGFIX-appropriate
+
+The app is correct (deterministic 4 s inertness, no defect). Fix = decouple the test's
+"inert until the delay" assertion from the camera-settle waiter and replace it with a
+**race-free enable-latency floor** measured from navigation: a `setTimeout(4000)` scheduled
+no earlier than navigation physically cannot fire before 4000 ms of wall-clock, so any floor
+< 4000 ms never races — yet it still trips on a real premature-enablement regression.
+Behavior-preserving (same semantic: controls start disabled, stay inert until the delay,
+then real input works), evidenced, single test-function edit (well < 300 LOC), matrix reused
+not re-authored. → investigate complete.
+
+## Fix
+
+Harness-only change to `tests/e2e/matrix.spec.ts` (net 45 LOC: 34 ins / 11 del), the app is
+untouched:
+- Added module constants `ENABLE_DELAY_MS = 4000`, `INERT_FLOOR_MS = ENABLE_DELAY_MS - 1000`.
+- In the "keeps pointer navigation inert…" test: capture `navigationStart = Date.now()` before
+  `openGraphPage`; keep the early "controls start disabled" assertion; **removed** the racy
+  `waitForStableCameraDistance` + "still disabled after camera placement" snapshot; after
+  `waitForPointerEnablement`, assert `enableLatencyMs = Date.now() - navigationStart >=
+  INERT_FLOOR_MS`. A `setTimeout(4000)` scheduled no earlier than navigation cannot fire
+  before 4000 ms of wall-clock, so a 3000 ms floor never races the boundary yet still fails
+  on premature enablement (the invariant means controls stayed inert across `[0, 3000)`).
+
+### Validation evidence
+
+- `npm run typecheck`: clean. `npx eslint tests/e2e/matrix.spec.ts`: exit 0 (only lint errors
+  repo-wide are the untracked `.claude/hooks/worktree-write-guard.cjs` harness file — env noise
+  per lessons-critical, absent from clean checkouts).
+- porch `check`: build ✓ (9.8s), unit tests ✓ (24 tests, 1.0s).
+- **Fix works, non-flaky** — fixed test at real `enableDelay=4000`, `--repeat-each=5` both
+  engines: **10/10 PASS** (5 Chromium + 5 Firefox).
+- **Old assertion was genuinely racy** — with app `enableDelay=2700` (enablement lands between
+  handle-reachable and camera-settle), the **unmodified** old test failed **3/3** at line 135
+  ("should still be disabled after camera placement", Received: true).
+- **New assertion is load-bearing** — with app `enableDelay=2000` (premature), the fixed test
+  correctly failed **3/3** (caught via the start-disabled assertion; floor + early assertion
+  together cover premature enablement).
+- App reverted to `enableDelay=4000` and rebuilt; `git diff` touches only
+  `tests/e2e/matrix.spec.ts`. → fix complete; committing, then transitioning to pr.

--- a/tests/e2e/matrix.spec.ts
+++ b/tests/e2e/matrix.spec.ts
@@ -29,6 +29,18 @@ const ZOOM_EPSILON = 0.5;
 // Give CI generous headroom without changing the local qualification timing.
 const SETTLE_TIMEOUT_MS = process.env.CI ? 20_000 : 5_000;
 
+// The app enables pointer navigation ENABLE_DELAY_MS after component mount
+// (FocusGraph's `enableDelay` default). Inertness is proven against a floor
+// safely below that: a setTimeout(ENABLE_DELAY_MS) scheduled no earlier than
+// navigation cannot fire before ENABLE_DELAY_MS of wall-clock elapse, so a
+// sub-delay floor never races the boundary — unlike gating the check on a
+// camera-settle waiter, which has no ordering relationship to the timer and on
+// the Firefox software-WebGL local gate finishes only ~0.8 s before enablement
+// (issue #33). The 1 s margin keeps the floor clear of the boundary while still
+// tripping on premature enablement.
+const ENABLE_DELAY_MS = 4000;
+const INERT_FLOOR_MS = ENABLE_DELAY_MS - 1000;
+
 async function snapshotOrFail(page: Parameters<typeof readGraphSnapshot>[0]): Promise<GraphSnapshot> {
     const snapshot = await readGraphSnapshot(page);
     expect(snapshot, "graph handle should stay reachable").not.toBeNull();
@@ -110,10 +122,15 @@ test("rotates the camera automatically until paused, then resumes", async ({page
 });
 
 test("keeps pointer navigation inert until the enable delay elapses", async ({page}) => {
+    // Reference for the enable-latency floor below. Captured before navigation
+    // so it precedes the mount that schedules the enable timer — the timer can
+    // then only fire at least ENABLE_DELAY_MS after this instant.
+    const navigationStart = Date.now();
     const errors = await openGraphPage(page);
 
     // Reach the imperative handle as early as possible — the enable timer
-    // starts at component mount and runs 4000 ms.
+    // starts at component mount and runs 4000 ms. Observing controls disabled
+    // here proves they do not start enabled.
     const early = await waitForGraphHandle(page);
     expect(
         early.controlsEnabled,
@@ -124,17 +141,23 @@ test("keeps pointer navigation inert until the enable delay elapses", async ({pa
     // this environment: SwiftShader plus force-engine warmup saturates the
     // main thread, and a measured wheel dispatch blocked ~6 s — past the
     // 4 s enable delay (recorded qualification evidence). The inert-before
-    // half is therefore verified numerically (controls start disabled and
-    // stay disabled until the delay elapses), and real input is exercised
-    // immediately after enablement.
-    await waitForStableCameraDistance(page);
-    const beforeEnablement = await snapshotOrFail(page);
-    expect(
-        beforeEnablement.controlsEnabled,
-        "navigation controls should still be disabled after camera placement",
-    ).toBe(false);
-
+    // half is therefore verified by timing: controls start disabled (asserted
+    // above) and do not enable until the delay elapses, and real input is
+    // exercised immediately after enablement.
+    //
+    // The enable latency is measured from `navigationStart` rather than gated
+    // on a camera-settle waiter: camera placement has no ordering relationship
+    // to the enable timer, so gating on it raced the boundary and spuriously
+    // observed controls already enabled (issue #33). A floor below the delay is
+    // race-free (the timer cannot fire that early) yet still fails on premature
+    // enablement — the invariant `enableLatencyMs >= INERT_FLOOR_MS` means the
+    // controls stayed inert across the whole `[0, INERT_FLOOR_MS)` window.
     await waitForPointerEnablement(page);
+    const enableLatencyMs = Date.now() - navigationStart;
+    expect(
+        enableLatencyMs,
+        "navigation controls must stay inert until the enable delay elapses",
+    ).toBeGreaterThanOrEqual(INERT_FLOOR_MS);
 
     // The same real input must work once enabled.
     const beforeZoom = await waitForStableCameraDistance(page);

--- a/tests/e2e/matrix.spec.ts
+++ b/tests/e2e/matrix.spec.ts
@@ -30,16 +30,26 @@ const ZOOM_EPSILON = 0.5;
 const SETTLE_TIMEOUT_MS = process.env.CI ? 20_000 : 5_000;
 
 // The app enables pointer navigation ENABLE_DELAY_MS after component mount
-// (FocusGraph's `enableDelay` default). Inertness is proven against a floor
-// safely below that: a setTimeout(ENABLE_DELAY_MS) scheduled no earlier than
-// navigation cannot fire before ENABLE_DELAY_MS of wall-clock elapse, so a
-// sub-delay floor never races the boundary — unlike gating the check on a
+// (FocusGraph's `enableDelay` default). Inertness is proven against a floor just
+// below that boundary: a setTimeout(ENABLE_DELAY_MS) scheduled no earlier than
+// `navigationStart` cannot fire before ENABLE_DELAY_MS of wall-clock elapse, so
+// enablement is always observed >= ENABLE_DELAY_MS after navigation and any
+// floor < ENABLE_DELAY_MS is race-free — unlike gating the check on a
 // camera-settle waiter, which has no ordering relationship to the timer and on
 // the Firefox software-WebGL local gate finishes only ~0.8 s before enablement
-// (issue #33). The 1 s margin keeps the floor clear of the boundary while still
-// tripping on premature enablement.
+// (issue #33).
+//
+// `navigationStart` is the tightest race-free anchor available to the harness:
+// the timer is scheduled in the mount effect (~0.7 s after navigation here), and
+// that instant is not observable through the canvas-gated probe (the canvas —
+// and thus every snapshot — first appears ~2.7 s in, AFTER scheduling, and any
+// canvas-relative anchor races the timer). The mount offset is therefore folded
+// into the measurement, so the FLOOR margin is kept small (500 ms) to still trip
+// on a delay materially shorter than 4000 ms; a regression within ~0.7 s of the
+// boundary is beyond what a from-navigation floor can resolve without adding
+// test-only instrumentation to app code.
 const ENABLE_DELAY_MS = 4000;
-const INERT_FLOOR_MS = ENABLE_DELAY_MS - 1000;
+const INERT_FLOOR_MS = ENABLE_DELAY_MS - 500;
 
 async function snapshotOrFail(page: Parameters<typeof readGraphSnapshot>[0]): Promise<GraphSnapshot> {
     const snapshot = await readGraphSnapshot(page);


### PR DESCRIPTION
## Summary

Removes the intermittent Firefox-only failure of `tests/e2e/matrix.spec.ts` →
*"keeps pointer navigation inert until the enable delay elapses"* on the **local**
two-engine qualification gate. The fix is **harness-only** — application code is
untouched; the matrix is reused, not re-authored.

The Chromium (SwiftShader) required CI gate was already deterministic (10/10) and is
unaffected.

## Root Cause

The test's second assertion — *"navigation controls should still be disabled after
camera placement"* — gated on `waitForStableCameraDistance(page)`, a camera-settle
waiter that has **no ordering relationship** to the app's 4000 ms pointer-enable timer.

The app enables pointer navigation deterministically at `mount + 4000 ms`
(`FocusGraph`'s `enableDelay` default) — there is **no app defect**. But on the Firefox
software-WebGL local gate the two independent timelines run close together:

| event (measured, 10 iterations, from `page.goto`) | range |
|---|---|
| camera-settle complete (`waitForStableCameraDistance`) | 3.2 – 3.9 s |
| controls enable (real transition) | 4.6 s+ |

The margin was as small as **~0.8 s**. When a scheduling spike / GC pause lands camera
settle *after* enablement, the snapshot reads `controlsEnabled === true` and the
assertion fails spuriously — even though the app behaved correctly.

**Deterministic reproduction:** temporarily lowering the app's `enableDelay` to 2700 ms
(so enablement lands between handle-reachability and camera-settle) makes the
**unmodified** test fail **3/3** at the *"still disabled after camera placement"*
assertion — the exact failure mode #13's review documented.

**bugfix-27 attribution:** *not implicated.* `orbitCameraStep` rotates the camera
position about the world origin (`applyAxisAngle` preserves distance-from-origin) and
re-aims orientation (`lookAt`) — an orientation-only change that cannot affect
`cameraDistance` settle timing. The race is a pre-existing harness-design coupling,
present regardless of the drift-free orbit.

## Fix

`tests/e2e/matrix.spec.ts`, one test function + two module constants (net 45 LOC):

- Capture `navigationStart = Date.now()` before navigation.
- Keep the early *"controls start disabled"* assertion.
- **Remove** the racy `waitForStableCameraDistance` + *"still disabled after camera
  placement"* snapshot.
- After `waitForPointerEnablement`, assert
  `enableLatencyMs = Date.now() - navigationStart >= INERT_FLOOR_MS`, where
  `INERT_FLOOR_MS = ENABLE_DELAY_MS - 500` (**3500 ms**).

A `setTimeout(4000)` scheduled no earlier than navigation physically cannot fire before
4000 ms of wall-clock elapse, so enablement is always observed ≥ 4000 ms after navigation
and **any floor < 4000 ms never races** the boundary — yet the invariant still fails on
premature enablement. The floor is set just under the boundary (500 ms margin) to catch a
materially-early enable; the mount/timer-scheduling instant (~0.7–1.0 s after navigation)
is not observable through the canvas-gated probe, so `navigationStart` is the only race-free
anchor and that mount offset is folded into the floor's detection threshold (an inherent
limit of harness-only observation — closing it would require a test-only hook in production
code, against this repo's harness-side-observation-only discipline). Behavior-preserving:
controls start disabled, stay inert until the delay elapses, then real input works.

## Test Plan

- `npm run typecheck` — clean.
- `npx eslint tests/e2e/matrix.spec.ts` — exit 0. (The only repo-wide lint errors come
  from the untracked `.claude/hooks/worktree-write-guard.cjs` builder-harness file, absent
  from clean checkouts — environment noise per `lessons-critical.md`.)
- porch `check` — build ✓, unit tests ✓ (24 tests).
- **Fix works, non-flaky:** fixed test at real `enableDelay=4000` on **both engines** →
  **16/16 PASS** (5×+3× Chromium + 5×+3× Firefox across the 3000 ms and final 3500 ms floors).
- **Old assertion was genuinely racy:** app `enableDelay=2700` → unmodified test fails
  **3/3** at the *"still disabled after camera placement"* assertion.
- **New floor is load-bearing:** app `enableDelay=2000` (premature) → fixed test correctly
  fails **3/3**; `enableDelay=2500` Firefox → **3/3** fail.

### Review

3-way CMAP (`--protocol bugfix --type pr`): **gemini APPROVE**, **claude APPROVE**, **codex**
initially **REQUEST_CHANGES** (floor too loose relative to the 4000 ms boundary). Addressed by
raising the floor `3000 → 3500` (`ENABLE_DELAY_MS - 500`), the tightest race-free value; codex
re-review → **COMMENT** ("code change is focused, the race explanation matches the actual
helper/app code, and the test remains deterministic"), with the only ask being this PR-body
sync — done here.

Fixes #33
