### PR TITLE
[Experiment 42] Probe v2: robust kernel-output retrieval (run #1 evidence)

### DIFF
--- a/.github/workflows/kaggle-gpu-spike.yml
+++ b/.github/workflows/kaggle-gpu-spike.yml
@@ -78,8 +78,14 @@ jobs:
           PY
 
       # --- Access-token-string credential path ---
+      # continue-on-error: the action's own status/log-dump step crashes on this
+      # kernel's log format (ConvertFrom-Json "Additional text encountered") and
+      # never prints the kernel stdout — a real reporting defect. We let the job
+      # proceed to the retrieval/verdict steps below, which read the actual
+      # result artifact and set the true job status.
       - name: Run WebGL probe on Kaggle GPU kernel (api_token)
         if: steps.sniff.outputs.mode == 'string'
+        continue-on-error: true
         # Frederisk/kaggle-action@v2.0.0 pinned by SHA (audited 2026-07-21).
         uses: Frederisk/kaggle-action@e6bafb6bf66da87116cca560a7636422213cf354
         with:
@@ -97,6 +103,7 @@ jobs:
       # --- Legacy username/key credential path ---
       - name: Run WebGL probe on Kaggle GPU kernel (username/key)
         if: steps.sniff.outputs.mode == 'json'
+        continue-on-error: true
         uses: Frederisk/kaggle-action@e6bafb6bf66da87116cca560a7636422213cf354
         with:
           username: ${{ steps.sniff.outputs.username }}
@@ -110,3 +117,39 @@ jobs:
           enable_internet: 'true'
           machine_shape: ${{ inputs.machine_shape }}
           timeout_seconds: '1200'
+
+      # The kaggle CLI + ~/.kaggle credentials were set up by the action above and
+      # persist on the runner. By the time the action returns (even on its crash),
+      # the kernel is in a TERMINAL state, so its output is fetchable. This is the
+      # real evidence channel — it bypasses the action's broken stdout dump.
+      - name: Retrieve Kaggle kernel output (robust)
+        if: always()
+        shell: bash
+        run: |
+          OWNER=mohidmakhdoomi   # kernel owner for this token (confirmed via push URL)
+          SLUG=nextjs3dfg-webgl-probe
+          kaggle kernels output "$OWNER/$SLUG" -p kernel-output || true
+          echo "=== retrieved files ==="; ls -la kernel-output || true
+          echo "=== webgl_probe_result.json (structured verdict) ==="
+          cat "kernel-output/webgl_probe_result.json" 2>/dev/null || echo "(no result artifact — kernel may have crashed before writing it)"
+          echo "=== reconstructed kernel stdout ==="
+          if [ -f "kernel-output/$SLUG.log" ]; then
+            jq -r '.[].data' "kernel-output/$SLUG.log" 2>/dev/null \
+              || python3 -c "import json,sys;print(''.join(x.get('data','') for x in json.load(open(sys.argv[1]))))" "kernel-output/$SLUG.log" 2>/dev/null \
+              || cat "kernel-output/$SLUG.log"
+          fi
+
+      - name: Verdict (job status reflects the actual WebGL result)
+        if: always()
+        shell: bash
+        run: |
+          f=kernel-output/webgl_probe_result.json
+          if [ ! -f "$f" ]; then
+            echo "::warning::No result artifact — kernel crashed before writing it; inspect stdout above."
+            exit 1
+          fi
+          verdict="$(python3 -c "import json;print(json.load(open('$f'))['verdict'])")"
+          flagset="$(python3 -c "import json;d=json.load(open('$f'));print(d.get('hardware_flag_set') or 'none')")"
+          echo "Kaggle GPU WebGL verdict: $verdict (hardware flag set: $flagset)"
+          # Job PASSES only if a real hardware renderer was obtained.
+          test "$verdict" = "hardware"

--- a/codev/state/experiment-42_thread.md
+++ b/codev/state/experiment-42_thread.md
@@ -43,3 +43,22 @@ Implemented:
 - Added a **credential-sniff step**: reads secret from `env` (never interpolated), parses JSON→`username`/`key` (both `::add-mask::`ed) routed to the action's username+key inputs, else passes through as `api_token`. Two SHA-pinned (`e6bafb6`) conditional action calls. Only non-secret `mode` leaves in clear.
 - Updated notes.md (status=GO, repro/dispatch, sniff design, go/no-go resolved).
 - Next: push branch, open PR with **`Refs #42`** (partial — issue stays open until probe result + recommendation), notify architect for immediate review.
+
+## 2026-07-21 — PR #45 merged; live probe dispatched
+
+- PR #45 opened; 3-way CMAP review = 2 APPROVE / 1 REQUEST_CHANGES. Required change: pin probe `playwright==1.61.1` (was `--upgrade`). Fixed in `cc7212e`. Also recorded + guarded the **Stage-2 hard-gate**: `playwright.config.ts` hardcodes `--use-angle=swiftshader` and reads no args env → `playwright test` forces software WebGL even on GPU; runner now fails fast until config is wired. (Stage-1 unaffected — probe launches Chromium directly.)
+- CI: first `cc7212e` run came back `cancelled` due to an isolated **shard 3/4 cancellation** (infra eviction; shards 1/2/4 + quality passed). Re-ran non-successful jobs (`gh run rerun --failed`) → **fully green** (all 7 jobs success). Not a real failure; not caused by my diff.
+- **Merged PR #45** (merge commit) per architect's standing "CI green → merge yourself → dispatch" instruction. Workflow now on `main`.
+- **Dispatched the live Stage-1 probe:** run `29859449200` (`workflow_dispatch`, machine_shape=NvidiaTeslaT4). Watching for the `UNMASKED_RENDERER_WEBGL` verdict. Kaggle adds queue/boot latency so this can take several minutes.
+
+## 2026-07-21 — Probe run #1 result: infra worked, but action's reporting is BROKEN
+
+Run `29859449200` (~4 min) outcome — three facts, evidence saved to `data/output/probe-run-29859449200.{log,clean.txt}`:
+1. ✅ **Credential sniff worked**: `Detected credential mode: string` → token is a raw access-token, routed to `api_token`, secret never echoed.
+2. ✅ **Kernel pushed & ran**: `Kernel version 1 successfully pushed` → `KernelWorkerStatus.RUNNING` (~3.5 min) → `KernelWorkerStatus.ERROR`.
+3. ❌ **Action reporting DEFECT**: on kernel ERROR the action tries to dump the log via `Get-Content | ConvertFrom-Json -AsHashtable` and **crashes** (`Conversion from JSON failed: Additional text encountered`). So the kernel's stdout (nvidia-smi + WebGL renderer + VERDICT) was **never surfaced**. Can't yet tell if ERROR = my intended `exit(1)` (software WebGL) or a genuine kernel crash. **This is itself a strong finding** reinforcing "crude/fragile reporting → reject for required CI."
+
+**v2 iteration (this commit)** — self-sufficient evidence channel, bypassing the action's bug:
+- Probe writes a structured `webgl_probe_result.json` artifact (retrievable kernel output), plus captures nvidia-smi.
+- Workflow: `continue-on-error` on the action step + an `if: always()` step that runs `kaggle kernels output mohidmakhdoomi/nextjs3dfg-webgl-probe` directly and prints the result JSON + reconstructed stdout, then a Verdict step that sets job pass/fail from the actual `verdict` (hardware vs software). kaggle CLI + `~/.kaggle` creds persist from the action's earlier steps.
+- Plan: PR → merge (CI green) → re-dispatch → read the real renderer verdict. Within the architect's sanctioned "few manual retries."

--- a/experiments/42_kaggle_gpu_ci/data/output/probe-run-1-evidence.md
+++ b/experiments/42_kaggle_gpu_ci/data/output/probe-run-1-evidence.md
@@ -1,0 +1,53 @@
+# Probe run #1 — evidence (GitHub Actions run 29859449200)
+
+Workflow: `kaggle-gpu-spike.yml` @ probe v1 · dispatched 2026-07-21 18:57 UTC ·
+`machine_shape=NvidiaTeslaT4` · job conclusion: **failure** (~4 min).
+
+Decisive log excerpts (ANSI/timestamps stripped), in order:
+
+## 1. Credential sniff — worked, secret never echoed
+```
+Detected credential mode: string (secret contents never shown)
+```
+→ `KAGGLE_API_TOKEN` is a raw access-token string (not legacy JSON); routed to the
+action's `api_token` input. The value was never printed.
+
+## 2. Kernel authenticated, pushed, and ran on GPU
+```
+Successfully installed ... kaggle-2.2.3 kagglesdk-0.1.34 ...
+Kernel version 1 successfully pushed.  Please check progress at
+  https://www.kaggle.com/code/mohidmakhdoomi/nextjs3dfg-webgl-probe
+... Current kernel status: nextjs3dfg-webgl-probe has status "KernelWorkerStatus.RUNNING"   (~3.5 min of polling)
+[2026-07-21T19:01:36] Current kernel status: nextjs3dfg-webgl-probe has status "KernelWorkerStatus.ERROR"
+```
+→ Auth + push + remote GPU execution all functioned. The kernel reached a
+terminal **ERROR** state.
+
+## 3. The action's result reporting is BROKEN — verdict never surfaced
+On kernel ERROR the action tries to dump the kernel log with
+`Get-Content $log | ConvertFrom-Json -AsHashtable | %{ $_['data'] }` and crashes:
+```
+Kernel log downloaded to .../nextjs3dfg-webgl-probe.log
+ConvertFrom-Json: ...
+  Conversion from JSON failed with error: Additional text encountered after
+  finished reading JSON content: ,. Path '', line 1, position 0.
+##[error]Process completed with exit code 1.
+```
+→ The kernel's stdout (nvidia-smi, Playwright install, `UNMASKED_RENDERER_WEBGL`,
+the probe VERDICT) was **never printed**. So this run cannot tell us whether the
+`ERROR` was the probe's intended `exit(1)` (software WebGL) or a genuine kernel
+crash — the answer is hidden behind the action's own defect.
+
+## Findings from run #1
+- ✅ **Feasibility of auth/push/run on Kaggle GPU: confirmed.** The sniff + pinned
+  action + private GPU kernel path works end-to-end.
+- ❌ **Reporting defect (confirmed, not theoretical):** `Frederisk/kaggle-action`
+  fails to render the kernel log on failure — the single most important output
+  (the WebGL verdict) is lost. Reinforces "crude/fragile reporting" as a reject
+  driver for any required-CI role.
+- ⏭ **Verdict still open** → probe v2 adds a structured `webgl_probe_result.json`
+  artifact + a workflow step that fetches `kaggle kernels output` directly,
+  bypassing the broken dump. Re-dispatch reads the real renderer.
+
+Full raw run log is available via `gh run view 29859449200 --log` if needed; it is
+not committed (88 KB of ANSI + poll spam).

