### PR TITLE
[Bugfix #22] Verify fixed-node right-click release (native-GPU) + regression coverage

### DIFF
--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: verify-and-fix-fixed-node-righ
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T04:14:33.857Z'
-updated_at: '2026-07-21T17:17:14.376Z'
+updated_at: '2026-07-21T17:17:32.073Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: verify-and-fix-fixed-node-righ
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T04:14:33.857Z'
-updated_at: '2026-07-21T04:21:23.480Z'
+updated_at: '2026-07-21T04:59:01.463Z'

--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-22
+title: verify-and-fix-fixed-node-righ
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-21T04:14:33.857Z'
+updated_at: '2026-07-21T04:14:33.858Z'

--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-21T05:07:00.316Z'
+    approved_at: '2026-07-21T17:17:14.376Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T04:14:33.857Z'
-updated_at: '2026-07-21T05:07:00.317Z'
-pr_ready_for_human: true
+updated_at: '2026-07-21T17:17:14.376Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-21T05:07:00.316Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T04:14:33.857Z'
-updated_at: '2026-07-21T04:59:01.463Z'
+updated_at: '2026-07-21T05:07:00.317Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
+++ b/codev/projects/bugfix-22-verify-and-fix-fixed-node-righ/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: verify-and-fix-fixed-node-righ
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-21T04:14:33.857Z'
-updated_at: '2026-07-21T04:14:33.858Z'
+updated_at: '2026-07-21T04:21:23.480Z'

--- a/codev/state/bugfix-22_thread.md
+++ b/codev/state/bugfix-22_thread.md
@@ -194,3 +194,36 @@ PR #43 (base main). porch check green (build + unit). CMAP (bugfix pr):
   and passes — codex's sandbox likely blocks subprocess/tmpdir. No committed-config suppression
   (per hot lesson). Rebuttal recorded as PR comment #issuecomment-5030356962.
 Requesting the `pr` gate (porch done); STOP and wait for human approval before merge.
+
+## CI failure on head ae74af7 — root-caused from shard-4 traces (gate on hold)
+
+Architect put the `pr` gate approval on hold: the new `tests/e2e/right-click-release.spec.ts`
+failed 3/3 on E2E shard 4/4 of run 29803086403 (all 6 in-test aim attempts missed each run).
+Downloaded playwright-test-results-4 (error-context.md + trace.zip x3) and root-caused with #34 rigor.
+
+**Definitive root cause = INVALID AIM POINT from a zoom over-shoot (architect hypothesis b):**
+- `zoomIntoClickRange` wheels `-2400` repeatedly. The 2-core runner's SwiftShader crawls
+  (**5 animation frames took 18.3s ≈ 3.6s/frame** in the trace), so the Trackball accumulates a
+  large pending zoom offset while `cameraDistance` reads a stable-looking **1.68** across several
+  250ms polls (no new frame rendered between reads) — this fools `waitForStableCameraDistance`.
+- `fixBestNode` pins a node at that moment → **valid on-screen point (407,256)**, fixedNodeCount 0→1.
+- One more frame then applies the whole accumulated offset, slamming the camera to the Trackball
+  **min distance 0.1** (graph center). The pinned node now projects to **(3414,2338)** — far outside
+  the **800×600** viewport. All 6 retries re-aim at that same off-screen point (camera frozen at the
+  floor) → `mouse.move` lands off-canvas → hover never commits → release never fires. retry1 identical
+  (off-screen (3678,2500)). Settle-frame count is irrelevant: the pointer was never over the node.
+- Secondary artifact: `nodeScreenPointById` reports `fixed:false` for the pinned id → duplicate node
+  `__data` instances share an id (harness reporting only; release still works locally 7/7 + native 3/3,
+  so the raycast-resolved node IS the pinned one). Hardening it to prefer the fx-defined instance.
+
+**Fix (waits + validation only; zoom dynamics unchanged; workers untouched; assertion unchanged):**
+1. New `waitForCameraRest` (graph-handle.ts): frame-based settle — resolves only after cameraDistance
+   holds across N consecutive real animation frames, so it is NOT fooled by slow-frame plateaus or a
+   mid-drain freeze (unlike the wall-clock 2-sample `waitForStableCameraDistance`). Drains the pending
+   zoom offset BEFORE the node is fixed, so the pinned node cannot drift off-screen afterward.
+2. Wrap zoom→rest→fix→on-screen-verify in a bounded reload-retry: a fresh page gives an offset-free
+   camera; only accept a fixed node whose projection is on-screen (rare degenerate-floor viewpoint → reload).
+3. Right-click loop: per-attempt `waitForCameraRest` + on-screen re-validation of the target before
+   dispatching; more settle frames + longer release poll. Off-screen drift self-heals instead of 6
+   identical misses.
+Next: implement, re-prove on CI green shards (local SwiftShader is not representative).

--- a/codev/state/bugfix-22_thread.md
+++ b/codev/state/bugfix-22_thread.md
@@ -181,3 +181,16 @@ flag to architect for transparency. Escalation not warranted (no architectural/a
 tests (incl. flaky-prone click-to-focus #6), smoke #11, and the new right-click-release #10.
 graph-handle refactor confirmed non-breaking. Acceptance criterion 3 satisfied. Next: porch check
 (build + unit), commit, porch done → PR phase.
+
+## PR phase — PR #43 opened; CMAP done
+PR #43 (base main). porch check green (build + unit). CMAP (bugfix pr):
+- Gemini APPROVE (HIGH, no issues); Claude APPROVE (HIGH, no issues).
+- Codex REQUEST_CHANGES (HIGH): (1) `npm run lint` fails on `.claude/hooks/worktree-write-guard.cjs`;
+  (2) `npm test` fails on `tests/audit-report.test.mjs`.
+- Both rebutted as untracked-harness / reviewer-sandbox environment noise, PROVEN on a clean
+  checkout (`git worktree add --detach HEAD` @ d5cc8a1 + real `npm ci`): lint exit 0, typecheck
+  exit 0, npm test 39/39. `.claude/hooks/` is untracked (git ls-files shows only .claude/skills/*),
+  absent from clean checkouts; audit-report.test.mjs is self-contained (mkdtemp+spawnSync, no net)
+  and passes — codex's sandbox likely blocks subprocess/tmpdir. No committed-config suppression
+  (per hot lesson). Rebuttal recorded as PR comment #issuecomment-5030356962.
+Requesting the `pr` gate (porch done); STOP and wait for human approval before merge.

--- a/codev/state/bugfix-22_thread.md
+++ b/codev/state/bugfix-22_thread.md
@@ -227,3 +227,10 @@ Downloaded playwright-test-results-4 (error-context.md + trace.zip x3) and root-
    dispatching; more settle frames + longer release poll. Off-screen drift self-heals instead of 6
    identical misses.
 Next: implement, re-prove on CI green shards (local SwiftShader is not representative).
+
+## CI PROVEN GREEN on the slow runner — head 0f2c7ac (run 29804841084)
+All 4 E2E shards + Quality + Validation gate = success. The previously-failing **shard 4/4 passed
+in 292s** (was 3/3 fail on ae74af7). Quality (lint/typecheck/unit/audit) green. The zoom-overshoot
+hardening (waitForCameraRest drains the offset before the fix; on-screen-validated aim) holds on the
+2-core CI SwiftShader, not just local. Acceptance criteria intact; assertion never weakened; workers
+untouched. Gate remains on hold — awaiting human approval (NOT self-approving). Notifying architect.

--- a/codev/state/bugfix-22_thread.md
+++ b/codev/state/bugfix-22_thread.md
@@ -1,0 +1,183 @@
+# bugfix-22 thread — Verify and fix fixed-node right-click release in native GPU Chromium
+
+Issue #22 (BUGFIX, strict mode). Follow-up from PR #21 / issue #9 manual matrix item 11.
+
+## Architect guidance (2026-07-21)
+- Host is WSL2 → headed Chromium still uses SwiftShader; native-GPU evidence likely unobtainable.
+- Acceptance criteria explicitly allow the alternative path: conclusively determine WITH EVIDENCE
+  whether the right-click release failure is app/library behavior or an automation-environment
+  limitation; document it; add durable regression coverage IF a real defect exists.
+- Do not burn time chasing a native GPU. Reason from the library right-click release code path
+  plus SwiftShader reproduction evidence.
+- Preserve left-click focus, node-drag fixation, and server/client WebGL boundaries.
+
+## Investigate phase — findings so far
+
+### App code path (app/components/FocusGraph.tsx)
+- `handleRightClick` (lines 135-144) wired to `onNodeRightClick`. On right-click of a node with
+  `fx !== undefined`, it clears `fx/fy/fz`. Looks correct by construction.
+- `handleClick` (left-click) calls `handleDragEnd` to fix the node + animate camera + stop rotation.
+- `handleDragEnd` fixes the dragged node and releases any previously-fixed node.
+- All three gated on `clickEnabled` (enabled after `enableDelay`, default 4000ms).
+
+### Prior-project evidence (the key finding)
+- Issue #9 review: item 11 (physical right-click releases fixed node) "Failed/unverifiable" in
+  headless SwiftShader; reproduced identically on rollback baseline → not an upgrade regression.
+- Issue #10 review: claimed node DRAG and RIGHT-click "do not register" via Playwright synthetic
+  events in headless SwiftShader even when aimed at a confirmed node.
+- **Issue #11 review (lines 274-279): corrected that claim.** Found the more precise truth,
+  confirmed across both engines: **right-click DOES register** when aimed at the fixed node's exact
+  projection after wheeling to moderate depth; drag registers intermittently (~50%); left-click
+  only lands on a *stationary* target. => The item-11 "failure" was an aiming/automation timing
+  limitation, NOT an app/library defect.
+
+### patches/
+- All three patch-package patches are `.d.ts` type-only (three r0.185 Renderer shim, React 19 JSX,
+  generic bound). None touch runtime interaction behavior.
+
+## Hypothesis
+The app right-click release path is correct. The item-11 failure is an automation-environment
+(SwiftShader synthetic-input aiming/timing) limitation, not an app/library defect. Plan: prove
+right-click release registers in headless SwiftShader using the same hover-first settle technique
+the click test uses (issue #34), and add durable e2e regression coverage: fix a node, right-click
+it, assert fixedNodeCount 1 → 0. Verify against the actual library right-click mechanism first.
+
+## Investigate conclusion (root cause — CONFIRMED)
+
+Read the installed library source (react-force-graph-3d 1.29.1 → three-render-objects, the exact
+version issue #11 qualified). The pointer dispatch (three-render-objects.mjs L552-578):
+
+    container.addEventListener('pointerup', ev => {
+      if (!isPointerPressed) return;
+      ...
+      requestAnimationFrame(() => {                     // deferred one frame
+        if (ev.button === 0) onClick(hoverObj || null, ...);       // left
+        if (ev.button === 2 && onRightClick) onRightClick(hoverObj || null, ...); // right
+      });
+    });
+    container.addEventListener('contextmenu', ev => { if (onRightClick) ev.preventDefault(); });
+
+=> Right-click (button 2) and left-click (button 0) dispatch through the SAME pointerup handler,
+the SAME requestAnimationFrame defer, reading the SAME throttled-raycast `hoverObj`. The only
+difference is the button number and which app handler runs. `hoverObj` is set by a raycast
+throttled to `pointerRaycasterThrottleMs` (~50ms) in the render loop (L272-291).
+
+**Root cause: there is NO app/library defect.**
+- App `handleRightClick` (FocusGraph.tsx L135-144) correctly clears fx/fy/fz on a fixed node.
+- Library dispatches right-click identically to left-click.
+- The item-11 "failure" is the SAME SwiftShader synthetic-input hover-race that affected
+  left-click (issue #34): a bare move+down+up resolves its deferred click before the throttled
+  raycast has committed `hoverObj`, so the handler fires with a null hover and releases nothing.
+  Issue #11 already found (and this code confirms) right-click DOES register with proper aiming
+  (hover-first settle). It is an automation-environment limitation, not app/library behavior.
+
+**Scope: BUGFIX-appropriate, test-only, no app code change.**
+- No fix to app code (nothing is broken). Deliverable = durable regression coverage that locks in
+  the correct right-click-release contract + conclusive documentation of the item-11 root cause.
+- Files to change (Fix phase): tests only.
+  1. Deterministic unit test (mirror tests/click-registration.test.mjs — the #34 harness): model
+     button-2 dispatch + app release-on-right-click semantics; prove a hovered FIXED node is
+     released, and that too-few settle frames still lose the race (guard stays load-bearing).
+  2. e2e right-click release in matrix.spec.ts (SwiftShader): fix a node then right-click it with
+     hover-first settle + button:'right'; assert fixedNodeCount 1→0. Gather real SwiftShader
+     evidence; keep it robust (retries) so the smoke gate stays green (acceptance criterion 3).
+- Native-GPU headed Chromium: unobtainable on WSL2 (SwiftShader only) per architect; will record
+  that + the SwiftShader+code-path evidence as the conclusive determination.
+
+Baseline: unit tests 36/36 green. Signaling investigate PHASE_COMPLETE.
+
+## FIX phase — NATIVE GPU BREAKTHROUGH (architect updated guidance 04:24Z)
+
+Architect superseded "don't chase native GPU": actively probe WSL2 GPU paravirtualization first.
+Ran the probes — hardware WebGL IS achievable here:
+
+- `/dev/dxg` present; `nvidia-smi` → NVIDIA GeForce RTX 3080, driver 581.29, CUDA 13.0.
+- WSLg active: DISPLAY=:0, WAYLAND_DISPLAY=wayland-0, /mnt/wslg/.X11-unix present.
+- `/usr/lib/wsl/lib` has libd3d12.so, libd3d12core.so, libdxcore.so; Mesa 26.0.3 with d3d12_dri.so.
+- Default `glxinfo -B` → llvmpipe (software, "Accelerated: no"); `/dev/dri` absent (DRI3 error).
+- **Forcing `GALLIUM_DRIVER=d3d12 LD_LIBRARY_PATH=/usr/lib/wsl/lib glxinfo -B` → Device: D3D12
+  (NVIDIA GeForce RTX 3080), Accelerated: YES.**
+- **Headed Chromium probe** (env GALLIUM_DRIVER=d3d12, LD_LIBRARY_PATH=/usr/lib/wsl/lib, DISPLAY=:0;
+  args `--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox`, headless:false):
+  **UNMASKED_RENDERER_WEBGL = "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080),
+  OpenGL 4.6)"** — genuine hardware WebGL, NOT SwiftShader/llvmpipe.
+  - `--use-angle=gl-egl` also works (OpenGL ES 3.1). `--use-gl=egl` → SwiftShader. `--use-angle=vulkan`
+    → llvmpipe (Mesa dozen/Vulkan-d3d12 not selected). So the winning backend is ANGLE→native-GL.
+
+=> Native-GPU headed Chromium IS available. Next: reproduce manual matrix item 11 (right-click
+release of a fixed node) on this RTX 3080 hardware WebGL and record the result as the native-GPU
+evidence acceptance criterion 1 asks for. Winning launch config recorded above.
+
+## NATIVE-GPU ITEM-11 RESULT — CONCLUSIVE (3/3 runs PASS)
+
+Ran a headed-Chromium reproduction against the production app (`npm run start`) on RTX 3080 HW WebGL.
+Launch env: MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA, GALLIUM_DRIVER=d3d12, LIBGL_ALWAYS_SOFTWARE=false,
+LD_LIBRARY_PATH=/usr/lib/wsl/lib, DISPLAY=:0. Args: --use-gl=angle --use-angle=gl
+--ignore-gpu-blocklist --disable-gpu-sandbox, headless:false.
+
+App page's own WebGL renderer confirmed: "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce
+RTX 3080), OpenGL 4.6)" — genuine hardware, not SwiftShader.
+
+Reproduction steps + result (item 11 = "right-click a fixed node releases fx/fy/fz"):
+1. Load app, wait for pointer enablement, pause auto-rotation.
+2. Wheel-zoom into click range.
+3. REAL USER PATH: physically left-click a node → fixedNodeCount 0→1 (node fixed); wait for the
+   focus camera tween; physically RIGHT-CLICK the fixed node → fixedNodeCount 1→0 (RELEASED).
+   => PASS on all 3 runs (nodes fixed then released: Pablissimo, Graphileon, Graphileon).
+4. ISOLATED right-click: deterministically fix the best on-screen node, then physically
+   right-click it → fixedNodeCount 1→0 (RELEASED). => PASS on all 3 runs.
+
+**CONCLUSION (conclusive determination the issue asks for):**
+Right-click release of a fixed node WORKS on native-GPU headed Chromium. The manual matrix item-11
+"failure" observed under headless SwiftShader was an **automation-environment limitation** — the
+software-render hover-timing race (same class as issue #34, where a bare synthetic click/right-click
+resolves its rAF-deferred dispatch before the throttled hover raycast commits `hoverObj`), NOT an
+application or library defect. App `handleRightClick` and the library's `onNodeRightClick` dispatch
+are correct. This resolves the PR #21/#9 item-11 follow-up.
+
+## Remaining FIX work (durable regression coverage)
+No app code change (nothing is broken). Add committed, NON-FLAKY regression coverage that locks in
+the right-click-release contract so a future regression of handleRightClick is caught:
+- Deterministic unit test (mirror tests/click-registration.test.mjs #34 harness) for right-click
+  release — drives the real shared settleHoverThenClick helper (add `button` param).
+- SwiftShader e2e test that exercises the real app handler (fix a node, real right-click releases
+  it) — only commit to the CI gate if it proves robust under SwiftShader (measure repeatedly);
+  else keep unit-only + this documented native-GPU evidence.
+Native-GPU is a local-only capability (CI has no GPU) so it stays documented evidence, not a CI lane.
+
+## FIX phase — regression coverage added (all SwiftShader-green)
+
+Architect constraint honored: committed tests do NOT depend on GPU env vars or hardware; they stay
+green under software rendering (CI is SwiftShader-only). Native-GPU is issue-record evidence only.
+
+Committed deliverables (test-only; NO app code change — nothing is broken):
+1. `tests/right-click-release.test.mjs` — deterministic unit harness (mirrors the #34
+   click-registration harness) modelling three-render-objects' button-2 dispatch + the app's
+   release-on-right-click semantics in plain JS. Proves: bare right-click loses the hover race and
+   releases nothing (the item-11 report); hover-first right-click releases; too-few settle frames
+   still miss (keeps the settle count load-bearing). Node-only, no browser/WebGL → always green.
+2. `tests/e2e/right-click-release.spec.ts` — real-app-handler guard under headless SwiftShader:
+   deterministically pin fx/fy/fz on the best on-screen node (harness probe), then a REAL
+   hover-first right-click (button:right) must clear it → fixedNodeCount 1→0. Fix-setup is
+   deterministic (the flaky part is the click FIX, which item 11 is not about); the release is a
+   genuine right-click through onNodeRightClick→handleRightClick.
+3. `tests/e2e/pointer.ts` — `settleHoverThenClick` gains a `button` param (default "left"), shared
+   by the unit + e2e right-click paths; backward compatible with all existing callers.
+4. `tests/e2e/graph-handle.ts` — additive probes `__graphFixBestNode` / `__graphNodeScreenById`
+   (+ `fixBestNode`/`nodeScreenPointById` helpers); `__graphNodeScreen` refactored to share a
+   `bestOnScreenNode` picker (same public return shape → existing tests unaffected).
+
+Robustness measured before committing the e2e test: isolated right-click release under headless
+SwiftShader passed 7/7 (1 foreground + 6/6 background probe). unit 39/39 green; typecheck + lint
+clean. Running full chromium (SwiftShader) e2e suite to confirm the new test + no regression in the
+existing matrix (graph-handle refactor preserves pickNodeScreenPoint's contract).
+
+LOC note: ~480 added lines, ALL test/harness (zero app change). Over the 300 BUGFIX guideline, but
+well-contained to tests/ and exactly the "durable regression coverage" the issue requests; will
+flag to architect for transparency. Escalation not warranted (no architectural/app change).
+
+## Full chromium (SwiftShader) e2e gate — GREEN
+`E2E_ENGINES=chromium npx playwright test` → **11/11 passed (9.7m)**, local retries:0. All 8 matrix
+tests (incl. flaky-prone click-to-focus #6), smoke #11, and the new right-click-release #10.
+graph-handle refactor confirmed non-breaking. Acceptance criterion 3 satisfied. Next: porch check
+(build + unit), commit, porch done → PR phase.

--- a/tests/e2e/graph-handle.ts
+++ b/tests/e2e/graph-handle.ts
@@ -287,22 +287,30 @@ export async function installGraphProbe(page: Page): Promise<void> {
 
         // Re-read a specific node's screen point by id. A fixed node stays put
         // (rotation paused, camera settled), so a right-click retry can re-aim
-        // at exactly the node it fixed.
+        // at exactly the node it fixed. three-forcegraph can expose more than
+        // one scene object whose `__data` carries the same node id (e.g. a mesh
+        // plus a label), so prefer the instance that actually holds the pinned
+        // fx/fy/fz — that is the one `fixBestNode` mutated and the one the
+        // library's raycast resolves as the hovered node — and fall back to the
+        // first match otherwise. Without this preference the lookup can report a
+        // duplicate, unpinned instance (`fixed: false`) for a node that IS fixed.
         window.__graphNodeScreenById = (id) => {
             const handle = findHandle();
             if (handle === null) {
                 return null;
             }
 
-            const node = collectNodeData(handle).find(
-                (candidate) => candidate.id === id,
+            const matches = collectNodeData(handle).filter(
+                (candidate) =>
+                    candidate.id === id &&
+                    typeof candidate.x === "number" &&
+                    typeof candidate.y === "number" &&
+                    typeof candidate.z === "number",
             );
-            if (
-                node === undefined ||
-                typeof node.x !== "number" ||
-                typeof node.y !== "number" ||
-                typeof node.z !== "number"
-            ) {
+            const node =
+                matches.find((candidate) => candidate.fx !== undefined) ??
+                matches[0];
+            if (node === undefined) {
                 return null;
             }
 
@@ -547,4 +555,70 @@ export async function waitForStableCameraDistance(
         throw new Error("graph handle unavailable after camera settled");
     }
     return snapshot;
+}
+
+/**
+ * Resolves once the camera distance holds steady across `stableFrames`
+ * consecutive REAL animation frames, draining any pending Trackball zoom offset.
+ *
+ * `waitForStableCameraDistance` samples on a wall-clock interval (250 ms) and
+ * returns after two close reads. Under GPU-less software rendering on a slow
+ * 2-core runner a single frame can take multiple seconds, so a rapid `-2400`
+ * wheel burst leaves a large zoom offset pending while consecutive wall-clock
+ * reads observe the SAME not-yet-advanced frame — an apparently "stable"
+ * plateau. `waitForStableCameraDistance` returns there, the next rendered frame
+ * then applies the whole accumulated offset and slams the camera to its minimum
+ * distance, and a node fixed on the plateau projects far off-screen (issue #22,
+ * shard-4 trace: cameraDistance 1.68 → 0.1, node (407,256) → (3414,2338)).
+ *
+ * Sampling once PER `requestAnimationFrame` instead defeats that: a slow-frame
+ * plateau spans few real frames, and any offset the render loop is still
+ * applying moves the distance and resets the stable counter, so this returns
+ * only when the camera is genuinely at rest. Frame-based, so it self-scales to
+ * render speed; `maxFrames` bounds the wait so a never-resting camera cannot
+ * hang the test (the caller re-validates and recovers).
+ */
+export async function waitForCameraRest(
+    page: Page,
+    {
+        stableFrames = 20,
+        epsilon = 0.5,
+        maxFrames = 600,
+    }: {stableFrames?: number; epsilon?: number; maxFrames?: number} = {},
+): Promise<void> {
+    await page.evaluate(
+        ({stableFrames, epsilon, maxFrames}) =>
+            new Promise<void>((resolve) => {
+                const distance = (): number => {
+                    const snapshot = window.__graphProbe();
+                    return snapshot === null
+                        ? Number.NaN
+                        : snapshot.cameraDistance;
+                };
+                let previous = distance();
+                let stable = 0;
+                let frame = 0;
+                const tick = (): void => {
+                    const current = distance();
+                    if (
+                        Number.isFinite(current) &&
+                        Number.isFinite(previous) &&
+                        Math.abs(current - previous) < epsilon
+                    ) {
+                        stable += 1;
+                    } else {
+                        stable = 0;
+                    }
+                    previous = current;
+                    frame += 1;
+                    if (stable >= stableFrames || frame >= maxFrames) {
+                        resolve();
+                        return;
+                    }
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        {stableFrames, epsilon, maxFrames},
+    );
 }

--- a/tests/e2e/graph-handle.ts
+++ b/tests/e2e/graph-handle.ts
@@ -27,6 +27,18 @@ export type NodeScreenPoint = {
     distanceToCenter: number;
 };
 
+export type FixedNodeScreenPoint = {
+    x: number;
+    y: number;
+    id: string | number;
+};
+
+export type NodeScreenById = {
+    x: number;
+    y: number;
+    fixed: boolean;
+};
+
 
 export type CollectedErrors = {
     consoleErrors: string[];
@@ -37,6 +49,8 @@ declare global {
     interface Window {
         __graphProbe: () => GraphSnapshot | null;
         __graphNodeScreen: () => NodeScreenPoint | null;
+        __graphFixBestNode: () => FixedNodeScreenPoint | null;
+        __graphNodeScreenById: (id: string | number) => NodeScreenById | null;
         __webglContextLostCount: number;
     }
 }
@@ -170,16 +184,23 @@ export async function installGraphProbe(page: Page): Promise<void> {
             };
         };
 
-        window.__graphNodeScreen = () => {
+        // Shared picker: the best (closest-to-center, comfortably in front of
+        // the camera, within-margin) on-screen node, returned WITH its node
+        // data. When zoomed in the camera sits inside the node cloud and
+        // graph2ScreenCoords maps nodes BEHIND the camera to plausible on-screen
+        // coordinates, so only nodes in front along the view direction are valid
+        // click targets.
+        const bestOnScreenNode = (): {
+            node: any;
+            x: number;
+            y: number;
+            distanceToCenter: number;
+        } | null => {
             const handle = findHandle();
             if (handle === null) {
                 return null;
             }
 
-            // When zoomed in, the camera sits inside the node cloud and
-            // graph2ScreenCoords maps nodes BEHIND the camera to plausible
-            // on-screen coordinates. Only nodes comfortably in front of the
-            // camera along its view direction are valid click targets.
             const camera = handle.camera();
             const viewDirection = camera
                 .getWorldDirection(camera.position.clone())
@@ -187,7 +208,12 @@ export async function installGraphProbe(page: Page): Promise<void> {
 
             const margin = 60;
             const minDepth = 50;
-            let best: NodeScreenPoint | null = null;
+            let best: {
+                node: any;
+                x: number;
+                y: number;
+                distanceToCenter: number;
+            } | null = null;
             for (const node of collectNodeData(handle)) {
                 if (
                     typeof node.x !== "number" ||
@@ -224,10 +250,64 @@ export async function installGraphProbe(page: Page): Promise<void> {
                     coords.y - window.innerHeight / 2,
                 );
                 if (best === null || distanceToCenter < best.distanceToCenter) {
-                    best = {x: coords.x, y: coords.y, distanceToCenter};
+                    best = {node, x: coords.x, y: coords.y, distanceToCenter};
                 }
             }
             return best;
+        };
+
+        window.__graphNodeScreen = () => {
+            const best = bestOnScreenNode();
+            return best === null
+                ? null
+                : {
+                      x: best.x,
+                      y: best.y,
+                      distanceToCenter: best.distanceToCenter,
+                  };
+        };
+
+        // Deterministically FIX the best on-screen node (pin fx/fy/fz to its
+        // current position) and return its screen point + id. This lets a
+        // right-click-release test establish a known fixed node WITHOUT relying
+        // on the software-WebGL-flaky click/drag fix path (issue #34); the
+        // release itself is still exercised through a real right-click. The app
+        // is never modified — fx/fy/fz are the same public node fields the drag
+        // and click handlers set.
+        window.__graphFixBestNode = () => {
+            const best = bestOnScreenNode();
+            if (best === null) {
+                return null;
+            }
+            best.node.fx = best.node.x;
+            best.node.fy = best.node.y;
+            best.node.fz = best.node.z;
+            return {x: best.x, y: best.y, id: best.node.id};
+        };
+
+        // Re-read a specific node's screen point by id. A fixed node stays put
+        // (rotation paused, camera settled), so a right-click retry can re-aim
+        // at exactly the node it fixed.
+        window.__graphNodeScreenById = (id) => {
+            const handle = findHandle();
+            if (handle === null) {
+                return null;
+            }
+
+            const node = collectNodeData(handle).find(
+                (candidate) => candidate.id === id,
+            );
+            if (
+                node === undefined ||
+                typeof node.x !== "number" ||
+                typeof node.y !== "number" ||
+                typeof node.z !== "number"
+            ) {
+                return null;
+            }
+
+            const coords = handle.graph2ScreenCoords(node.x, node.y, node.z);
+            return {x: coords.x, y: coords.y, fixed: node.fx !== undefined};
         };
     });
 }
@@ -242,6 +322,19 @@ export async function pickNodeScreenPoint(
     page: Page,
 ): Promise<NodeScreenPoint | null> {
     return page.evaluate(() => window.__graphNodeScreen());
+}
+
+export async function fixBestNode(
+    page: Page,
+): Promise<FixedNodeScreenPoint | null> {
+    return page.evaluate(() => window.__graphFixBestNode());
+}
+
+export async function nodeScreenPointById(
+    page: Page,
+    id: string | number,
+): Promise<NodeScreenById | null> {
+    return page.evaluate((nodeId) => window.__graphNodeScreenById(nodeId), id);
 }
 
 /**

--- a/tests/e2e/pointer.ts
+++ b/tests/e2e/pointer.ts
@@ -43,17 +43,28 @@ export async function waitForAnimationFrames(
  * hover raycast to register the node BEFORE pointerdown/up, so the deferred
  * click reads a resolved hover. This only ADDS frame-based (self-scaling)
  * waits — it trims none, and it does not touch worker concurrency.
+ *
+ * The same mechanism — and therefore the same fix — applies to a RIGHT-click
+ * (issue #22). three-render-objects dispatches BOTH buttons from the single
+ * `pointerup` handler behind the same `requestAnimationFrame`, reading the same
+ * throttled `hoverObj`; only `ev.button` differs (0 → `onClick`, 2 →
+ * `onRightClick`). So a bare right-click on a fixed node loses the identical
+ * hover race and releases nothing — exactly the manual-matrix item-11 report —
+ * while a hover-first right-click reads a resolved hover and releases it. Pass
+ * `button: "right"` to exercise that path.
  */
 export async function settleHoverThenClick(
     page: Page,
     x: number,
     y: number,
     settleFrames = 5,
+    button: "left" | "right" = "left",
 ): Promise<void> {
     await page.mouse.move(x, y);
     // Let committed hover raycasts run at the new pointer position before the
-    // click is dispatched — so the deferred onClick reads a resolved hover.
+    // click is dispatched — so the deferred onClick/onRightClick reads a
+    // resolved hover.
     await waitForAnimationFrames(page, settleFrames);
-    await page.mouse.down();
-    await page.mouse.up();
+    await page.mouse.down({button});
+    await page.mouse.up({button});
 }

--- a/tests/e2e/right-click-release.spec.ts
+++ b/tests/e2e/right-click-release.spec.ts
@@ -7,6 +7,7 @@ import {
     nodeScreenPointById,
     openGraphPage,
     readGraphSnapshot,
+    waitForCameraRest,
     waitForGraphHandle,
     waitForSizedCanvas,
     waitForStableCameraDistance,
@@ -30,6 +31,28 @@ import {settleHoverThenClick} from "./pointer";
 // the exact reason a bare right-click "did not release" under SwiftShader.
 
 const SETTLE_TIMEOUT_MS = process.env.CI ? 20_000 : 5_000;
+
+// A projected point must sit this far inside the viewport to be a reliable
+// hover target. Matches the on-screen margin `bestOnScreenNode` uses when it
+// picks/fixes a node, so any node it approves also clears this gate; a fixed
+// node whose projection has drifted outside it (a zoom over-shoot to the
+// Trackball's minimum distance) is unreachable and must not be aimed at.
+const ON_SCREEN_MARGIN = 40;
+
+function isOnScreen(
+    point: {x: number; y: number},
+    viewport: {width: number; height: number} | null,
+): boolean {
+    if (viewport === null) {
+        return false;
+    }
+    return (
+        point.x >= ON_SCREEN_MARGIN &&
+        point.y >= ON_SCREEN_MARGIN &&
+        point.x <= viewport.width - ON_SCREEN_MARGIN &&
+        point.y <= viewport.height - ON_SCREEN_MARGIN
+    );
+}
 
 async function waitForPointerEnablement(
     page: Parameters<typeof readGraphSnapshot>[0],
@@ -72,67 +95,126 @@ async function zoomIntoClickRange(
         }
     }
     await waitForStableCameraDistance(page);
+    // Drain any pending Trackball zoom offset the wall-clock settle above can
+    // miss on a slow runner: otherwise a later frame applies it and slams the
+    // camera to its minimum distance AFTER a node is fixed, projecting that node
+    // off-screen (issue #22). Frame-based, so it waits exactly as long as the
+    // software renderer needs.
+    await waitForCameraRest(page);
+}
+
+async function reloadGraph(
+    page: Parameters<typeof readGraphSnapshot>[0],
+): Promise<void> {
+    const reload = await page.goto("/");
+    expect(reload?.ok(), "recovery navigation should succeed").toBe(true);
+    await waitForSizedCanvas(page);
+    await waitForGraphHandle(page);
+    await waitForPointerEnablement(page);
+    await ensureRotationPaused(page);
+}
+
+// Establish exactly one FIXED, on-screen node with the camera genuinely at rest
+// — the precondition item 11 describes (the user fixed it before right-clicking).
+// Pinning fx/fy/fz (fixBestNode) is the same public state the drag/click
+// handlers set and, unlike a real click, triggers no focus-camera animation, so
+// once the camera is at rest the pinned node stays exactly where it was fixed.
+//
+// The ordering is load-bearing: zoomIntoClickRange now DRAINS the pending zoom
+// offset (waitForCameraRest) before returning, so the node is fixed only after
+// the camera has stopped. A node fixed on a slow-runner zoom plateau projected
+// off-screen once that offset later applied and slammed the camera to its
+// minimum distance — every retry then aimed off-canvas and released nothing
+// (issue #22, shard 4/4). Each try starts from a fresh, offset-free page, a
+// stray wheel-path fix restarts clean, and only a fixed node whose projection is
+// on-screen is accepted; the rare degenerate viewpoint (camera at the Trackball
+// minimum with no hittable node) reloads rather than returning an unreachable aim.
+async function establishFixedOnScreenNode(
+    page: Parameters<typeof readGraphSnapshot>[0],
+    viewport: {width: number; height: number} | null,
+): Promise<{id: string | number; x: number; y: number} | null> {
+    for (let setup = 0; setup < 3; setup += 1) {
+        if (setup > 0) {
+            await reloadGraph(page);
+        }
+        await zoomIntoClickRange(page);
+
+        const preFix = await readGraphSnapshot(page);
+        if (preFix === null || preFix.fixedNodeCount !== 0) {
+            continue; // stray wheel-path fix — restart from a clean page
+        }
+
+        const fixed = await fixBestNode(page);
+        if (fixed === null) {
+            continue; // no on-screen node at this viewpoint — retry fresh
+        }
+
+        await expect
+            .poll(
+                async () => (await readGraphSnapshot(page))?.fixedNodeCount ?? 0,
+                {
+                    message: "pinning fx/fy/fz should register the node as fixed",
+                    timeout: SETTLE_TIMEOUT_MS,
+                },
+            )
+            .toBe(1);
+
+        // Confirm the camera is still at rest, then that the fixed node projects
+        // on-screen. It will unless a residual offset moved the camera after the
+        // fix — in which case aiming is hopeless and a fresh page is the fix.
+        await waitForCameraRest(page);
+        const point = await nodeScreenPointById(page, fixed.id);
+        if (point !== null && isOnScreen(point, viewport)) {
+            return {id: fixed.id, x: point.x, y: point.y};
+        }
+    }
+    return null;
 }
 
 test("right-clicking a fixed node releases its fx/fy/fz", async ({page}) => {
-    test.setTimeout(180_000);
+    test.setTimeout(240_000);
     const errors = await openGraphPage(page);
     await waitForSizedCanvas(page);
     await waitForGraphHandle(page);
     await waitForPointerEnablement(page);
     await ensureRotationPaused(page);
 
-    // Bring nodes into hittable range and start from a clean (no fixed node)
-    // state. A stray wheel-path fix (observed in both engines) would make the
-    // final `fixedNodeCount === 0` assertion pass for the wrong reason, so
-    // recover on a fresh page if one slips through.
-    await zoomIntoClickRange(page);
-    for (let recovery = 0; recovery < 2; recovery += 1) {
-        const snapshot = await readGraphSnapshot(page);
-        if (snapshot !== null && snapshot.fixedNodeCount === 0) {
-            break;
-        }
-        const reload = await page.goto("/");
-        expect(reload?.ok(), "recovery navigation should succeed").toBe(true);
-        await waitForSizedCanvas(page);
-        await waitForGraphHandle(page);
-        await waitForPointerEnablement(page);
-        await ensureRotationPaused(page);
-        await zoomIntoClickRange(page);
-    }
-
-    // Establish exactly one FIXED node — the precondition item 11 describes
-    // (the user fixed it before right-clicking). Pinning fx/fy/fz is the same
-    // public state the drag/click handlers set; the release is what this test
-    // exercises for real.
-    const fixed = await fixBestNode(page);
-    expect(fixed, "an on-screen node should be available to fix").not.toBeNull();
-    await expect
-        .poll(async () => (await readGraphSnapshot(page))?.fixedNodeCount ?? 0, {
-            message: "pinning fx/fy/fz should register the node as fixed",
-            timeout: SETTLE_TIMEOUT_MS,
-        })
-        .toBe(1);
-
-    const targetId = (fixed as {id: string | number}).id;
+    const viewport = page.viewportSize();
+    const target = await establishFixedOnScreenNode(page, viewport);
+    expect(
+        target,
+        "should fix an on-screen node with the camera at rest",
+    ).not.toBeNull();
+    const fixedTarget = target as {
+        id: string | number;
+        x: number;
+        y: number;
+    };
 
     // Real right-click, hover-first, on the fixed node. Retry: under software
     // WebGL the decisive onRightClick resolves a render frame after pointerup,
-    // and a single aim can miss the throttled hover commit. The assertion is
-    // only satisfiable by releasing the actual fixed node, so retries only
-    // improve the odds of landing the hover — they cannot pass falsely.
+    // and a single aim can miss the throttled hover commit. Re-read the node's
+    // CURRENT projection each attempt (waitForCameraRest first so it is not read
+    // mid-motion) and only dispatch when it is on-screen — the camera is at rest
+    // so it stays put, but this refuses to fire blindly off-canvas, the shard-4
+    // failure mode. The assertion is only satisfiable by releasing the actual
+    // fixed node, so retries cannot pass falsely.
     let released = false;
     for (let attempt = 0; attempt < 6 && !released; attempt += 1) {
+        await waitForCameraRest(page);
         const point =
-            (await nodeScreenPointById(page, targetId)) ??
-            (fixed as {x: number; y: number});
-        await settleHoverThenClick(page, point.x, point.y, 5, "right");
+            (await nodeScreenPointById(page, fixedTarget.id)) ?? fixedTarget;
+        if (!isOnScreen(point, viewport)) {
+            continue;
+        }
+
+        await settleHoverThenClick(page, point.x, point.y, 8, "right");
         try {
             await expect
                 .poll(
                     async () =>
                         (await readGraphSnapshot(page))?.fixedNodeCount ?? 1,
-                    {timeout: 2_500},
+                    {timeout: 5_000},
                 )
                 .toBe(0);
             released = true;

--- a/tests/e2e/right-click-release.spec.ts
+++ b/tests/e2e/right-click-release.spec.ts
@@ -1,0 +1,153 @@
+import {expect, test} from "@playwright/test";
+import process from "node:process";
+import {
+    expectCleanErrorBudget,
+    ensureRotationPaused,
+    fixBestNode,
+    nodeScreenPointById,
+    openGraphPage,
+    readGraphSnapshot,
+    waitForGraphHandle,
+    waitForSizedCanvas,
+    waitForStableCameraDistance,
+} from "./graph-handle";
+import {settleHoverThenClick} from "./pointer";
+
+// Issue #22: right-clicking a visibly hovered FIXED node must release its
+// fx/fy/fz. This is the real-application-handler guard for that contract under
+// the CI renderer (headless SwiftShader). The companion node-only unit test
+// (tests/right-click-release.test.mjs) models the timing mechanism
+// deterministically; this test exercises the genuine
+// onNodeRightClick → handleRightClick path in a real WebGL context.
+//
+// The fix step is deterministic (pin fx/fy/fz on the best on-screen node via
+// the harness probe) rather than a real click/drag: the manual-matrix item-11
+// concern is the RIGHT-CLICK RELEASE, and chaining a software-WebGL-flaky fix
+// click ahead of it would only add unrelated flakiness (issue #34). The release
+// itself is a genuine right-click, issued hover-first so the library's
+// throttled raycast commits the node as `hoverObj` before the rAF-deferred
+// onRightClick resolves — the same technique the click-to-focus test uses, and
+// the exact reason a bare right-click "did not release" under SwiftShader.
+
+const SETTLE_TIMEOUT_MS = process.env.CI ? 20_000 : 5_000;
+
+async function waitForPointerEnablement(
+    page: Parameters<typeof readGraphSnapshot>[0],
+): Promise<void> {
+    await expect
+        .poll(
+            async () => (await readGraphSnapshot(page))?.controlsEnabled ?? false,
+            {
+                message:
+                    "expected navigation controls to enable after the configured delay",
+                timeout: 20_000,
+            },
+        )
+        .toBe(true);
+}
+
+// Wheel the rotating cloud closer until nodes are realistically hittable. Same
+// adaptive shape as the click-to-focus test: rapid same-direction wheels stall
+// the Trackball's per-frame zoom guard, so a stalled burst pauses to let the
+// internal offset decay. Wheeling from a screen corner keeps sweeping nodes out
+// from under the pointer so the wheel path does not register a stray fix.
+async function zoomIntoClickRange(
+    page: Parameters<typeof readGraphSnapshot>[0],
+): Promise<void> {
+    await page.mouse.move(60, 540);
+    for (let burst = 0; burst < 60; burst += 1) {
+        const before = await readGraphSnapshot(page);
+        if (before !== null && before.cameraDistance < 450) {
+            break;
+        }
+        await page.mouse.wheel(0, -2_400);
+        await page.waitForTimeout(600);
+        const after = await readGraphSnapshot(page);
+        if (
+            before !== null &&
+            after !== null &&
+            before.cameraDistance - after.cameraDistance < 1
+        ) {
+            await page.waitForTimeout(2_500);
+        }
+    }
+    await waitForStableCameraDistance(page);
+}
+
+test("right-clicking a fixed node releases its fx/fy/fz", async ({page}) => {
+    test.setTimeout(180_000);
+    const errors = await openGraphPage(page);
+    await waitForSizedCanvas(page);
+    await waitForGraphHandle(page);
+    await waitForPointerEnablement(page);
+    await ensureRotationPaused(page);
+
+    // Bring nodes into hittable range and start from a clean (no fixed node)
+    // state. A stray wheel-path fix (observed in both engines) would make the
+    // final `fixedNodeCount === 0` assertion pass for the wrong reason, so
+    // recover on a fresh page if one slips through.
+    await zoomIntoClickRange(page);
+    for (let recovery = 0; recovery < 2; recovery += 1) {
+        const snapshot = await readGraphSnapshot(page);
+        if (snapshot !== null && snapshot.fixedNodeCount === 0) {
+            break;
+        }
+        const reload = await page.goto("/");
+        expect(reload?.ok(), "recovery navigation should succeed").toBe(true);
+        await waitForSizedCanvas(page);
+        await waitForGraphHandle(page);
+        await waitForPointerEnablement(page);
+        await ensureRotationPaused(page);
+        await zoomIntoClickRange(page);
+    }
+
+    // Establish exactly one FIXED node — the precondition item 11 describes
+    // (the user fixed it before right-clicking). Pinning fx/fy/fz is the same
+    // public state the drag/click handlers set; the release is what this test
+    // exercises for real.
+    const fixed = await fixBestNode(page);
+    expect(fixed, "an on-screen node should be available to fix").not.toBeNull();
+    await expect
+        .poll(async () => (await readGraphSnapshot(page))?.fixedNodeCount ?? 0, {
+            message: "pinning fx/fy/fz should register the node as fixed",
+            timeout: SETTLE_TIMEOUT_MS,
+        })
+        .toBe(1);
+
+    const targetId = (fixed as {id: string | number}).id;
+
+    // Real right-click, hover-first, on the fixed node. Retry: under software
+    // WebGL the decisive onRightClick resolves a render frame after pointerup,
+    // and a single aim can miss the throttled hover commit. The assertion is
+    // only satisfiable by releasing the actual fixed node, so retries only
+    // improve the odds of landing the hover — they cannot pass falsely.
+    let released = false;
+    for (let attempt = 0; attempt < 6 && !released; attempt += 1) {
+        const point =
+            (await nodeScreenPointById(page, targetId)) ??
+            (fixed as {x: number; y: number});
+        await settleHoverThenClick(page, point.x, point.y, 5, "right");
+        try {
+            await expect
+                .poll(
+                    async () =>
+                        (await readGraphSnapshot(page))?.fixedNodeCount ?? 1,
+                    {timeout: 2_500},
+                )
+                .toBe(0);
+            released = true;
+        } catch {
+            released = false;
+        }
+    }
+
+    expect(
+        released,
+        "a real right-click on the fixed node should release its fx/fy/fz",
+    ).toBe(true);
+
+    const finalSnapshot = await readGraphSnapshot(page);
+    expect(finalSnapshot?.fixedNodeCount ?? 1).toBe(0);
+    expect(finalSnapshot?.contextLostCount ?? 1).toBe(0);
+    expectCleanErrorBudget(errors);
+});

--- a/tests/right-click-release.test.mjs
+++ b/tests/right-click-release.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {settleHoverThenClick} from "./e2e/pointer.ts";
+
+// Deterministic regression harness for issue #22: right-clicking a visibly
+// hovered FIXED node must release it (clear fx/fy/fz). Like the issue-#34
+// click-registration harness it ships beside, it reproduces the exact library
+// mechanism in plain JS — no browser, no WebGL, no GPU — so it stays green under
+// software rendering (CI is SwiftShader-only).
+//
+// The mechanism (three-render-objects): BOTH mouse buttons are dispatched from
+// the SAME `pointerup` handler, deferred one animation frame by the SAME
+// `requestAnimationFrame`, reading the SAME throttled-raycast `hoverObj`; only
+// `ev.button` differs (0 → onClick fixes, 2 → onRightClick releases). The
+// hovered node becomes `hoverObj` only a few frames after the pointer arrives
+// (aim-to-raycast latency, modelled by HOVER_LATENCY_FRAMES). So a bare
+// move+down+up RIGHT-click resolves its deferred `onRightClick` before the
+// raycast has committed the hover → the handler fires with a null hover and
+// releases nothing. That is exactly the manual-matrix item-11 report ("physical
+// right-click did not release the fixed node") under headless SwiftShader — an
+// automation-environment timing limitation, confirmed by a native-GPU repro
+// where the release works. Moving first and waiting real frames lets the hover
+// commit so the deferred right-click releases the node. If the shared
+// hover-first fix regresses (or its settle count drops below the modelled
+// latency) the "releases" assertion fails.
+
+const HOVER_LATENCY_FRAMES = 3; // frames the raycast needs to commit the hover
+const TARGET = {x0: 100, y0: 100, x1: 300, y1: 300};
+const TARGET_CENTER = {x: 200, y: 200};
+
+function createFakeGraph() {
+    const model = {
+        frame: 0,
+        overSinceFrame: null, // frame the pointer entered the node, else null
+        pressed: false,
+        hoverObj: null, // "node" only after the raycast commits it
+        pendingClick: null, // {frame, button}; resolves on a later frame
+        // One node, already FIXED — the precondition item 11 describes: the user
+        // fixed it (left-click / drag) before right-clicking to release it.
+        fixed: true,
+    };
+
+    const overTarget = (x, y) =>
+        x >= TARGET.x0 && x <= TARGET.x1 && y >= TARGET.y0 && y <= TARGET.y1;
+
+    // One render-loop frame: commit the throttled hover raycast, then resolve
+    // any deferred click reading that hover (mirrors three-render-objects, incl.
+    // its `ev.button` branch: onClick fixes, onRightClick releases).
+    const tickFrame = () => {
+        model.frame += 1;
+        model.hoverObj =
+            model.overSinceFrame !== null &&
+            model.frame - model.overSinceFrame >= HOVER_LATENCY_FRAMES
+                ? "node"
+                : null;
+        if (
+            model.pendingClick !== null &&
+            model.frame > model.pendingClick.frame
+        ) {
+            if (model.hoverObj === "node") {
+                if (model.pendingClick.button === "right") {
+                    model.fixed = false; // onNodeRightClick releases a fixed node
+                } else {
+                    model.fixed = true; // onNodeClick fixes it
+                }
+            }
+            model.pendingClick = null;
+        }
+    };
+
+    const setPointer = (x, y) => {
+        if (overTarget(x, y)) {
+            if (model.overSinceFrame === null) {
+                model.overSinceFrame = model.frame;
+            }
+        } else {
+            model.overSinceFrame = null;
+            model.hoverObj = null;
+        }
+    };
+
+    const page = {
+        mouse: {
+            async move(x, y) {
+                setPointer(x, y);
+            },
+            async down() {
+                model.pressed = true;
+            },
+            async up(opts) {
+                if (!model.pressed) {
+                    return;
+                }
+                model.pressed = false;
+                model.pendingClick = {
+                    frame: model.frame, // deferred to next frame
+                    button: opts?.button ?? "left",
+                };
+            },
+        },
+        // Run the helper's real page-context frame loop against the model clock:
+        // its `requestAnimationFrame(cb)` advances exactly one render frame.
+        async evaluate(fn, arg) {
+            const realRaf = globalThis.requestAnimationFrame;
+            globalThis.requestAnimationFrame = (cb) => {
+                tickFrame();
+                cb(model.frame);
+                return model.frame;
+            };
+            try {
+                return await fn(arg);
+            } finally {
+                globalThis.requestAnimationFrame = realRaf;
+            }
+        },
+    };
+
+    // Advance the render loop after a click is issued (in the browser the loop
+    // never stops; the deferred click resolves on a following frame).
+    const runRenderLoop = (frames) => {
+        for (let i = 0; i < frames; i += 1) {
+            tickFrame();
+        }
+    };
+
+    return {page, model, runRenderLoop};
+}
+
+async function bareRightClick(page, x, y) {
+    // The pre-fix sequence: move then immediately press/release, with no frames
+    // in between for the hover raycast to commit.
+    await page.mouse.move(x, y);
+    await page.mouse.down({button: "right"});
+    await page.mouse.up({button: "right"});
+}
+
+test("a bare right-click loses the hover race and releases no node (the item-11 report)", async () => {
+    const {page, model, runRenderLoop} = createFakeGraph();
+    assert.equal(model.fixed, true, "precondition: the node starts fixed");
+    await bareRightClick(page, TARGET_CENTER.x, TARGET_CENTER.y);
+    runRenderLoop(HOVER_LATENCY_FRAMES + 3); // give the loop ample time
+    assert.equal(
+        model.fixed,
+        true,
+        "a bare move+down+up right-click should resolve its deferred onRightClick " +
+            "before the hover raycast commits — reproducing the item-11 " +
+            "'right-click did not release the fixed node' failure",
+    );
+});
+
+test("settleHoverThenClick(button:right) releases the fixed node by letting the hover commit first", async () => {
+    const {page, model, runRenderLoop} = createFakeGraph();
+    await settleHoverThenClick(page, TARGET_CENTER.x, TARGET_CENTER.y, 5, "right");
+    runRenderLoop(2); // resolve the deferred right-click
+    assert.equal(
+        model.fixed,
+        false,
+        "moving first and waiting real animation frames must let the hover " +
+            "raycast commit the node before the deferred right-click resolves, " +
+            "so onNodeRightClick releases it",
+    );
+});
+
+test("too few settle frames still lose the race (the frames are the fix)", async () => {
+    // Guards against the fix degrading to a token wait: the settle must clear
+    // the aim-to-raycast latency, so a count below it must still miss. This is
+    // what makes the default (> the modelled latency) load-bearing.
+    const {page, model, runRenderLoop} = createFakeGraph();
+    await settleHoverThenClick(page, TARGET_CENTER.x, TARGET_CENTER.y, 1, "right");
+    runRenderLoop(2);
+    assert.equal(
+        model.fixed,
+        true,
+        "one settle frame is below the modelled hover latency and must not release",
+    );
+});


### PR DESCRIPTION
## Summary

Follow-up from PR #21 / issue #9 manual-matrix **item 11** ("physically right-clicking a visibly
hovered fixed node did not release it"), which failed only under headless Chromium + SwiftShader.

**Determination: right-click release of a fixed node works correctly.** The item-11 failure was an
**automation-environment limitation** (a software-render hover-timing race), not an application or
library defect. Verified two ways — a native-GPU reproduction and a code-path analysis — and locked
in with durable, SwiftShader-green regression coverage. **No application code changed.**

## Native-GPU evidence (acceptance criterion 1)

Native-GPU headed Chromium *is* obtainable on this WSL2 host via GPU paravirtualization, so the
item-11 repro was run on real hardware rather than only documented as unobtainable.

- Probe: `/dev/dxg` present; `nvidia-smi` → NVIDIA GeForce RTX 3080 (driver 581.29); WSLg active.
  Default `glxinfo -B` gives software `llvmpipe`, but forcing Mesa's D3D12 Gallium driver
  (`GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`) yields `Device: D3D12 (NVIDIA GeForce
  RTX 3080), Accelerated: yes`. Adapter-agnostic: the base config auto-selects the sole adapter;
  `MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA` + `LIBGL_ALWAYS_SOFTWARE=false` are optional
  multi-GPU disambiguators, and the path falls back to software if no hardware adapter is found.
- Headed Chromium (`--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox`,
  headless:false, on WSLg `DISPLAY=:0`) reports the app's own WebGL renderer as
  **`ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)`** — genuine
  hardware WebGL, not SwiftShader/llvmpipe.
- **Item-11 reproduction (3/3 runs PASS):** load app → wait for pointer enablement → pause
  auto-rotation → wheel-zoom into range → physically **left-click a node to fix it**
  (`fixedNodeCount` 0→1) → physically **right-click the fixed node** → `fixedNodeCount` 1→0
  (**released**). An isolated variant (deterministically pin a node, then real right-click) also
  released 3/3.

The native-GPU setup is environment-specific (WSLg + a hardware adapter) and CI has no GPU, so it is
recorded here as issue evidence, **not** added as a committed test lane.

## Root cause / code-path analysis

`react-force-graph-3d@1.29.1` → `three-render-objects` dispatches **both** mouse buttons from a
single `pointerup` handler, behind the **same** `requestAnimationFrame`, reading the **same**
throttled-raycast `hoverObj`; only `ev.button` differs (`0 → onClick`, `2 → onRightClick`). The
app's `onNodeRightClick={handleRightClick}` clears `fx/fy/fz` when the hovered node is fixed — this
is correct. Under software WebGL a *bare* right-click (move+down+up with no settle) resolves its
rAF-deferred `onRightClick` before the throttled hover raycast commits the node as `hoverObj`, so
the handler fires with a null hover and releases nothing. This is the identical race that made a
bare left-click miss (issue #34); the hover-first "settle" technique defeats both.

## Changes (test/harness only — no app change)

- `tests/right-click-release.test.mjs` — **deterministic** unit harness (mirrors the issue-#34
  `click-registration.test.mjs`) modelling the button-2 dispatch + release semantics in plain JS.
  Asserts a bare right-click releases nothing (the item-11 report), a hover-first right-click
  releases, and too few settle frames still miss (keeps the settle count load-bearing). No
  browser/WebGL → green under software rendering.
- `tests/e2e/right-click-release.spec.ts` — real-app-handler guard under headless SwiftShader:
  pin `fx/fy/fz` on the best on-screen node (harness probe), then a **real** hover-first right-click
  must clear it (`fixedNodeCount` 1→0). The fix-setup is deterministic (the item-11 concern is the
  release, not the fix); the release runs through the genuine `onNodeRightClick → handleRightClick`
  path.
- `tests/e2e/pointer.ts` — `settleHoverThenClick` gains a `button` param (default `"left"`), shared
  by both new tests; backward compatible with all existing callers.
- `tests/e2e/graph-handle.ts` — additive probes `__graphFixBestNode` / `__graphNodeScreenById`
  (+ `fixBestNode` / `nodeScreenPointById` helpers); `__graphNodeScreen` refactored to share a
  `bestOnScreenNode` picker with an unchanged public return shape.

## Test plan

- `npm test` (unit): 39/39 pass (36 prior + 3 new). Deterministic, renderer-independent.
- Isolated right-click-release robustness under **headless SwiftShader**: 7/7 (measured before
  committing the e2e test).
- `E2E_ENGINES=chromium npx playwright test` (SwiftShader, CI-equivalent, local `retries:0`):
  **11/11 passed** — all 8 existing matrix tests (incl. the flaky-prone click-to-focus), the smoke
  test, and the new right-click-release test. Confirms the `graph-handle` refactor preserved the
  existing suite and the new e2e test is green under software rendering.
- `npm run typecheck` and `npm run lint`: clean.
- Native-GPU (RTX 3080) item-11 repro: 3/3 PASS (see above).

Fixes #22
