### PR TITLE
[Experiment 42] Fix probe pin to playwright==1.61.0 (run #3 confirmed verified account)

### DIFF
--- a/codev/state/experiment-42_thread.md
+++ b/codev/state/experiment-42_thread.md
@@ -62,3 +62,12 @@ Run `29859449200` (~4 min) outcome — three facts, evidence saved to `data/outp
 - Probe writes a structured `webgl_probe_result.json` artifact (retrievable kernel output), plus captures nvidia-smi.
 - Workflow: `continue-on-error` on the action step + an `if: always()` step that runs `kaggle kernels output mohidmakhdoomi/nextjs3dfg-webgl-probe` directly and prints the result JSON + reconstructed stdout, then a Verdict step that sets job pass/fail from the actual `verdict` (hardware vs software). kaggle CLI + `~/.kaggle` creds persist from the action's earlier steps.
 - Plan: PR → merge (CI green) → re-dispatch → read the real renderer verdict. Within the architect's sanctioned "few manual retries."
+
+## 2026-07-21 — Probe run #2 (v2): ACCOUNT-LEVEL blocker found; architect verifying
+
+PR #46 merged (CI green); re-dispatched → run `29860830320`. v2 retrieval WORKED (fetched kernel stdout, bypassing the action bug). Verdict from the kernel stdout (evidence: `data/output/probe-run-2-evidence.md`):
+- ❌ **No internet**: `pip install playwright==1.61.1` → `Temporary failure in name resolution` (DNS) → probe crashed before writing the result artifact. Without egress, NOTHING in our stack can install (`npm ci`, browsers, `git clone`).
+- ❌ **No GPU**: `nvidia-smi: command not found`; only **Mesa software** GL libs present — despite `machine_shape=NvidiaTeslaT4`/`enable_gpu:true`.
+- **Root cause (diagnosed):** unverified Kaggle account → Kaggle silently disables BOTH internet and GPU (the action's README warns of exactly this). Both runs (#1, #2) failed at this same layer; the make-or-break WebGL question was never reached.
+- **Architect chose to phone-verify the account** (said "wait ~5 min"). Plan: wait, then re-dispatch the (already-merged v2) probe → this time expect internet+GPU present → finally read the hardware-vs-software `UNMASKED_RENDERER_WEBGL` verdict → then finalize adopt/defer/reject.
+- Standing reject drivers unchanged regardless of WebGL outcome: ToS on sustained CI use, queue/cold-start wall clock, the **confirmed** reporting defect, reproducibility-contract violation, Stage-2 config hard-gate. Sibling issues #41/#44 remain the credential-free alternative.

--- a/codev/state/experiment-42_thread.md
+++ b/codev/state/experiment-42_thread.md
@@ -71,3 +71,11 @@ PR #46 merged (CI green); re-dispatched → run `29860830320`. v2 retrieval WORK
 - **Root cause (diagnosed):** unverified Kaggle account → Kaggle silently disables BOTH internet and GPU (the action's README warns of exactly this). Both runs (#1, #2) failed at this same layer; the make-or-break WebGL question was never reached.
 - **Architect chose to phone-verify the account** (said "wait ~5 min"). Plan: wait, then re-dispatch the (already-merged v2) probe → this time expect internet+GPU present → finally read the hardware-vs-software `UNMASKED_RENDERER_WEBGL` verdict → then finalize adopt/defer/reject.
 - Standing reject drivers unchanged regardless of WebGL outcome: ToS on sustained CI use, queue/cold-start wall clock, the **confirmed** reporting defect, reproducibility-contract violation, Stage-2 config hard-gate. Sibling issues #41/#44 remain the credential-free alternative.
+
+## 2026-07-21 — Run #3 (verified account): diagnosis CONFIRMED; trivial probe bug fixed
+
+Architect phone-verified the account; waited ~5.5 min; re-dispatched → run `29861849190` (evidence: `data/output/probe-run-3-evidence.md`).
+- ✅ **GPU now present**: `nvidia-smi` → 2× Tesla T4. ✅ **Internet now works**: pip reached PyPI. So the phone-verification diagnosis was correct — account layer unblocked.
+- ❌ New trivial blocker (my bug): `playwright==1.61.1` has **no Python distribution** (Python `playwright` 1.61 line maxes at `1.61.0`; JS/Python patch numbers diverge). pip errored → probe exited before installing Chromium → still no artifact.
+- **Fixed**: pin `playwright==1.61.0` (same 1.61 Chromium as JS `@playwright/test@1.61.1`) + made browser-install non-fatal so the artifact is always written. PR → merge → re-dispatch (run #4).
+- **Crux still ahead**: kernel GL userspace is **Mesa-only** (no NVIDIA EGL/GL vendor driver) even with the T4 present → strong prior that Chromium WebGL still falls back to **llvmpipe software**, not the GPU. Run #4 measures it directly.

--- a/experiments/42_kaggle_gpu_ci/data/output/probe-run-2-evidence.md
+++ b/experiments/42_kaggle_gpu_ci/data/output/probe-run-2-evidence.md
@@ -1,0 +1,63 @@
+# Probe run #2 — evidence (GitHub Actions run 29860830320)
+
+Workflow: `kaggle-gpu-spike.yml` @ probe **v2** (robust retrieval) · dispatched
+2026-07-21 19:16 UTC · `machine_shape=NvidiaTeslaT4` · job conclusion: **failure**
+(~4.5 min). The v2 retrieval bypassed the action's broken log dump and
+successfully fetched the kernel's stdout — so this run reveals the real cause.
+
+## Reconstructed kernel stdout (verbatim, key parts)
+
+```
+Experiment 42 — Kaggle GPU WebGL probe
+
+$ bash -lc nvidia-smi -L || echo 'no nvidia-smi'
+bash: line 1: nvidia-smi: command not found
+no nvidia-smi
+
+$ bash -lc cat /etc/os-release | head -3 || true
+PRETTY_NAME="Ubuntu 22.04.5 LTS"
+
+$ ... ls /usr/lib/.../ egl|gles|gl.so|nvidia ...
+libEGL_mesa.so.0        libGLESv2.so.2     libGL.so.1
+libEGL.so.1             libOpenGL.so.0     libwayland-egl.so.1
+   # ^ Mesa SOFTWARE GL only — NO NVIDIA/EGL vendor driver present
+
+$ /usr/bin/python3 -m pip install --quiet playwright==1.61.1
+WARNING: Retrying ... after connection broken by 'NewConnectionError(...
+  Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/playwright/
+   # ^ repeated 5x
+ERROR: Could not find a version that satisfies the requirement playwright==1.61.1 (from versions: none)
+ERROR: No matching distribution found for playwright==1.61.1
+command failed (1): /usr/bin/python3 -m pip install --quiet playwright==1.61.1
+```
+
+The probe then raised `SystemExit` (pip `check=True`) → kernel ended `ERROR`
+**before** writing `webgl_probe_result.json`, so the retrieval reported
+"(no result artifact)". The v2 log-retrieval channel itself worked correctly.
+
+## What this proves — two hard blockers, one likely root cause
+
+1. **No internet in the kernel.** `enable_internet: true` was requested, yet DNS
+   resolution fails → `pip` cannot reach PyPI. Without egress the kernel cannot
+   `pip install`, `npm ci`, download Playwright browsers, or even `git clone` our
+   repo. **Our stack cannot run at all.**
+2. **No GPU in the kernel.** `nvidia-smi` is absent and only **Mesa software** GL
+   libraries are present, despite `machine_shape=NvidiaTeslaT4` /
+   `enable_gpu: true`. Any WebGL here would be **llvmpipe/Mesa software** — the
+   same software-render class we already have on GitHub runners. **Zero benefit.**
+3. **Most likely root cause: the Kaggle account is not phone-verified.** Kaggle
+   silently disables **both** internet and GPU for unverified accounts — the
+   action's own README warns of exactly this ("kaggle may require you to use your
+   mobile phone number… network unavailable or GPU unavailable… kaggle restricts
+   unauthenticated users"). The simultaneous loss of internet **and** GPU is that
+   signature. (Secondary possibility: the metadata flags weren't applied to the
+   commit run — less likely given both were lost together.)
+
+## Consequence for the experiment
+
+The make-or-break WebGL question could **not** be reached: a more fundamental
+account-level blocker stops the stack from installing. Both live runs (#1, #2)
+failed at this same layer. **Precise unblock condition:** phone-verify the Kaggle
+account behind `KAGGLE_API_TOKEN`, confirm a kernel then actually receives
+internet + a GPU (`nvidia-smi` present), and only then can the probe test whether
+Chromium obtains a hardware `UNMASKED_RENDERER_WEBGL`.

--- a/experiments/42_kaggle_gpu_ci/data/output/probe-run-3-evidence.md
+++ b/experiments/42_kaggle_gpu_ci/data/output/probe-run-3-evidence.md
@@ -1,0 +1,44 @@
+# Probe run #3 — evidence (GitHub Actions run 29861849190)
+
+Workflow: `kaggle-gpu-spike.yml` @ probe v2 · dispatched 2026-07-21 ~19:35 UTC
+(after the Kaggle account was phone-verified) · `machine_shape=NvidiaTeslaT4` ·
+job conclusion: **failure** (~1 min) · verdict artifact: still none, but for a new
+(trivial, now-fixed) reason.
+
+## Verification worked — the account-layer blocker is gone
+
+```
+$ nvidia-smi -L
+GPU 0: Tesla T4 (UUID: GPU-41bdf1f6-...)
+GPU 1: Tesla T4 (UUID: GPU-bde42e00-...)          # ← GPU now present (was absent in run #2)
+
+$ pip install --quiet playwright==1.61.0           # internet now works:
+ERROR: Could not find a version that satisfies the requirement playwright==1.61.1
+  (from versions: 1.9.0, ... , 1.60.0, 1.61.0)     # ← pip REACHED PyPI and listed versions
+```
+
+Both prior blockers are resolved by phone verification:
+- ✅ **GPU present:** 2× Tesla T4 (`nvidia-smi` works).
+- ✅ **Internet present:** `pip` reached PyPI (it enumerated available versions) —
+  contrast run #2's `Temporary failure in name resolution`.
+
+## New, trivial blocker (my bug) — now fixed
+
+The pin `playwright==1.61.1` has **no Python distribution**: the Python `playwright`
+package's 1.61 line tops out at **1.61.0** (JS `@playwright/test` and the Python
+package diverge at the patch level; there is no Python 1.61.1). pip therefore
+errored `No matching distribution found`, and the probe (pip `check=True`) exited
+before installing Chromium — hence still "no result artifact."
+
+**Fix (committed):** pin the Python package to `playwright==1.61.0` — the same 1.61
+Chromium line as our JS `@playwright/test@1.61.1` — and make the browser-install
+steps non-fatal so a launch failure can never again pre-empt the result artifact.
+
+## Note on GL libraries (still relevant for the WebGL test)
+
+Even with the GPU present, the kernel's userspace GL is **Mesa only**
+(`libEGL_mesa`, `libGL`, `libGLESv2`) — **no NVIDIA GL/EGL vendor driver** is
+installed. This is the crux of the make-or-break question: without an NVIDIA
+EGL/GL ICD (or a working Vulkan/ANGLE path to the T4), headless Chromium will
+likely still resolve WebGL to **Mesa software (llvmpipe)**, not the Tesla T4.
+Run #4 measures this directly.

--- a/experiments/42_kaggle_gpu_ci/kaggle_webgl_probe.py
+++ b/experiments/42_kaggle_gpu_ci/kaggle_webgl_probe.py
@@ -103,17 +103,21 @@ def main():
     sh(["bash", "-lc", "ls -1 /usr/lib/x86_64-linux-gnu/ | grep -iE 'egl|gles|gl\\.so|nvidia' || echo 'no GL/EGL vendor libs found'"])
     sh(["bash", "-lc", "which glxinfo eglinfo vulkaninfo 2>/dev/null || echo 'no gl diag tools'"])
 
-    # 2) Install Playwright + Chromium, version-PINNED to our repo's
-    #    @playwright/test (1.61.1) so the probe exercises the SAME Chromium build
-    #    we ship — otherwise a newer browser could report a different WebGL
-    #    renderer/flag behavior than our actual stack, invalidating the evidence.
-    sh([sys.executable, "-m", "pip", "install", "--quiet", "playwright==1.61.1"], check=True)
-    # --with-deps needs apt (root). Kaggle kernels run as root; if this is flaky,
-    # fall back to a plain install and let missing libs surface in the launch.
+    # 2) Install Playwright (Python), pinned to the SAME 1.61 line as our repo's
+    #    @playwright/test@1.61.1 so the probe exercises the same Chromium build.
+    #    NOTE: JS and Python patch numbers diverge — the Python `playwright`
+    #    package has NO 1.61.1 (its 1.61 line tops out at 1.61.0), and 1.61.x
+    #    ships the same Chromium revision, so 1.61.0 is the correct Python
+    #    counterpart. (Confirmed empirically: run #3 showed pip max = 1.61.0.)
+    sh([sys.executable, "-m", "pip", "install", "--quiet", "playwright==1.61.0"], check=True)
+    # Browser + system deps. --with-deps needs apt (root; Kaggle kernels are
+    # root). Keep ALL browser-install steps NON-FATAL so we always reach the
+    # probe loop and always write the result artifact — a launch failure then
+    # surfaces per-flag-set as class=error rather than aborting before evidence.
     code, _ = sh(["python", "-m", "playwright", "install", "--with-deps", "chromium"])
     if code != 0:
-        print("WARN: 'install --with-deps' failed; retrying without deps", flush=True)
-        sh(["python", "-m", "playwright", "install", "chromium"], check=True)
+        print("WARN: 'install --with-deps' failed; retrying browser-only", flush=True)
+        sh(["python", "-m", "playwright", "install", "chromium"])  # non-fatal
 
     from playwright.sync_api import sync_playwright  # noqa: E402
 

--- a/experiments/42_kaggle_gpu_ci/notes.md
+++ b/experiments/42_kaggle_gpu_ci/notes.md
@@ -1,6 +1,6 @@
 # Experiment 42: kaggle-action for free Kaggle GPU CI compute
 
-**Status**: In Progress — **live runs #1 & #2 both blocked at the account layer (kernel got no internet + no GPU → stack can't install); root cause diagnosed as an unverified Kaggle account.** Architect is phone‑verifying the account (2026‑07‑21 ~19:2x); re‑dispatching the probe afterward to finally test whether Chromium gets a hardware `UNMASKED_RENDERER_WEBGL`. Disposition deferred until that verified run. (Note: even a positive WebGL result would not make this a *required*‑gate candidate — the ToS/wall‑clock/reporting‑defect/reproducibility drivers still apply; the verified run decides whether even a narrow non‑required lane has any merit.)
+**Status**: In Progress — **account verification CONFIRMED the diagnosis: run #3 (verified account) got 2× Tesla T4 GPU + working internet.** It then exposed a probe bug (Python `playwright` has no `1.61.1`; its 1.61 line tops out at `1.61.0`), now fixed. Re‑dispatching (run #4) to finally reach the hardware‑WebGL test. Disposition still deferred to that run. (Even a positive WebGL result would not make this a *required*‑gate candidate — ToS/wall‑clock/reporting‑defect/reproducibility drivers stand; the verified run decides whether a narrow non‑required lane has any merit.)
 
 **Date**: 2026-07-21
 

--- a/experiments/42_kaggle_gpu_ci/notes.md
+++ b/experiments/42_kaggle_gpu_ci/notes.md
@@ -1,7 +1,6 @@
 # Experiment 42: kaggle-action for free Kaggle GPU CI compute
 
-**Status**: In Progress — **design + security audit complete; architect GO on all 3 asks (issue #42 decision record, 2026‑07‑21); live Stage‑1 probe pending PR merge → manual dispatch.**
-**Preliminary disposition (pre‑probe)**: leaning **DEFER / REJECT for the required‑CI framing**; at most a *non‑required, ToS‑risky GPU‑qualification lane* whose sole benefit (real hardware WebGL) is still **unproven** and rides entirely on the Stage‑1 probe.
+**Status**: In Progress — **live runs #1 & #2 both blocked at the account layer (kernel got no internet + no GPU → stack can't install); root cause diagnosed as an unverified Kaggle account.** Architect is phone‑verifying the account (2026‑07‑21 ~19:2x); re‑dispatching the probe afterward to finally test whether Chromium gets a hardware `UNMASKED_RENDERER_WEBGL`. Disposition deferred until that verified run. (Note: even a positive WebGL result would not make this a *required*‑gate candidate — the ToS/wall‑clock/reporting‑defect/reproducibility drivers still apply; the verified run decides whether even a narrow non‑required lane has any merit.)
 
 **Date**: 2026-07-21
 


### PR DESCRIPTION
## Run #3: phone verification worked — now a one-line probe fix to reach the WebGL test

**Run #3** (`29861849190`, after the account was phone-verified) confirmed the root-cause diagnosis:
- ✅ **GPU present:** `nvidia-smi` → 2× Tesla T4.
- ✅ **Internet present:** pip reached PyPI (enumerated versions) — vs run #2's DNS failure.

It then exposed a trivial bug of mine: **the Python `playwright` package has no `1.61.1`** (its 1.61 line tops out at `1.61.0`; JS `@playwright/test` and the Python package diverge at the patch level). pip errored `No matching distribution`, so the probe exited before installing Chromium.

**Fix:** pin Python `playwright==1.61.0` (same 1.61 Chromium line as our JS `@playwright/test@1.61.1`) and make browser-install steps non-fatal so a launch failure can never again pre-empt the `webgl_probe_result.json` artifact.

Scope unchanged: probe script only; workflow still `workflow_dispatch`-only, SHA-pinned, non-required. Evidence: `experiments/42_kaggle_gpu_ci/data/output/probe-run-3-evidence.md`.

> Note: the kernel's GL userspace is Mesa-only (no NVIDIA vendor driver), so the hardware-WebGL question is still genuinely open — run #4 measures it directly.

Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)