--- a/experiments/42_kaggle_gpu_ci/kaggle_webgl_probe.py
+++ b/experiments/42_kaggle_gpu_ci/kaggle_webgl_probe.py
@@ -98,7 +98,7 @@ def main():
     print("=" * 72)
 
     # 1) Environment evidence (parallels the action's own nvidia-smi check).
-    sh(["bash", "-lc", "nvidia-smi -L || echo 'no nvidia-smi'"])
+    _, gpu_out = sh(["bash", "-lc", "nvidia-smi -L || echo 'no nvidia-smi'"])
     sh(["bash", "-lc", "cat /etc/os-release | head -3 || true"])
     sh(["bash", "-lc", "ls -1 /usr/lib/x86_64-linux-gnu/ | grep -iE 'egl|gles|gl\\.so|nvidia' || echo 'no GL/EGL vendor libs found'"])
     sh(["bash", "-lc", "which glxinfo eglinfo vulkaninfo 2>/dev/null || echo 'no gl diag tools'"])
@@ -144,9 +144,27 @@ def main():
             if entry.get("class") == "hardware" and hardware_hit is None:
                 hardware_hit = name
 
+    summary = {
+        "verdict": "hardware" if hardware_hit else "software_or_error",
+        "hardware_flag_set": hardware_hit,
+        "gpu": gpu_out.strip(),
+        "results": results,
+    }
+
+    # Write a structured artifact to the kernel working dir. Kaggle collects
+    # files written here as retrievable kernel OUTPUT — so `kaggle kernels
+    # output` fetches this verdict directly, independent of the action's
+    # (fragile) stdout-log parsing. This is the primary evidence channel.
+    try:
+        with open("webgl_probe_result.json", "w") as f:
+            json.dump(summary, f, indent=2, default=str)
+        print("Wrote webgl_probe_result.json (retrievable kernel output artifact).")
+    except Exception as e:  # noqa: BLE001
+        print(f"WARN: could not write result artifact: {e}")
+
     print("\n" + "=" * 72)
     print("PROBE RESULT (machine-readable):")
-    print(json.dumps(results, indent=2, default=str))
+    print(json.dumps(summary, indent=2, default=str))
     print("=" * 72)
 
     if hardware_hit:


### PR DESCRIPTION
## Stage-1 probe iteration — get the WebGL verdict despite the action's reporting bug

**Run #1** (`29859449200`) proved the path works but exposed a defect:
- ✅ Credential sniff → `mode=string`, secret never echoed; kernel authenticated, **pushed, and ran on a Kaggle T4 GPU**.
- ❌ On kernel `ERROR`, `Frederisk/kaggle-action`'s log dump **crashes** (`ConvertFrom-Json: Additional text encountered`), so the kernel stdout — the actual `UNMASKED_RENDERER_WEBGL` verdict — was never printed. (Evidence: `experiments/42_kaggle_gpu_ci/data/output/probe-run-1-evidence.md`.)

This is itself a finding (fragile reporting → reject driver for required CI). **v2** makes evidence self-sufficient:
- Probe writes a structured `webgl_probe_result.json` artifact (+ captures `nvidia-smi`).
- Workflow marks the action `continue-on-error` and adds `if: always()` steps that fetch `kaggle kernels output` **directly** (bypassing the broken dump) and set job status from the real hardware-vs-software verdict.

Scope unchanged: still `workflow_dispatch`-only, SHA-pinned `e6bafb6`, non-required, manual dispatch only. Required gate + `npm run validate` untouched.

Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)