### PR TITLE
[Spec 44] Opt-in native-GPU local e2e lane (WSL2 Mesa d3d12 / hardware WebGL, software fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /test-results/
 /blob-report/
 /all-blob-reports/
+# opt-in GPU lane probe transcripts (scripts/e2e-gpu-lane.mjs); kept out of
+# test-results/ because Playwright wipes that dir at suite start
+/gpu-lane-logs/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ npm run browser:install
 | `npm run build` | Create the production Next.js build. |
 | `npm run start` | Start a previously built production application. |
 | `npm run test:smoke` | Build, start the production server, and run the Chromium and Firefox WebGL smoke. |
+| `npm run test:e2e:gpu` | Opt-in: run the full Chromium e2e suite on verified hardware WebGL when a GPU adapter is usable, with loud software fallback otherwise. **Not part of the gate.** See [Opt-in native-GPU e2e lane](#opt-in-native-gpu-e2e-lane). |
 | `npm run validate` | Fail fast through lint, typecheck, and the `test:smoke` browser suite (build plus the Chromium + Firefox WebGL smoke). |
 | `npm run audit:full` | Report findings in the complete dependency graph. |
 | `npm run audit:production` | Report findings with development dependencies omitted. |
@@ -133,3 +134,101 @@ Qualification").
 On every run it uploads the two audit artifacts. When Playwright produces
 diagnostics, the workflow also uploads the merged `playwright-report` and the
 per-shard `playwright-test-results-<n>` artifacts.
+
+## Opt-in native-GPU e2e lane
+
+```sh
+npm run test:e2e:gpu
+```
+
+An **opt-in, local-only** lane (issue #44) that runs the *full* Chromium e2e
+suite on **genuine hardware-accelerated WebGL** instead of SwiftShader. It is
+additional tooling and evidence, **never the green gate**: `npm run validate`,
+`test:smoke`, CI, and every committed test are unchanged and stay on the
+qualified SwiftShader serial path. Nothing in the repo behaves differently
+unless you invoke the lane.
+
+What one invocation does (`scripts/e2e-gpu-lane.mjs`):
+
+1. **Probes the host** and picks a hardware recipe from an evidence-ordered
+   candidate list (WSL2 Mesa d3d12 for any vendor adapter; ANGLE-Vulkan/GL on
+   native Linux). Unusable candidates are skipped with a one-line cause +
+   remedy diagnostic.
+2. **Verifies the renderer before trusting anything**: launches the repo's own
+   Playwright Chromium under the candidate flags and reads
+   `UNMASKED_RENDERER_WEBGL`; the string must not match
+   SwiftShader/llvmpipe/software. Failed candidates fall through to the next
+   (per-candidate transcripts land in `gpu-lane-logs/`).
+3. **Runs the suite** — `npm run build`, then `npx playwright test` with
+   `E2E_ENGINES=chromium` and the verified flags injected through the
+   config's `PW_CHROMIUM_ARGS` hook. Same production server, same
+   `workers: 1`, same `retries: 0`, same timeouts as the normal local suite.
+4. **Reports honestly.** The run ends with a machine-greppable block:
+
+   ```
+   === E2E GPU LANE REPORT ===
+   mode: hardware | software-fallback
+   renderer: <verbatim UNMASKED_RENDERER_WEBGL>
+   engine: chromium
+   suite: pass | fail (exit n)
+   wall-clock: <total>s (build <n>s, suite <n>s)
+   ```
+
+   `mode: hardware` is only ever printed after the deny-list assertion
+   passed. When no adapter is usable the lane still runs the suite under the
+   default SwiftShader args with an unmissable `SOFTWARE FALLBACK` banner at
+   the start and before the report — a fallback run can never be mistaken for
+   hardware evidence. The suite's own pass/fail is the lane's exit code.
+
+Measured on the qualification host (WSL2, RTX 3080): hardware suite ≈ 97 s vs
+≈ 594 s for the same suite under SwiftShader — about **6× faster**, with the
+SwiftShader-only hover/timing flake class absent.
+
+### Env controls and flags
+
+| Control | Effect |
+| --- | --- |
+| `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware candidates; run the software-fallback path deterministically (how the fallback is exercised on a GPU-capable machine). |
+| `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when no candidate verifies — use for hardware-evidence runs so a silent fallback can't pollute results. |
+| `--probe-only` | Probe + verify + report without building or running the suite. |
+| `--mode=headed\|headless` | Override the run mode. Default is **headless** (proven equivalent; see below). Headed needs WSLg/X (`DISPLAY`). |
+| `--candidate=<id>` / `--channel=<name>` | Probe a specific recipe / a specific Playwright channel (`--channel` is probe-only). Used by the FR5 matrix. |
+
+Pass flags through npm like `npm run test:e2e:gpu -- --probe-only`.
+
+### WSL2 Mesa d3d12 recipe (what the lane automates)
+
+Proven on WSL2 + RTX 3080 (PR #43, then productized here). The lane detects
+`/dev/dxg` + `/usr/lib/wsl/lib` and injects, per spawn (never into your
+shell):
+
+```sh
+GALLIUM_DRIVER=d3d12                       # select Mesa's D3D12 gallium driver
+LD_LIBRARY_PATH=/usr/lib/wsl/lib:$LD_LIBRARY_PATH   # WSL GPU driver libs (libd3d12.so, libdxcore.so)
+# Chromium flags (via PW_CHROMIUM_ARGS):
+--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox
+```
+
+`--use-angle=gl-egl` is a proven alternate backend (OpenGL ES 3.1);
+ANGLE-Vulkan is a known llvmpipe dead end under WSL2 and is only tried on
+native Linux. Optional multi-GPU disambiguators pass through if you export
+them: `MESA_D3D12_DEFAULT_ADAPTER_NAME=<vendor>` (pick the adapter) and
+`LIBGL_ALWAYS_SOFTWARE=false`. The sandbox/blocklist relaxations above exist
+**only** inside this explicitly invoked lane — never in default launch args or
+CI.
+
+**Headless works** (2026-07 investigation): default Playwright headless
+(headless shell), new headless (`--channel=chromium`), and headed WSLg all
+reach the adapter with identical renderer strings and identical suite timing —
+the d3d12 path needs no display, so the lane defaults to headless and works on
+display-less WSL2 hosts. Evidence, including the 4-cell matrix and repeat-run
+stability results, lives in `codev/reviews/44-add-an-opt-in-native-gpu-local.md`.
+
+### Status and sequencing
+
+- Renderer strings and timings above are **evidence dated 2026-07** on one
+  host (Mesa 26.0.3, driver 581.29); driver updates can shift them. The lane
+  probes rather than assumes, and falls back loudly.
+- `workers` stays `1` in the lane, matching the qualified suite. Raising
+  parallelism on top of this lane is issue #41's qualification, sequenced
+  after this one — do not raise it ad hoc.

--- a/codev/plans/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/plans/44-add-an-opt-in-native-gpu-local.md
@@ -1,0 +1,502 @@
+# Plan: Add an Opt-In Native-GPU Local E2E Lane (Hardware WebGL with Software Fallback)
+
+## Metadata
+- **ID**: plan-2026-07-21-add-an-opt-in-native-gpu-local
+- **Status**: draft
+- **Specification**: [codev/specs/44-add-an-opt-in-native-gpu-local.md](../specs/44-add-an-opt-in-native-gpu-local.md)
+- **Created**: 2026-07-21
+
+## Executive Summary
+
+Implements the spec's selected **Approach C**: a Node wrapper script
+(`scripts/e2e-gpu-lane.mjs`, exposed as `npm run test:e2e:gpu`) layered over the
+already-merged, already-proven-default-inert `PW_CHROMIUM_ARGS` hook in
+`playwright.config.ts`. The wrapper probes the host, selects a hardware recipe
+from a data-driven candidate list, verifies the effective
+`UNMASKED_RENDERER_WEBGL` through the repo's own Playwright Chromium *before*
+trusting anything, runs the full Chromium e2e suite (build → production server →
+suite, mirroring `test:smoke` semantics), and ends with a machine-greppable
+mode/renderer/wall-clock report. Exhausted or absent hardware ⇒ loud software
+fallback (never a hard failure by default); `E2E_GPU_REQUIRE=1` hard-fails for
+qualification integrity; `E2E_GPU_FORCE_FALLBACK=1` deterministically exercises
+the fallback path on the GPU-capable host.
+
+The canonical SwiftShader serial gate is untouched by construction: no committed
+test, no CI file, and no default config behavior changes. The only touched
+shared file is `playwright.config.ts`, and only its **comment block** (the spec's
+NFR requires the "#44 will consume this" note to become "the lane consumes
+this"); default-inertness is proven by a config-load check with lane env unset.
+
+Four phases isolate the pure-logic core (unit-testable everywhere, GPU-free)
+from suite execution, from the bounded FR5 headless investigation, and from the
+FR8/FR9 qualification-and-documentation work — so each commit is small,
+independently testable, and independently revertible.
+
+Evidence base this plan builds on (no rediscovery needed):
+- WSL2 d3d12 headed recipe proven end-to-end on this host (bugfix-22 thread):
+  `GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`, `DISPLAY=:0`,
+  args `--use-gl=angle --use-angle=gl --ignore-gpu-blocklist
+  --disable-gpu-sandbox`, headed ⇒ `ANGLE (… D3D12 (NVIDIA GeForce RTX 3080),
+  OpenGL 4.6)`. `--use-angle=gl-egl` also reached hardware (OpenGL ES 3.1);
+  `--use-angle=vulkan` fell back to llvmpipe **on WSL2**.
+- Native-Linux ANGLE-Vulkan recipe proven on a Tesla T4 (experiment 42 run #5).
+- The pre-flight renderer-probe pattern already designed in
+  `experiments/42_kaggle_gpu_ci/kaggle_e2e_runner.py` (launch repo Chromium,
+  read `UNMASKED_RENDERER_WEBGL`, deny-list classify).
+
+## Success Metrics
+
+Copied from the spec's acceptance scenarios and made implementation-checkable:
+
+- [ ] `npm run test:e2e:gpu` on this WSL2/RTX 3080 host: probe selects the d3d12
+      recipe, renderer logged and deny-list-asserted (≠ SwiftShader/llvmpipe),
+      full Chromium suite runs, final greppable report says hardware + renderer
+      + wall-clock (Scenario 1, FR1–FR4, FR10).
+- [ ] `E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu`: loud fallback notice,
+      suite runs under default SwiftShader args, report unmistakably says
+      software-fallback, exit code = suite result (Scenario 2, FR2/FR3).
+- [ ] `E2E_GPU_REQUIRE=1` with no verifiable hardware ⇒ non-zero exit with
+      per-candidate log (FR2/FR3 strict switch).
+- [ ] Skipped/failed candidates each produce a one-line cause + remedy
+      diagnostic covering the FR11 enumerated cases.
+- [ ] FR5 headless matrix (≤4 probes) executed and conclusively recorded;
+      lane default set accordingly.
+- [ ] FR8: 3+ consecutive full-suite hardware runs under `E2E_GPU_REQUIRE=1`
+      (per-test results, renderer strings, wall-clocks, retries policy) + one
+      forced-fallback full run (doubles as the contemporaneous SwiftShader
+      serial baseline wall-clock) recorded in review artifacts.
+- [ ] FR6: `.github/workflows/validation.yml` and the `validate`/`test:smoke`
+      script chain absent from the PR diff; `playwright.config.ts` diff is
+      comment-only; config-load check with lane env unset shows chromium launch
+      args exactly `["--use-angle=swiftshader","--enable-unsafe-swiftshader"]`
+      and unchanged workers/retries/timeout/reporter/webServer; PR CI fully
+      green under SwiftShader.
+- [ ] FR7: new unit tests (`tests/gpu-lane.test.mjs`) pass with no GPU, no
+      browser, no lane env — green on CI runners via the existing `npm test`
+      glob.
+- [ ] FR9: README documents the lane (command, hardware/fallback semantics,
+      WSL2 Mesa d3d12 recipe incl. optional `MESA_D3D12_DEFAULT_ADAPTER_NAME`/
+      `LIBGL_ALWAYS_SOFTWARE` disambiguators, FR5 outcome, non-gate status, #41
+      sequencing note).
+- [ ] No dependency/lockfile/toolchain movement; `package.json` delta is the
+      lane script entry only.
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "lane_wrapper_core", "title": "Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests"},
+    {"id": "full_lane_and_inertness_proof", "title": "Full-suite lane command, npm script, comment sync, default-inert proof"},
+    {"id": "headless_investigation", "title": "Bounded headless-vs-headed investigation (FR5) and lane default"},
+    {"id": "qualification_evidence_and_docs", "title": "Repeat-run qualification evidence (FR8) and documentation (FR9)"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: `lane_wrapper_core` — probe engine, candidate data, deterministic policy, unit tests
+**Dependencies**: None
+
+#### Objectives
+- Build the lane's brain as pure, unit-testable logic plus a thin probe
+  executable: host probing, data-driven candidate selection, the FR3
+  deterministic candidate lifecycle (prereq-skip → verify-fail → exhaustion →
+  fallback), env controls, FR11 diagnostics, and renderer classification —
+  all runnable standalone via a probe-only mode before the suite wiring exists.
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs` — ESM, Node built-ins + `@playwright/test`
+      only; no side effects on import (CLI entry guarded), pure functions
+      exported for tests.
+- [ ] Probe-only mode: `node scripts/e2e-gpu-lane.mjs --probe-only` runs
+      probe → candidate selection → renderer verification → greppable
+      mode/renderer report, without building or running the suite.
+- [ ] `tests/gpu-lane.test.mjs` — unit tests of the pure logic (picked up
+      automatically by the existing `npm test` glob `tests/*.test.mjs`).
+
+#### Implementation Details
+
+**Candidate list (data, ordered by evidence strength)** — each entry:
+`{id, prereqs, env, flags, mode, diagnostics}`:
+
+1. `wsl2-d3d12-angle-gl` (proven, bugfix-22): prereqs `/dev/dxg` exists,
+   `/usr/lib/wsl/lib` exists, and for headed mode a usable display (`DISPLAY`
+   set or `/mnt/wslg/.X11-unix` present). Env: `GALLIUM_DRIVER=d3d12`,
+   `LD_LIBRARY_PATH=/usr/lib/wsl/lib` (prepended to any existing value);
+   pass through operator-set `MESA_D3D12_DEFAULT_ADAPTER_NAME` /
+   `LIBGL_ALWAYS_SOFTWARE` untouched. Flags: `--use-gl=angle --use-angle=gl
+   --ignore-gpu-blocklist --disable-gpu-sandbox`. Mode: headed (Phase 3 may
+   flip to headless per FR5).
+2. `wsl2-d3d12-angle-gl-egl` (proven alternate, OpenGL ES 3.1): same prereqs/
+   env, `--use-angle=gl-egl` variant.
+3. `native-linux-angle-vulkan` (proven on T4, exp42 run #5): prereq: no
+   `/dev/dxg` (on WSL2 Vulkan is a known llvmpipe dead end — skip, don't
+   waste a probe). Flags: `--use-gl=angle --use-angle=vulkan
+   --enable-features=Vulkan --ignore-gpu-blocklist`.
+4. `native-linux-angle-gl`: same prereq, `--use-angle=gl` variant.
+
+Adding a future recipe = appending one data entry (spec FR2's extensibility
+requirement).
+
+**Renderer probe** (the exp42 preflight pattern, in JS): import `chromium`
+from `@playwright/test`; `launch({headless, args: candidate.flags, env})`;
+open a blank page; evaluate a canvas `webgl` context +
+`WEBGL_debug_renderer_info` → `UNMASKED_RENDERER_WEBGL` (fall back to
+`gl.RENDERER` if the extension is missing); bounded per-candidate timeout
+(30 s launch-to-verdict); crash/timeout/no-context ⇒ failed candidate.
+Classification deny-list (case-insensitive): `swiftshader`, `llvmpipe`,
+`software`, `microsoft basic` ⇒ software; anything else with a non-empty
+string ⇒ hardware. Full string always recorded verbatim.
+
+**Deterministic lifecycle** (FR3, exactly as specced): prereq check skips with
+a one-line FR11 diagnostic (cause + remedy: `DISPLAY`/WSLg absent,
+`/usr/lib/wsl/lib` missing, etc.); verification failure logs the string and
+moves on (d3d12→llvmpipe gets the "Mesa d3d12 driver missing/not selected"
+hint); exhaustion ⇒ fallback marker returned to the caller. Env controls read
+once at entry: `E2E_GPU_FORCE_FALLBACK=1` short-circuits to fallback before
+any probe; `E2E_GPU_REQUIRE=1` converts exhaustion into exit 1 with the
+per-candidate summary. Lane-internal errors (malformed invocation, probe
+harness bugs) throw and exit non-zero in all modes.
+
+**Unit test targets** (all pure, no browser, no GPU, no lane env — FR7):
+renderer classification (hardware/software/empty cases incl. the proven ANGLE
+D3D12, ANGLE NVIDIA, SwiftShader, llvmpipe strings); candidate prereq
+filtering against an injected fake fs/env view (WSL2 host shape, native-Linux
+shape, GPU-less shape, headed-prereq-missing shape); lifecycle policy
+(skip vs fail vs exhaustion; force-fallback short-circuit; require-mode exit
+signaling); FR11 diagnostic line selection; greppable report formatting
+(exact `mode:`/`renderer:` line contract). Probe/launch functions are
+injected so tests never touch Playwright.
+
+#### Acceptance Criteria
+- [ ] `npm test` green (new file included by the glob) with no GPU/lane env.
+- [ ] `node scripts/e2e-gpu-lane.mjs --probe-only` on this host reports
+      hardware + an ANGLE D3D12 renderer string.
+- [ ] `E2E_GPU_FORCE_FALLBACK=1 … --probe-only` reports software-fallback
+      without launching any probe.
+- [ ] `E2E_GPU_REQUIRE=1` + an impossible candidate set exits non-zero with
+      the per-candidate log.
+- [ ] `npm run lint` and `npm run typecheck` clean.
+
+#### Test Plan
+- **Unit**: as above (this phase's main deliverable).
+- **Manual**: probe-only runs on this host — normal, force-fallback, and
+  require-mode variants; record renderer strings.
+
+#### Rollback Strategy
+Pure addition (2 new files); revert the commit.
+
+#### Risks
+- **Risk**: probe launch hangs under a broken driver combo.
+  - **Mitigation**: hard per-candidate timeout; timeout = failed candidate
+    with FR11 diagnostic (never wedges the lane).
+
+---
+
+### Phase 2: `full_lane_and_inertness_proof` — full-suite lane command, npm script, comment sync, default-inert proof
+**Dependencies**: Phase 1
+
+#### Objectives
+- Wire the verified recipe into a full end-to-end lane run and prove the
+  canonical gate untouched (FR1, FR4, FR6, FR10).
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs` extended: build + suite execution + final
+      report.
+- [ ] `package.json`: add `"test:e2e:gpu": "node scripts/e2e-gpu-lane.mjs"`
+      (the only manifest delta; no dependency/engines/lockfile movement).
+- [ ] `playwright.config.ts`: comment-only update — the hook's "retained to
+      serve issue #44" paragraph now describes the shipped lane (spec NFR
+      Maintainability). No code tokens change.
+- [ ] FR6 default-inert evidence recorded (procedure below).
+
+#### Implementation Details
+
+**Suite execution** (delegation over duplication): after a candidate passes
+verification, the wrapper runs `npm run build`, then spawns
+`npx playwright test` with env `{E2E_ENGINES: "chromium",
+PW_CHROMIUM_ARGS: candidate.flags.join(" "), ...candidate.env}` plus
+`--headed` when the recipe mode is headed (Playwright CLI flag — no config
+change needed for headed mode). The production server comes from the
+config's own `webServer` block, exactly as `test:smoke`. Fallback mode runs
+the identical build+test flow with **no** lane env (`PW_CHROMIUM_ARGS`
+unset ⇒ default SwiftShader args) after printing the loud warning. Suite
+exit code is preserved as the lane exit code in both modes; wall-clock
+captured per stage (build, suite) and total. `workers`/`retries` are not
+touched anywhere (config defaults: `workers: 1`, local `retries: 0`).
+
+Note: recipe env (`GALLIUM_DRIVER`, `LD_LIBRARY_PATH`) is applied to the
+spawned `playwright test` process (the exp42 runner approach), so the
+browser inherits it. The webServer child inherits it too — accepted:
+`/usr/lib/wsl/lib` contains only D3D12/DXCore GPU libraries, no libc-class
+overrides; the bugfix-22 runs already exercised Chromium+server under this
+env on this host. If Phase 2 testing surfaces any server-side interference,
+fall back to scoping env injection to the browser (documented decision).
+
+**FR10 report contract** (final lines, machine-greppable, stable keys):
+
+```
+=== E2E GPU LANE REPORT ===
+mode: hardware | software-fallback
+renderer: <verbatim UNMASKED_RENDERER_WEBGL>
+engine: chromium
+suite: pass | fail (exit <n>)
+wall-clock: <seconds>s (build <s>s, suite <s>s)
+```
+
+**FR6 proof procedure** (evidence recorded in the review artifact):
+1. `git diff main -- playwright.config.ts` — comment-only (no code tokens).
+2. `.github/workflows/validation.yml`, `validate`/`test:smoke` entries: absent
+   from `git diff main --stat` entirely.
+3. Config-load check with lane env unset (scratchpad script, output recorded
+   verbatim): load the config via `node --experimental-strip-types` (the file
+   is type-annotation-free TS) and assert chromium `launchOptions.args`
+   equals exactly `["--use-angle=swiftshader","--enable-unsafe-swiftshader"]`,
+   `workers === 1`, `retries === 0` (non-CI), `timeout === 120000` (non-CI),
+   reporter/webServer shapes unchanged; repeat with `PW_CHROMIUM_ARGS` set to
+   confirm the hook path still substitutes (sanity). Same check run against
+   `main`'s config for value-equality.
+4. PR CI (quality + 4 SwiftShader shards + gate) green — final proof point,
+   collected at Review.
+
+#### Acceptance Criteria
+- [ ] `npm run test:e2e:gpu` on this host: hardware mode, full suite executes,
+      report emitted, exit code = suite result.
+- [ ] `E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu`: full suite under
+      SwiftShader with loud warnings + software-fallback report.
+- [ ] FR6 items 1–3 recorded clean.
+- [ ] `npm test`, `npm run lint`, `npm run typecheck` green; no lockfile diff.
+
+#### Test Plan
+- **Unit**: extend `tests/gpu-lane.test.mjs` for report formatting/exit-code
+  mapping logic.
+- **Integration (manual, this host)**: one hardware full-suite run; one
+  forced-fallback full-suite run (both also feed Phase 4 evidence).
+- **Gate**: FR6 procedure.
+
+#### Rollback Strategy
+Revert the phase commit; `package.json` script entry and comment block go
+with it. Default behavior was never altered.
+
+#### Risks
+- **Risk**: headed WSLg suite proves flaky (focus/window management) across a
+  full run.
+  - **Mitigation**: recorded as lane findings (spec Decision 7); Phase 3 may
+    make headless the default; canonical waits are never retuned.
+- **Risk**: hardware timing breaks a qualified wait (e.g. camera-settle vs
+  the 4 s enable window).
+  - **Mitigation**: same — lane finding, disclosed; no canonical retuning;
+    any lane-only accommodation would be env-gated, default-inert, disclosed.
+
+---
+
+### Phase 3: `headless_investigation` — bounded FR5 matrix and lane default
+**Dependencies**: Phase 2
+
+#### Objectives
+- Answer headless-vs-headed conclusively within the spec's fixed matrix and
+  set the lane's default mode accordingly.
+
+#### Deliverables
+- [ ] Matrix results (≤4 probe runs, verbatim renderer strings or failures)
+      recorded in the review artifact.
+- [ ] `scripts/e2e-gpu-lane.mjs` candidate data updated **only if** headless
+      reaches hardware (default flips headless; headed stays available and
+      documented); no change otherwise.
+
+#### Implementation Details
+Matrix on the selected d3d12 recipe (this host class), via `--probe-only`
+with a mode override: {Playwright default headless (the bundled
+headless-shell path), explicit new-headless via the full Chromium binary if
+the pinned Playwright 1.61.1 distinguishes them — record which binary/mode
+each probe actually used} × {`--use-angle=gl`, `--use-angle=gl-egl`} — the
+two ANGLE backends already in the WSL2 candidate list. Stop condition: matrix
+exhausted. Conclusive positive = ≥1 combination passes the deny-list
+assertion (record which); conclusive negative = all combinations software/
+failed, recorded verbatim. No flag hunting beyond the matrix. If positive,
+one full-suite headless hardware run validates the flip before it becomes the
+default.
+
+#### Acceptance Criteria
+- [ ] Every matrix cell has a recorded outcome (string or failure), none
+      skipped silently.
+- [ ] Lane default matches the evidence; headed path remains reachable and
+      documented either way.
+- [ ] Unit suite updated if candidate data changed; all green.
+
+#### Test Plan
+- **Manual**: the matrix probes; one full headless suite run iff flipping.
+- **Unit**: candidate-data invariants still hold.
+
+#### Rollback Strategy
+Candidate-data-only change; revert restores headed default (which is the
+proven configuration).
+
+#### Risks
+- **Risk**: new-headless mode is not cleanly selectable under the pinned
+  Playwright.
+  - **Mitigation**: record exactly what 1.61.1 offers; an unreachable mode is
+    a recorded "not distinguishable at this pin" outcome, not an open end.
+
+---
+
+### Phase 4: `qualification_evidence_and_docs` — FR8 evidence and FR9 documentation
+**Dependencies**: Phase 3
+
+#### Objectives
+- Produce the repeat-run stability evidence that makes the lane trustworthy,
+  and the documentation that makes it discoverable (FR8, FR9, Scenarios 4–5).
+
+#### Deliverables
+- [ ] 3+ **consecutive** full-suite hardware lane runs under
+      `E2E_GPU_REQUIRE=1` (per-test pass/fail, verbatim renderer string,
+      wall-clock, retries policy per run) recorded in the review artifact
+      draft (`codev/reviews/44-add-an-opt-in-native-gpu-local.md`).
+- [ ] One forced-fallback full-suite run recorded — this is simultaneously
+      the fallback-path qualification and the contemporaneous serial
+      SwiftShader baseline wall-clock for comparison.
+- [ ] README section: lane command + what it does; hardware vs fallback
+      semantics and how to read the FR10 report; the WSL2 Mesa d3d12 recipe
+      (env, flags, optional `MESA_D3D12_DEFAULT_ADAPTER_NAME` /
+      `LIBGL_ALWAYS_SOFTWARE` disambiguators); FR5 outcome
+      (headless/headed); env controls (`E2E_GPU_FORCE_FALLBACK`,
+      `E2E_GPU_REQUIRE`); explicit **non-gate** status; #41 sequencing note
+      (`workers` stay 1 until #41 qualifies parallelism on this lane).
+- [ ] Instability findings (if any) recorded as lane findings — canonical
+      waits untouched (Decision 7).
+
+#### Implementation Details
+Runs use the lane exactly as shipped (no special harness). Retries policy:
+local default `retries: 0`; if evidence forces reconsideration it is
+disclosed with the runs, never silently changed. Wall-clock comparison table:
+3+ hardware runs vs the SwiftShader baseline (and vs bugfix-22's recorded
+9.7 m chromium suite as historical context). If a test proves
+timing-incompatible under hardware GL: record verbatim, leave canonical suite
+untouched, disclose any env-gated lane-only accommodation in the review.
+
+#### Acceptance Criteria
+- [ ] FR8 evidence complete and honest (per-run detail, no aggregation-only
+      claims, failures preserved verbatim).
+- [ ] A developer who never read #22/#42/#44 can find, run, and interpret the
+      lane from README alone (Scenario 5).
+- [ ] `npm run validate` green locally on the final tree; clean-worktree
+      proof (`git worktree add --detach HEAD` + `npm ci`) if any gate check
+      is polluted by untracked builder-harness files (hot lesson).
+
+#### Test Plan
+- **Manual/evidence**: the qualification runs themselves.
+- **Regression**: full `npm run validate` (SwiftShader, both engines) on the
+  final tree before PR.
+
+#### Rollback Strategy
+Docs + evidence only; revert the commit. Lane behavior unchanged by this
+phase (unless a disclosed finding forced an env-gated accommodation, which
+reverts with it).
+
+#### Risks
+- **Risk**: a hardware run flakes (new timing class), breaking "3+
+  consecutive".
+  - **Mitigation**: record verbatim, diagnose as a lane finding, restart the
+    consecutive count only after any (disclosed, lane-only) adjustment —
+    never by trimming canonical waits or hiding runs.
+
+## Dependency Map
+
+```
+Phase 1 (wrapper core + unit tests)
+   ↓
+Phase 2 (full lane + npm script + FR6 proof)
+   ↓
+Phase 3 (FR5 headless matrix → lane default)
+   ↓
+Phase 4 (FR8 evidence + FR9 docs)
+```
+
+## Resource Requirements
+
+- **Environment**: the pinned toolchain (Node 22.23.1 / npm 10.9.8, `npm ci`);
+  this WSL2 host with RTX 3080 + WSLg for hardware evidence; no new
+  dependencies, services, or infrastructure.
+- **Files touched (whole project)**: `scripts/e2e-gpu-lane.mjs` (new),
+  `tests/gpu-lane.test.mjs` (new), `package.json` (one script line),
+  `playwright.config.ts` (comments only), `README.md`,
+  `codev/reviews/44-add-an-opt-in-native-gpu-local.md`,
+  `codev/state/aspir-44_thread.md`.
+
+## Integration Points
+
+- **Internal**: `PW_CHROMIUM_ARGS` hook (merged, proven default-inert) — the
+  lane's only injection point into the qualified config; `E2E_ENGINES=chromium`
+  engine selection; `webServer` production-server flow via `playwright test`.
+- **External systems**: none (explicitly — the #42 lesson).
+
+## Risk Analysis
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Silent SwiftShader fallback mistaken for hardware | M | H | FR3 mandatory deny-list probe before suite; `E2E_GPU_REQUIRE=1` during qualification; FR10 report |
+| Hardware timing breaks qualified waits | M | M | Decision 7 discipline: lane findings recorded; canonical waits untouched; accommodations env-gated + disclosed |
+| Headed WSLg full-suite flake (focus/windowing) | M | M | FR5 may flip default to headless; findings recorded; headed remains proven-documented |
+| Config drift endangers canonical gate | L | H | Comment-only config diff; FR6 config-load equality proof; CI green |
+| Recipe env leaks into webServer child with side effects | L | M | GPU-only libs in `/usr/lib/wsl/lib`; bugfix-22 precedent; fallback = scope env to browser if evidence appears |
+| Driver/Mesa updates break the recipe later | M | L | Adapter-agnostic candidates + graceful fallback; README dates the evidence |
+| Wrapper drifts from real suite invocation | L | M | Delegation (`npm run build` + `npx playwright test` + config webServer); no duplicated invocation logic |
+
+## Validation Checkpoints
+
+1. **After Phase 1**: `npm test` green with zero lane env/GPU; probe-only
+   hardware verdict on this host; force-fallback and require-mode behave per
+   spec.
+2. **After Phase 2**: one full hardware run + one full forced-fallback run
+   complete with correct reports/exit codes; FR6 items 1–3 evidence recorded.
+3. **After Phase 3**: matrix fully recorded; lane default matches evidence.
+4. **Before PR**: FR8 evidence complete; `npm run validate` green (clean
+   worktree if needed); README complete; no lockfile diff;
+   `.github/workflows/validation.yml` absent from the diff.
+
+## Monitoring and Observability
+
+Terminal-only tooling: per-candidate FR11 diagnostics as they happen, a
+pre-report diagnostics summary, and the FR10 greppable report (the artifact
+future #41 qualification cites). No persistent telemetry.
+
+## Documentation Updates Required
+
+- [ ] README lane section (FR9 — the deliverable).
+- [ ] `playwright.config.ts` hook comment paragraph (Phase 2).
+- [ ] Review artifact with FR5/FR6/FR8 evidence (Phase 2–4 accumulation).
+
+## Post-Implementation Tasks
+
+- [ ] #41 consumes the FR8 evidence and the lane for its parallel-workers
+      qualification (explicitly out of scope here; `workers: 1` everywhere).
+- [ ] Possible future arch.md/lessons update at MAINTAIN time (not this PR
+      unless the review phase directs it).
+
+## Consultation Log
+
+(To be filled by porch-driven 3-way plan review.)
+
+## Approval
+
+ASPIR: no human plan gate; 3-way consultation + porch checks govern
+advancement. PR gate remains human-approved.
+
+## Change Log
+
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-07-21 | Initial plan | Draft from approved spec | Builder aspir-44 |
+
+## Notes
+
+- Working env-control names fixed by this plan: `E2E_GPU_FORCE_FALLBACK=1`,
+  `E2E_GPU_REQUIRE=1`; script name `scripts/e2e-gpu-lane.mjs`; npm script
+  `test:e2e:gpu`. (Spec left names as plan decisions.)
+- The unit-test file rides the existing `npm test` glob — no `package.json`
+  `test` script change, keeping the quality-lane script chain untouched.
+- No committed file may read the lane env vars except the wrapper itself;
+  `playwright.config.ts` continues to read only `PW_CHROMIUM_ARGS` (already
+  merged behavior).

--- a/codev/plans/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/plans/44-add-an-opt-in-native-gpu-local.md
@@ -146,6 +146,12 @@ open a blank page; evaluate a canvas `webgl` context +
 `WEBGL_debug_renderer_info` → `UNMASKED_RENDERER_WEBGL` (fall back to
 `gl.RENDERER` if the extension is missing); bounded per-candidate timeout
 (30 s launch-to-verdict); crash/timeout/no-context ⇒ failed candidate.
+Each probe attempt writes a per-candidate transcript log (candidate id,
+flags, injected env keys, timestamps, result or error stack) to a dedicated
+gitignored directory that Playwright does not manage/wipe (Playwright clears
+its `outputDir` at suite start, so `test-results/` is unusable for this);
+FR11 crash/timeout diagnostics name that log path (Codex plan-review
+comment 1).
 Classification deny-list (case-insensitive): `swiftshader`, `llvmpipe`,
 `software`, `microsoft basic` ⇒ software; anything else with a non-empty
 string ⇒ hardware. Full string always recorded verbatim.
@@ -222,9 +228,15 @@ PW_CHROMIUM_ARGS: candidate.flags.join(" "), ...candidate.env}` plus
 change needed for headed mode). The production server comes from the
 config's own `webServer` block, exactly as `test:smoke`. Fallback mode runs
 the identical build+test flow with **no** lane env (`PW_CHROMIUM_ARGS`
-unset ⇒ default SwiftShader args) after printing the loud warning. Suite
-exit code is preserved as the lane exit code in both modes; wall-clock
-captured per stage (build, suite) and total. `workers`/`retries` are not
+unset ⇒ default SwiftShader args) after printing the loud warning. The
+fallback child env is built from the wrapper's **pristine inherited env**
+(recipe env objects are composed per-spawn, never written into
+`process.env`) with `PW_CHROMIUM_ARGS` explicitly removed — so a
+software-fallback run can never inherit `GALLIUM_DRIVER`,
+`LD_LIBRARY_PATH` prepends, or any candidate-specific state from the lane
+(Codex plan-review comment 2; operator-shell-set vars are their own and
+pass through untouched). Suite exit code is preserved as the lane exit code
+in both modes; wall-clock captured per stage (build, suite) and total. `workers`/`retries` are not
 touched anywhere (config defaults: `workers: 1`, local `retries: 0`).
 
 Note: recipe env (`GALLIUM_DRIVER`, `LD_LIBRARY_PATH`) is applied to the
@@ -477,7 +489,13 @@ future #41 qualification cites). No persistent telemetry.
 
 ## Consultation Log
 
-(To be filled by porch-driven 3-way plan review.)
+Plan iteration 1 (2026-07-21): Gemini APPROVE, Claude APPROVE, Codex COMMENT
+(non-blocking, HIGH confidence). Codex's two comments incorporated:
+(1) probe crash/timeout transcript logs get a named, Playwright-safe,
+gitignored destination that FR11 diagnostics reference; (2) fallback child
+env is composed from the pristine inherited env minus `PW_CHROMIUM_ARGS`,
+never from mutated lane state. Codex independently verified the plan's repo
+premises (npm test glob, test:smoke chain, PW_CHROMIUM_ARGS hook).
 
 ## Approval
 
@@ -489,6 +507,7 @@ advancement. PR gate remains human-approved.
 | Date | Change | Reason | Author |
 |------|--------|--------|--------|
 | 2026-07-21 | Initial plan | Draft from approved spec | Builder aspir-44 |
+| 2026-07-21 | Probe-log destination + fallback env scrub made explicit | Codex plan-review comments | Builder aspir-44 |
 
 ## Notes
 

--- a/codev/plans/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/plans/44-add-an-opt-in-native-gpu-local.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - **ID**: plan-2026-07-21-add-an-opt-in-native-gpu-local
-- **Status**: draft
+- **Status**: complete (all four phases implemented and CMAP-approved)
 - **Specification**: [codev/specs/44-add-an-opt-in-native-gpu-local.md](../specs/44-add-an-opt-in-native-gpu-local.md)
 - **Created**: 2026-07-21
 

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -5,24 +5,24 @@ phase: implement
 plan_phases:
   - id: lane_wrapper_core
     title: 'Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests'
-    status: in_progress
+    status: complete
   - id: full_lane_and_inertness_proof
     title: Full-suite lane command, npm script, comment sync, default-inert proof
-    status: pending
+    status: in_progress
   - id: headless_investigation
     title: Bounded headless-vs-headed investigation (FR5) and lane default
     status: pending
   - id: qualification_evidence_and_docs
     title: Repeat-run qualification evidence (FR8) and documentation (FR9)
     status: pending
-current_plan_phase: lane_wrapper_core
+current_plan_phase: full_lane_and_inertness_proof
 gates:
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:26:47.107Z'
+updated_at: '2026-07-21T22:30:09.672Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -2,15 +2,27 @@ id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
 phase: implement
-plan_phases: []
-current_plan_phase: null
+plan_phases:
+  - id: lane_wrapper_core
+    title: 'Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests'
+    status: in_progress
+  - id: full_lane_and_inertness_proof
+    title: Full-suite lane command, npm script, comment sync, default-inert proof
+    status: pending
+  - id: headless_investigation
+    title: Bounded headless-vs-headed investigation (FR5) and lane default
+    status: pending
+  - id: qualification_evidence_and_docs
+    title: Repeat-run qualification evidence (FR8) and documentation (FR9)
+    status: pending
+current_plan_phase: lane_wrapper_core
 gates:
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:21:14.751Z'
+updated_at: '2026-07-21T22:26:23.049Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -41,4 +41,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:03:26.777Z'
+updated_at: '2026-07-21T23:35:23.349Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -41,4 +41,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:00:49.044Z'
+updated_at: '2026-07-21T23:01:08.495Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,7 +1,7 @@
 id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -10,7 +10,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:01:43.659Z'
+updated_at: '2026-07-21T22:05:50.303Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,7 +1,7 @@
 id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -10,7 +10,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:10:48.427Z'
+updated_at: '2026-07-21T22:13:00.917Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -11,18 +11,18 @@ plan_phases:
     status: complete
   - id: headless_investigation
     title: Bounded headless-vs-headed investigation (FR5) and lane default
-    status: in_progress
+    status: complete
   - id: qualification_evidence_and_docs
     title: Repeat-run qualification evidence (FR8) and documentation (FR9)
-    status: pending
-current_plan_phase: headless_investigation
+    status: in_progress
+current_plan_phase: qualification_evidence_and_docs
 gates:
   pr:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -41,4 +41,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:01:08.495Z'
+updated_at: '2026-07-21T23:03:26.777Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -41,7 +41,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:41:13.960Z'
+updated_at: '2026-07-21T23:41:19.363Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -21,8 +21,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: headless_investigation
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:56:36.828Z'
+updated_at: '2026-07-21T23:00:49.044Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:49:28.392Z'
+updated_at: '2026-07-21T22:56:36.828Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -41,4 +41,9 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:37:31.924Z'
+updated_at: '2026-07-21T23:41:13.960Z'
+pr_history:
+  - phase: review
+    pr_number: 50
+    branch: builder/aspir-44
+    created_at: '2026-07-21T23:41:13.960Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:26:23.049Z'
+updated_at: '2026-07-21T22:26:47.107Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -10,7 +10,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:00:59.724Z'
+updated_at: '2026-07-21T22:01:43.659Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,7 +22,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:30:09.672Z'
+updated_at: '2026-07-21T22:46:28.225Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,7 +1,7 @@
 id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
-phase: review
+phase: verify
 plan_phases:
   - id: lane_wrapper_core
     title: 'Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests'
@@ -24,7 +24,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -43,7 +43,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:52:02.239Z'
+updated_at: '2026-07-21T23:52:27.928Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,7 +1,7 @@
 id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
-phase: implement
+phase: review
 plan_phases:
   - id: lane_wrapper_core
     title: 'Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests'
@@ -14,15 +14,15 @@ plan_phases:
     status: complete
   - id: qualification_evidence_and_docs
     title: Repeat-run qualification evidence (FR8) and documentation (FR9)
-    status: in_progress
-current_plan_phase: qualification_evidence_and_docs
+    status: complete
+current_plan_phase: null
 gates:
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -41,4 +41,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:35:23.349Z'
+updated_at: '2026-07-21T23:37:31.924Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -8,21 +8,21 @@ plan_phases:
     status: complete
   - id: full_lane_and_inertness_proof
     title: Full-suite lane command, npm script, comment sync, default-inert proof
-    status: in_progress
+    status: complete
   - id: headless_investigation
     title: Bounded headless-vs-headed investigation (FR5) and lane default
-    status: pending
+    status: in_progress
   - id: qualification_evidence_and_docs
     title: Repeat-run qualification evidence (FR8) and documentation (FR9)
     status: pending
-current_plan_phase: full_lane_and_inertness_proof
+current_plan_phase: headless_investigation
 gates:
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:46:28.225Z'
+updated_at: '2026-07-21T22:49:28.392Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -18,8 +18,9 @@ plan_phases:
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-21T23:44:13.207Z'
+    approved_at: '2026-07-21T23:52:02.238Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -42,10 +43,10 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:44:13.208Z'
+updated_at: '2026-07-21T23:52:02.239Z'
 pr_history:
   - phase: review
     pr_number: 50
     branch: builder/aspir-44
     created_at: '2026-07-21T23:41:13.960Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -19,6 +19,7 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-21T23:44:13.207Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -41,9 +42,10 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:41:19.363Z'
+updated_at: '2026-07-21T23:44:13.208Z'
 pr_history:
   - phase: review
     pr_number: 50
     branch: builder/aspir-44
     created_at: '2026-07-21T23:41:13.960Z'
+pr_ready_for_human: true

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -10,7 +10,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:05:50.303Z'
+updated_at: '2026-07-21T22:10:48.427Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -10,7 +10,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T22:13:00.917Z'
+updated_at: '2026-07-21T22:21:14.751Z'

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,0 +1,16 @@
+id: '44'
+title: add-an-opt-in-native-gpu-local
+protocol: aspir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-21T22:00:59.724Z'
+updated_at: '2026-07-21T22:00:59.724Z'

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -25,6 +25,24 @@ totals into a zero-findings gate. Contributor commands and artifact names live i
 `README.md`; implementation details live in `.github/workflows/validation.yml`,
 `playwright.config.ts`, and `scripts/validate-audit-report.mjs`.
 
+An **opt-in native-GPU local lane** (`npm run test:e2e:gpu`,
+`scripts/e2e-gpu-lane.mjs`, spec 44) sits beside this gate, never inside it:
+it probes the host (WSL2 Mesa d3d12 for any vendor adapter; ANGLE
+Vulkan/GL on native Linux), verifies the effective
+`UNMASKED_RENDERER_WEBGL` against a SwiftShader/llvmpipe deny-list BEFORE
+trusting a run, then injects the verified flags through the config's
+env-gated `PW_CHROMIUM_ARGS` hook (env unset ⇒ byte-identical SwiftShader
+defaults) and runs the full Chromium suite — headless by default (the d3d12
+path needs no display; headed WSLg via `--mode=headed`) and ~6× faster than
+the SwiftShader serial baseline (qualified 2026-07 on WSL2/RTX 3080, 5/5
+full-suite passes at `retries: 0`). No usable adapter ⇒ the suite still runs
+under SwiftShader with a loud software-fallback banner; `E2E_GPU_REQUIRE=1`
+hard-fails instead (hardware-evidence integrity) and
+`E2E_GPU_FORCE_FALLBACK=1` exercises the fallback deterministically. The
+lane keeps `workers: 1` — parallelizing on top of it is issue #41's
+qualification, sequenced after spec 44. Recipe and evidence: `README.md`
+("Opt-in native-GPU e2e lane") and `codev/reviews/44-add-an-opt-in-native-gpu-local.md`.
+
 ## Dependency Classification and Lint Config
 
 Build-time and type-only packages are `devDependencies`: `postcss`,

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -43,6 +43,26 @@ gotcha, or constraint.
   identically across the three 0.172→0.185 upgrade in both Chromium and Firefox
   — treat the intermittent/blocked cases as a known harness delivery limitation,
   not an app defect, and qualify them with rate comparison against baseline.
+- Chromium silently falls back to SwiftShader when a GPU path fails, so any
+  "hardware run" claim needs a **renderer probe before the suite**: launch the
+  same browser/flag set the suite will use, read `UNMASKED_RENDERER_WEBGL`,
+  and deny-list assert (no SwiftShader/llvmpipe/software). For repeat-run
+  hardware evidence, pair the probe with a strict switch that hard-fails
+  instead of falling back (`E2E_GPU_REQUIRE=1`-style) — otherwise one silent
+  mid-series fallback poisons the whole series. Log the string verbatim every
+  run.
+- Probe capability claims before designing around their absence: "hardware
+  WebGL needs headed WSLg" was received wisdom from PR #43, but a cheap 4-cell
+  matrix (headless-shell/new-headless × two ANGLE backends, one probe each)
+  showed the Mesa d3d12 path needs **no display at all** — which flipped the
+  lane's default to headless and removed the WSLg dependency entirely. The
+  matrix cost minutes; the wrong assumption would have shipped a worse tool.
+- For wrapper code that must never wedge (timeouts racing a browser launch),
+  capture the launch promise **outside** the raced closure and reap it in
+  `finally` with a bounded close — a watchdog that wins before launch resolves
+  otherwise orphans the browser and can hold the process open. Make the
+  launcher/timeouts dependency-injectable so the timed-out-cleanup path has
+  deterministic unit coverage instead of being untestable.
 
 ## Toolchain and Worktree Hygiene
 

--- a/codev/reviews/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/reviews/44-add-an-opt-in-native-gpu-local.md
@@ -1,0 +1,100 @@
+# Review 44: Add an Opt-In Native-GPU Local E2E Lane
+
+## Metadata
+- **ID**: review-2026-07-21-add-an-opt-in-native-gpu-local
+- **Status**: in progress (evidence accumulating; finalized in the Review phase)
+- **Specification**: [codev/specs/44-add-an-opt-in-native-gpu-local.md](../specs/44-add-an-opt-in-native-gpu-local.md)
+- **Plan**: [codev/plans/44-add-an-opt-in-native-gpu-local.md](../plans/44-add-an-opt-in-native-gpu-local.md)
+
+This artifact accumulates the lane's qualification evidence phase by phase
+(FR5/FR6 now; FR8 stability runs and the final lessons in later phases), per
+the plan's "Phase 2–4 accumulation" note. All renderer strings are verbatim.
+
+## FR5 — Headless-vs-headed investigation (plan phase: headless_investigation)
+
+**Question**: can headless Chromium + ANGLE reach hardware GL on this host
+(WSL2, RTX 3080, Mesa d3d12), or is the proven headed-WSLg config required?
+
+**Method**: the spec's bounded matrix — one FR3 renderer probe per cell, via
+`node scripts/e2e-gpu-lane.mjs --probe-only --mode=headless
+--candidate=<id> [--channel=chromium]`. At the pinned `@playwright/test`
+1.61.1 the two headless modes ARE distinguishable and both binaries are
+installed by `playwright install chromium`:
+- default `headless: true` → **Chrome Headless Shell 149.0.7827.55**
+  (`chromium_headless_shell-1228`);
+- `channel: "chromium"` → **Chrome for Testing 149.0.7827.55** full binary in
+  new-headless mode (`chromium-1228`).
+
+**Result: conclusive POSITIVE — all 4 cells reach hardware** (2026-07-21,
+this host; probe transcripts in `gpu-lane-logs/probe-*.log` per cell):
+
+| Cell | Headless binary | ANGLE backend | UNMASKED_RENDERER_WEBGL (verbatim) |
+|---|---|---|---|
+| A | headless shell (default) | `--use-angle=gl` | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)` |
+| B | headless shell (default) | `--use-angle=gl-egl` | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL ES 3.1)` |
+| C | new headless (`--channel=chromium`) | `--use-angle=gl` | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)` |
+| D | new headless (`--channel=chromium`) | `--use-angle=gl-egl` | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL ES 3.1)` |
+
+The Mesa d3d12 path does **not** need a display: the matrix cells run with the
+same recipe env (`GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`)
+and no WSLg window.
+
+**Full-suite headless validation run** (before flipping the default):
+`node scripts/e2e-gpu-lane.mjs --mode=headless` → **11/11 passed**, suite
+97 s, total 108 s (build 10 s), renderer `ANGLE (Microsoft Corporation, D3D12
+(NVIDIA GeForce RTX 3080), OpenGL 4.6)`, exit 0 — timing identical to the
+headed run (97 s suite).
+
+**Decision**: the lane default is **headless** (headless shell path — the
+suite's own default headless, reachable with zero config surface). Headed
+remains one flag away (`--mode=headed`, DISPLAY/WSLg prereq applies only
+there) and is documented as the historically-proven alternative. The
+`--channel=chromium` new-headless result is probe-only knowledge: the suite
+cannot switch Playwright channel through `PW_CHROMIUM_ARGS`, and no config
+surface was added for it (default-inert discipline; the wrapper refuses
+`--channel` without `--probe-only` for exactly this honesty reason).
+
+## FR6 — Canonical gate provably untouched (plan phase: full_lane_and_inertness_proof)
+
+Collected 2026-07-21 on commit `d78194b` (unchanged since):
+
+1. `git diff main -- playwright.config.ts` — **comment-only** (the
+   `PW_CHROMIUM_ARGS` hook's OPT-IN paragraph now describes the shipped lane;
+   every changed line is a `//` comment, no code token differs).
+2. `.github/workflows/validation.yml`, `.nvmrc`, `package-lock.json` — absent
+   from `git diff main --stat` entirely. `package.json`'s only delta is the
+   added `"test:e2e:gpu"` script line.
+3. Config-load check with all lane env unset (`node
+   --experimental-strip-types`, real `playwright.config.ts`):
+   - chromium `launchOptions.args` =
+     `["--use-angle=swiftshader", "--enable-unsafe-swiftshader"]` (exact)
+   - projects `[chromium, firefox]`, `workers: 1`, `retries: 0` (non-CI),
+     `timeout: 120000` (non-CI), reporter `[list, html]`, webServer command/
+     `reuseExistingServer: false` unchanged.
+   - Hook sanity: with `PW_CHROMIUM_ARGS="--use-gl=angle --use-angle=gl"` the
+     resolved args are exactly the injected pair (the lane's injection point
+     works; env unset ⇒ SwiftShader defaults).
+4. PR CI green under SwiftShader — pending, recorded at the Review phase.
+
+## FR8 — Repeat-run stability evidence (accumulating; completed in plan phase: qualification_evidence_and_docs)
+
+Host: WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2), NVIDIA GeForce RTX
+3080, Mesa d3d12 Gallium; Node 22.23.1 / npm 10.9.8; `workers: 1`,
+`retries: 0` (config local defaults, untouched); full 11-test Chromium suite.
+
+| Run | Date | Mode | Renderer (verbatim) | Result | Suite | Total |
+|---|---|---|---|---|---|---|
+| HW-1 (headed) | 2026-07-21 | hardware, headed WSLg | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)` | 11/11 pass | 97 s | 108 s |
+| HW-2 (headless validation) | 2026-07-21 | hardware, headless | `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)` | 11/11 pass | 97 s | 108 s |
+| FB-1 (forced fallback / baseline) | 2026-07-21 | software-fallback (`E2E_GPU_FORCE_FALLBACK=1`) | not probed — default SwiftShader args | 11/11 pass | 594 s | 604 s |
+
+Baseline comparison: hardware suite 97 s vs contemporaneous SwiftShader
+serial baseline 594 s ⇒ **6.1× faster** (historical context: bugfix-22's
+chromium suite measured 9.7 m under SwiftShader). Zero flakes at
+`retries: 0` in all hardware runs so far. The FB-1 run also qualifies the
+fallback path (Scenario 2) on this host: loud banner at start and before the
+report, `mode: software-fallback`, suite exit semantics preserved.
+
+The 3+ consecutive qualification runs (under `E2E_GPU_REQUIRE=1`, on the
+final headless default) land in this section during
+`qualification_evidence_and_docs`.

--- a/codev/reviews/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/reviews/44-add-an-opt-in-native-gpu-local.md
@@ -23,7 +23,7 @@ when no adapter is usable. Headline results:
 - **Canonical gate provably untouched** — comment-only config diff, env-unset
   config-load equality, gate files absent from the diff, clean-checkout
   `npm run validate` exit 0.
-- Delivered: wrapper (795 lines incl. docs-comments), 30 GPU-free unit tests
+- Delivered: wrapper (795 lines incl. docs-comments), 29 GPU-free unit tests
   riding the existing `npm test` glob, README section, this evidence record.
   `package.json` delta is one script line; no dependency/lockfile movement.
 

--- a/codev/reviews/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/reviews/44-add-an-opt-in-native-gpu-local.md
@@ -137,3 +137,38 @@ hardware passes (HW-1 headed, HW-2 headless, Q-1..Q-3 headless).
 renderer, per-test results, wall-clocks, and retries policy recorded, plus
 the contemporaneous SwiftShader serial baseline (FB-1, 594 s suite) for the
 6.1× comparison and the forced-fallback qualification of Scenario 2.
+
+## Canonical gate proof on a clean checkout
+
+The worktree's `npm run lint` is polluted by an untracked builder-harness
+file (`.claude/hooks/worktree-write-guard.cjs` — 21 errors, absent from clean
+checkouts), so per the hot lesson the gate was proven on a detached clean
+worktree (`git worktree add --detach <dir> HEAD` + real `npm ci`, commit
+`dab9e49`):
+
+- **Run 1**: lint ✓, typecheck ✓, build ✓, e2e **21/22** — one failure:
+  `[firefox] matrix.spec.ts:224 "zooms in with the wheel and rotates with a
+  background drag"`, assertion "a background drag should rotate the camera"
+  received azimuth delta `0.0038` (< floor 1) — the synthetic background drag
+  did not register within the 5 s predicate window. Exit 1. Evidence
+  preserved verbatim (see Flaky Tests below).
+- **Run 2** (same clean worktree, no changes): lint ✓, typecheck ✓, build ✓,
+  e2e **22/22**, `VALIDATE EXIT: 0`. Both engines green.
+
+## Flaky Tests
+
+- `[firefox] tests/e2e/matrix.spec.ts:224 "zooms in with the wheel and
+  rotates with a background drag"` — failed once (1 of 2 clean-checkout
+  validate runs; passed on the immediate re-run and in the same run's
+  Chromium arm). **Pre-existing class, not introduced by this branch**: the
+  branch contains zero `tests/e2e/**` or `app/**` changes
+  (`git log main..HEAD -- tests/e2e/ app/` is empty), and the failure mode —
+  a synthetic drag losing the race against slow software-rendered frames on
+  the Firefox local arm — is the documented software-WebGL input-race family
+  (issue #11 measured drags registering intermittently under software
+  rendering; issue #33 documented the Firefox local-arm timing tail; this
+  class is exactly what the hardware lane exists to sidestep, and this test
+  passed in all 5 hardware/fallback Chromium lane runs). **Not skipped**: the
+  spec (Decision 7/FR6) forbids modifying the canonical suite as part of this
+  lane work; left for a dedicated follow-up if it recurs (tracking suggestion
+  filed with the architect at PR time).

--- a/codev/reviews/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/reviews/44-add-an-opt-in-native-gpu-local.md
@@ -95,6 +95,45 @@ chromium suite measured 9.7 m under SwiftShader). Zero flakes at
 fallback path (Scenario 2) on this host: loud banner at start and before the
 report, `mode: software-fallback`, suite exit semantics preserved.
 
-The 3+ consecutive qualification runs (under `E2E_GPU_REQUIRE=1`, on the
-final headless default) land in this section during
-`qualification_evidence_and_docs`.
+### Qualification runs (plan phase: qualification_evidence_and_docs)
+
+Three **consecutive** full-suite lane runs, 2026-07-21, on the final shipped
+configuration (headless default, `wsl2-d3d12-angle-gl` candidate), each under
+`E2E_GPU_REQUIRE=1` so an unnoticed fallback was impossible. Retries policy:
+`retries: 0` (config local default, untouched). Renderer, asserted and logged
+identically in all three runs:
+`ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)`.
+
+| Run | Result | Suite | Total | Lane exit |
+|---|---|---|---|---|
+| Q-1 | 11/11 pass | 94 s | 104 s (build 10 s) | 0 |
+| Q-2 | 11/11 pass | 95 s | 105 s (build 9 s) | 0 |
+| Q-3 | 11/11 pass | 95 s | 105 s (build 9 s) | 0 |
+
+Per-test durations across Q-1/Q-2/Q-3 (all pass; seconds):
+
+| Test | Q-1 | Q-2 | Q-3 |
+|---|---|---|---|
+| matrix: settles an initial force layout | 2.3 | 2.2 | 2.2 |
+| matrix: rotates automatically until paused, then resumes | 7.7 | 7.6 | 7.7 |
+| matrix: pointer inert until enable delay | 7.0 | 6.9 | 6.9 |
+| matrix: zooms out with the wheel | 8.6 | 8.5 | 8.6 |
+| matrix: zooms in + background-drag rotate | 13.3 | 13.7 | 13.9 |
+| matrix: click-to-focus + reset | 17.6 | 17.7 | 17.4 |
+| matrix: AxesHelper toggle | 3.6 | 4.6 | 4.5 |
+| matrix: canvas consistent across resize | 4.3 | 4.0 | 4.0 |
+| matrix: remounts fresh canvas on re-navigation | 2.9 | 2.9 | 2.9 |
+| right-click-release: releases fx/fy/fz | 17.9 | 17.8 | 17.8 |
+| smoke: renders graph + core controls | 7.0 | 6.9 | 6.9 |
+
+**Findings**: no instability observed — per-test wall-clock spread across the
+three runs is ≤ 1.0 s on every test; zero flakes at `retries: 0`; no
+timing-incompatible test; no lane-only accommodation was needed and none was
+added; canonical waits untouched (spec Decision 7 discipline had nothing to
+absorb). Including the phase-2/3 runs, the lane is 5-for-5 full-suite
+hardware passes (HW-1 headed, HW-2 headless, Q-1..Q-3 headless).
+
+**FR8 verdict**: satisfied — 3+ consecutive hardware runs with asserted
+renderer, per-test results, wall-clocks, and retries policy recorded, plus
+the contemporaneous SwiftShader serial baseline (FB-1, 594 s suite) for the
+6.1× comparison and the forced-fallback qualification of Scenario 2.

--- a/codev/reviews/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/reviews/44-add-an-opt-in-native-gpu-local.md
@@ -2,13 +2,122 @@
 
 ## Metadata
 - **ID**: review-2026-07-21-add-an-opt-in-native-gpu-local
-- **Status**: in progress (evidence accumulating; finalized in the Review phase)
+- **Status**: complete
 - **Specification**: [codev/specs/44-add-an-opt-in-native-gpu-local.md](../specs/44-add-an-opt-in-native-gpu-local.md)
 - **Plan**: [codev/plans/44-add-an-opt-in-native-gpu-local.md](../plans/44-add-an-opt-in-native-gpu-local.md)
 
-This artifact accumulates the lane's qualification evidence phase by phase
-(FR5/FR6 now; FR8 stability runs and the final lessons in later phases), per
-the plan's "Phase 2–4 accumulation" note. All renderer strings are verbatim.
+## Summary
+
+Productized the PR #43 / experiment-42 hardware-WebGL evidence into
+`npm run test:e2e:gpu` (`scripts/e2e-gpu-lane.mjs`): an opt-in lane that
+probes the host, verifies `UNMASKED_RENDERER_WEBGL` through the repo's own
+Playwright Chromium before trusting anything, runs the full Chromium e2e
+suite on the verified hardware recipe, and falls back loudly to SwiftShader
+when no adapter is usable. Headline results:
+
+- **Hardware suite ≈ 97 s vs 594 s SwiftShader** (6.1× faster), 5/5
+  full-suite passes at `retries: 0`, zero flakes, per-test spread ≤ 1 s.
+- **Headless works** — the FR5 matrix showed the WSL2 Mesa d3d12 path needs
+  no display (all 4 cells hardware), so the lane defaults to headless and
+  runs on display-less WSL2 hosts; headed WSLg is one `--mode=headed` away.
+- **Canonical gate provably untouched** — comment-only config diff, env-unset
+  config-load equality, gate files absent from the diff, clean-checkout
+  `npm run validate` exit 0.
+- Delivered: wrapper (795 lines incl. docs-comments), 30 GPU-free unit tests
+  riding the existing `npm test` glob, README section, this evidence record.
+  `package.json` delta is one script line; no dependency/lockfile movement.
+
+## Spec Compliance
+
+- FR1 one-command lane ✓ (`test:e2e:gpu`; default-inert proven). FR2
+  probe-and-select with data-driven candidates + `E2E_GPU_FORCE_FALLBACK` /
+  `E2E_GPU_REQUIRE` ✓. FR3 deterministic lifecycle with mandatory deny-list
+  verification ✓. FR4 full suite, workers 1, retries 0, nothing trimmed ✓.
+  FR5 bounded matrix, conclusive positive, recorded below ✓. FR6 gate proof
+  below ✓. FR7 committed tests GPU-free (unit suite passes with no
+  GPU/browser/lane env) ✓. FR8 3+ consecutive qualified runs below ✓. FR9
+  README ✓. FR10 greppable report ✓. FR11 per-candidate diagnostics with
+  cause + remedy + transcript path ✓.
+- Confirmed Decisions 1–10 honored; notably 7/8: no canonical wait retuned,
+  no lane-only accommodation was even needed, `workers: 1` everywhere.
+
+## Deviations from Plan
+
+- None material. The only mid-flight additions came from CMAP feedback:
+  probe-transcript log destination named up front, fallback env scrub made
+  explicit (both were plan-review comments folded in before implementation),
+  and the probe timeout-cleanup fix + injectability (impl-review catch).
+- The review artifact was created in phase 3 rather than phase 4 — a
+  phase-review correction (the plan's phase-3 deliverable required FR5
+  evidence in this artifact, not the builder thread).
+
+## Lessons Learned
+
+- **Probe before designing around an assumed limitation.** "Hardware WebGL
+  needs headed WSLg" was received wisdom from PR #43; a four-probe matrix
+  falsified it in minutes and made the shipped tool strictly better
+  (headless default, no display dependency).
+- **Silent SwiftShader fallback is the central failure mode** of any GPU
+  lane; the deny-list renderer probe before the suite plus the
+  `E2E_GPU_REQUIRE=1` strict switch turned "we think it ran on hardware"
+  into an asserted, logged fact on every run.
+- **Dependency-injected side effects paid off immediately**: making the
+  probe's launcher/timeouts/transcript-writer injectable let the
+  orphaned-browser-on-timeout defect (a real CMAP catch) get deterministic
+  regression tests instead of an untestable fix.
+- **The evidence-accumulator review file should exist from the first
+  evidence-producing phase** — creating it lazily cost one review iteration.
+- Hardware timing did not break a single qualified SwiftShader wait — the
+  risk table's top concern never materialized (the waits are floors/polls,
+  not ceilings, so faster frames only tightened them).
+
+## Technical Debt
+
+- None added to the product. Lane-adjacent notes: the FR5 `--channel`
+  new-headless knowledge is probe-only (the suite cannot switch channel
+  through `PW_CHROMIUM_ARGS`); if a future need arises it requires its own
+  env-gated, default-inert config surface with fresh inertness proof.
+
+## Consultation Feedback
+
+- Spec iter-1: Gemini/Claude APPROVE, Codex REQUEST_CHANGES ×4 (fallback
+  determinism, fallback testability on GPU hosts, FR5 bounding, operator
+  UX) — all accepted, spec amended (FR2 controls, FR3 lifecycle, FR5 matrix,
+  FR11).
+- Plan iter-1: Gemini/Claude APPROVE, Codex COMMENT ×2 (probe-log
+  destination, fallback env scrub) — folded into the plan pre-implementation.
+- Impl lane_wrapper_core: Codex caught the watchdog/late-launch browser leak
+  (fixed + 3 focused tests); phase-scoped re-review 3× APPROVE.
+- Impl full_lane_and_inertness_proof: 3× APPROVE.
+- Impl headless_investigation: Codex process catch (evidence belongs in this
+  artifact) — fixed; iter-2 passed.
+- Impl qualification_evidence_and_docs: 3× APPROVE.
+
+## Architecture Updates
+
+Routed to the **cold** `codev/resources/arch.md` (reference detail; the hot
+`arch-critical.md` cap and map are untouched — "`npm run validate` is the
+green gate" already carries the invariant this lane must respect):
+
+- **Validation Baseline** gained a paragraph recording the opt-in native-GPU
+  lane: command, probe→verify→inject flow over the `PW_CHROMIUM_ARGS` hook,
+  headless default, 6× measured speedup, fallback/strict env controls,
+  never-the-gate status, and the #41 `workers: 1` sequencing.
+
+## Lessons Learned Updates
+
+Routed to the **cold** `codev/resources/lessons-learned.md` under the
+existing **Validation Evidence** section (no new top-level section, so the
+hot map in `lessons-critical.md` stays accurate; hot tier untouched):
+
+- Renderer-probe-before-suite + strict-switch pattern for hardware evidence
+  (silent SwiftShader fallback is the failure mode to design against).
+- Probe capability claims before designing around their absence (the 4-cell
+  matrix that falsified "needs headed WSLg").
+- Capture-outside-the-race + bounded reap + DI for timeout-racing browser
+  launches, so cleanup paths get deterministic tests.
+
+All renderer strings below are verbatim.
 
 ## FR5 — Headless-vs-headed investigation (plan phase: headless_investigation)
 
@@ -172,3 +281,19 @@ worktree (`git worktree add --detach <dir> HEAD` + real `npm ci`, commit
   spec (Decision 7/FR6) forbids modifying the canonical suite as part of this
   lane work; left for a dedicated follow-up if it recurs (tracking suggestion
   filed with the architect at PR time).
+
+## Follow-up Items
+
+- **#41 (local e2e parallelization)**: this lane removes the
+  SwiftShader-contention rationale for `workers: 1` locally; #41 should
+  qualify `workers > 1` **on this lane** using the FR8 methodology
+  (`E2E_GPU_REQUIRE=1`, 3+ consecutive runs, per-test results) and cite this
+  review's tables as the serial-hardware baseline (94–97 s suite).
+- The Firefox background-drag flake (above): if it recurs on future local
+  qualification runs, file a dedicated issue in the #33 family rather than
+  retuning inside unrelated work.
+- Recipe drift watch: the evidence is dated 2026-07 (Mesa 26.0.3, NVIDIA
+  driver 581.29, Playwright 1.61.1/Chromium 149). The lane probes rather than
+  assumes, so drift degrades to a loud fallback, not a wrong claim — but if
+  fallback starts appearing on this host, re-run `--probe-only` per candidate
+  and compare transcripts against this review.

--- a/codev/specs/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/specs/44-add-an-opt-in-native-gpu-local.md
@@ -1,0 +1,468 @@
+# Specification 44: Add an Opt-In Native-GPU Local E2E Lane (Hardware WebGL with Software Fallback)
+
+## Summary
+
+Productize the hardware-WebGL configuration proven in PR #43 (issue #22) and
+experiment 42 into an **opt-in, one-command local e2e lane** (working name
+`npm run test:e2e:gpu`) that runs the existing Playwright Chromium suite under
+**genuine hardware-accelerated WebGL** when a GPU adapter is available, and
+**falls back to software rendering with an unmistakable notice** when it is not.
+
+The lane is **additional tooling and evidence, never the green gate**. The
+qualified SwiftShader serial gate stays canonical: `npm run validate`, the
+`.github/workflows/validation.yml` required gate, and every committed test's
+default behavior must be **byte-for-byte / behavior-identical** to today
+(arch: Validation Baseline).
+
+The delivery rests on capabilities that already exist in the repo:
+
+- `playwright.config.ts` already reads an env-gated `PW_CHROMIUM_ARGS` hook
+  (added by experiment 42, explicitly retained **for this issue**): unset ⇒
+  byte-identical forced-SwiftShader args; set ⇒ the injected flag set.
+- PR #43 (issue #22, `codev/state/bugfix-22_thread.md`) proved the WSL2 recipe
+  end-to-end on this host: Mesa d3d12 Gallium driver
+  (`GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`) + headed
+  Chromium via WSLg (`DISPLAY=:0`) with
+  `--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox`
+  → `UNMASKED_RENDERER_WEBGL = "ANGLE (Microsoft Corporation, D3D12 (NVIDIA
+  GeForce RTX 3080), OpenGL 4.6)"`, with manual-matrix item 11 passing 3/3.
+- Experiment 42 run #5 proved the **non-WSL2** counterpart (generic
+  Linux + NVIDIA proprietary userspace): ANGLE-**Vulkan**
+  (`--use-gl=angle --use-angle=vulkan`) → `ANGLE (NVIDIA … Tesla T4)`,
+  verified with `--disable-software-rasterizer`. On WSL2 that same Vulkan
+  backend falls back to llvmpipe — so the winning backend **differs by host
+  environment**, and the lane must probe/select rather than hardcode one.
+
+Why this is worth building (from issue #44):
+
+1. **Faster local iteration** — render frames stop being CPU-bound SwiftShader
+   work.
+2. **Higher-fidelity behavior evidence** — real-GPU runs are what end users
+   actually experience; the SwiftShader flake class (#34, #33, #22) does not
+   exist there.
+3. **Unblocks #41** — with rendering off the CPU, `workers > 1` becomes far
+   more plausible locally; the SwiftShader-contention rationale for
+   `workers: 1` largely evaporates on this lane (qualification itself belongs
+   to #41).
+
+## Problem Analysis
+
+### Current state
+
+- Every local e2e run (`npm run test:smoke`, `npm run validate`) renders WebGL
+  through Chromium's bundled SwiftShader — a deterministic but CPU-bound
+  software rasterizer. The compound interaction tests (camera settle, drags,
+  hover-race-sensitive clicks) run slowly and carry a documented flake class
+  (#33, #34, #22) that exists **only** under software rendering: the throttled
+  hover raycast loses races against synthetic input when frames take seconds.
+- Hardware WebGL on this WSL2 host was assumed impossible until PR #43 proved
+  otherwise. Today the proven configuration exists **only as issue/thread
+  evidence** (`codev/state/bugfix-22_thread.md`, PR #43,
+  `experiments/42_kaggle_gpu_ci/`): there is no command, script, or documented
+  repo recipe to run the suite on it. Reproducing it requires archaeology
+  across two closed work items.
+- The `PW_CHROMIUM_ARGS` hook (the only prerequisite config change) is already
+  merged, default-inert, and deliberately waiting for this issue.
+- The Kaggle GPU-CI counterpart (#42) was REJECTED on Kaggle-AUP grounds; its
+  conclusion explicitly routes the native-GPU goal here: local hardware, no
+  third party, no credential, no ToS exposure.
+
+### Desired state
+
+- One documented command (working name `npm run test:e2e:gpu`) builds the app
+  and runs the full local Chromium e2e suite under verified hardware WebGL
+  when an adapter exists — any vendor, WSL2 or native Linux — and under
+  software rendering **with a clear, loud fallback notice** when none does.
+- The actual renderer is **logged and asserted**: in hardware mode the
+  `UNMASKED_RENDERER_WEBGL` string must not contain `SwiftShader` or
+  `llvmpipe`; in fallback mode the run proceeds but is unmistakably labeled
+  software.
+- The lane has its **own repeat-run stability evidence** (3+ consecutive
+  full-suite runs recorded) before being documented as trusted — hardware GL
+  shifts every timeline the SwiftShader matrix was qualified against.
+- The canonical gate is provably untouched: `npm run validate`,
+  `.github/workflows/validation.yml`, and default Playwright behavior are
+  unchanged; CI remains SwiftShader-only and green.
+- The recipe (WSL2 Mesa d3d12 environment, multi-GPU disambiguators, fallback
+  semantics, non-gate status) is documented in the repo instead of buried in
+  issue history.
+
+### Stakeholders
+
+- **Primary**: the project developer(s) running local e2e iteration.
+- **Secondary**: issue #41 (local parallelization — consumes this lane's
+  qualification), future flake triage (#33/#34-class attribution now has a
+  hardware control arm).
+- **Technical**: builder implementing this spec; CI is a stakeholder only in
+  the sense that it must be provably unaffected.
+
+## Confirmed Decisions
+
+1. **Additive lane, never the gate.** The SwiftShader serial gate stays
+   canonical. `npm run validate` and `.github/workflows/validation.yml` are
+   byte-for-byte unchanged. The lane must not be wired into `validate`,
+   `test:smoke`, or CI.
+2. **Injection point is the existing `PW_CHROMIUM_ARGS` hook.** Default
+   (env unset) behavior of `playwright.config.ts` stays byte-identical
+   (SwiftShader args, `workers: 1`, `retries: 0` locally, qualified timeouts).
+   Any additional config surface the lane needs (e.g. an env-gated headed
+   toggle, if the Playwright `--headed` CLI flag is insufficient) must follow
+   the same pattern: env unset ⇒ byte-identical behavior, proven the same way
+   experiment 42 proved the hook (load the real config with env unset and
+   compare).
+3. **Adapter-agnostic via probe-and-select, with graceful fallback.** The lane
+   probes the host and selects from a small candidate recipe list rather than
+   hardcoding a vendor or backend:
+   - WSL2 path (proven, PR #43): `/dev/dxg` + `/usr/lib/wsl/lib` + Mesa d3d12
+     ⇒ `GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`, ANGLE→GL
+     flags, headed via WSLg unless headless is proven (FR5). Works for any
+     adapter the d3d12 layer exposes (NVIDIA/AMD/Intel); the base config
+     auto-selects a sole adapter, `MESA_D3D12_DEFAULT_ADAPTER_NAME=<vendor>`
+     and `LIBGL_ALWAYS_SOFTWARE=false` are optional multi-GPU disambiguators.
+   - Native-Linux path (proven on Kaggle T4, experiment 42 run #5): working
+     GL/Vulkan userspace ⇒ ANGLE-Vulkan (or ANGLE-GL) candidates.
+   - No adapter / all candidates fail verification ⇒ software fallback with a
+     clear warning; the lane must not hard-depend on GPU presence.
+4. **Renderer verification is mandatory, not advisory.** The lane reads the
+   effective `UNMASKED_RENDERER_WEBGL` through the same Chromium build and
+   flag set the suite will use, logs it, and asserts it is not
+   SwiftShader/llvmpipe before trusting a hardware run. A hardware-mode run
+   whose renderer probe returns software must not silently proceed as if it
+   were hardware (it either falls back loudly or fails the probe step,
+   depending on the fallback decision at runtime).
+5. **Chromium-only lane.** The proven configurations are Chromium+ANGLE.
+   Firefox hardware GL is out of scope (its local qualification arm stays
+   software, unchanged).
+6. **Committed tests stay lane-independent.** Everything merged must pass
+   under default software rendering on CI runners. No committed test may
+   require GPU env vars, hardware presence, or the lane to be meaningful. Any
+   lane-only behavior in test/harness files must be env-gated and
+   default-inert.
+7. **Separate timing qualification, no retuning of the canonical suite.** The
+   matrix's waits/floors were qualified under SwiftShader timing. The lane
+   needs its own repeat-run evidence (FR8). If a test proves
+   timing-incompatible under hardware GL, that is recorded as a lane finding;
+   the qualified SwiftShader waits must NOT be trimmed or retuned to
+   accommodate the lane (any lane-only accommodation must be env-gated and
+   default-inert, and disclosed in the review).
+8. **`workers: 1` stays.** Parallel workers on the GPU lane are #41's
+   qualification, sequenced after this issue. This spec must not raise
+   workers anywhere, including inside the lane.
+9. **No new dependencies.** The lane wrapper is Node built-ins (and the
+   already-installed `@playwright/test`) only. `package.json` changes are
+   limited to adding lane script(s); `engines`, `dependencies`,
+   `devDependencies`, and the lockfile are untouched.
+10. **Sandbox flags are opt-in-only.** `--disable-gpu-sandbox` /
+    `--ignore-gpu-blocklist` (and any similar relaxation the recipe needs) are
+    acceptable **only** inside the explicitly invoked local lane; they must
+    never appear in default launch args, committed test expectations, or CI.
+
+## Scope
+
+### In scope
+
+- A one-command opt-in lane (npm script + supporting wrapper under
+  `scripts/`) that: probes the host, selects/injects the hardware recipe via
+  `PW_CHROMIUM_ARGS` (+ required env), builds and serves the app the same way
+  the existing suite does, verifies the renderer, runs the **full** Chromium
+  e2e suite (no test dropped, no timing trimmed), and reports which mode
+  (hardware/software-fallback) actually ran.
+- Graceful software fallback with a clear notice when no adapter is usable.
+- A bounded headless-vs-headed investigation (FR5) with the result recorded.
+- Repeat-run stability evidence for the lane (FR8) recorded in the review
+  artifacts, including wall-clock comparison against the serial SwiftShader
+  local baseline.
+- Repo documentation of the lane and the WSL2 Mesa d3d12 recipe (FR9).
+- Proof that the canonical gate is untouched (FR6).
+
+### Out of scope (non-goals)
+
+- Raising `workers` anywhere or qualifying parallel execution (#41).
+- Any CI/GPU-in-CI work (#42 REJECTED on AUP grounds; CI stays
+  SwiftShader-only).
+- Firefox hardware WebGL.
+- Making the lane a required or default path; changing `npm run validate`,
+  `test:smoke`, or `.github/workflows/validation.yml` in any way.
+- Retuning committed test waits/floors for hardware timing.
+- New dependencies, toolchain changes, or app (`app/**`) code changes — this
+  is tooling/evidence work; the app is not modified.
+- Windows-native / macOS lane variants (document as untested if mentioned).
+
+## Constraints and Invariants
+
+- **Reproducibility contract** (arch-critical): Node `22.23.1`, npm `10.9.8`,
+  lockfile v3, `npm ci`; no dependency regeneration. This work adds no
+  packages, so the lockfile must show no delta.
+- **Canonical gate**: `npm run validate` is the green gate;
+  `.github/workflows/validation.yml` byte-for-byte unchanged (verifiable via
+  `git diff` — the file must not appear in the PR diff at all).
+- **Default-inert principle**: with no lane env set and the lane script not
+  invoked, every behavior in the repo — Playwright launch args, projects,
+  workers, retries, timeouts, reporters, webServer — is identical to today.
+- **Evidence honesty** (lessons: Validation Evidence): record the exact
+  renderer string, mode, and per-run results; never broaden an
+  environment-limited result into a general claim; preserve nonzero/diagnostic
+  evidence rather than normalizing it.
+- **Committed-tree proof discipline** (hot lesson): if a local gate check
+  fails only on untracked harness files, prove the gate on a clean worktree
+  (`git worktree add --detach HEAD` + real `npm ci`) instead of suppressing in
+  committed config.
+
+## Solution Exploration
+
+### Approach A: Documentation only (recipe in README, no tooling)
+
+**Description**: Write up the PR #43 recipe; users export env vars and run
+Playwright by hand.
+
+**Pros**: Zero code risk; canonical gate trivially untouched.
+
+**Cons**: Fails the issue's acceptance criteria outright — no one-command
+lane, no renderer assertion, no fallback behavior, no stability evidence. The
+recipe stays fragile archaeology (multi-line env + flags), and silent
+SwiftShader fallback (the exact failure mode Chromium defaults to) goes
+undetected — a user can believe they ran hardware when they did not.
+
+**Complexity**: Low. **Risk**: Low (but does not solve the problem).
+
+### Approach B: First-class GPU project inside `playwright.config.ts`
+
+**Description**: Add a `chromium-gpu` Playwright project (or config fork)
+carrying the hardware flags/headed mode, selected via `E2E_ENGINES=chromium-gpu`.
+
+**Pros**: Pure-Playwright ergonomics; no wrapper process; flags visible in one
+file.
+
+**Cons**: The config cannot probe the host (adapter detection, WSL2-vs-native
+selection, env var injection like `GALLIUM_DRIVER`/`LD_LIBRARY_PATH` must
+happen **before** browser launch, some before Node starts the browser
+process); graceful fallback with a loud notice and a pre-suite renderer
+assertion do not fit a declarative project block. It also grows the qualified
+config's surface area — more risk to the byte-identical default contract for
+no probing capability.
+
+**Complexity**: Medium. **Risk**: Medium (config drift risk on the canonical
+gate; silent-fallback risk remains).
+
+### Approach C: Wrapper-script lane over the existing `PW_CHROMIUM_ARGS` hook (selected)
+
+**Description**: A Node wrapper (under `scripts/`, exposed as
+`npm run test:e2e:gpu`) that (1) probes the host and selects a candidate
+recipe (WSL2 d3d12 / native GL / none), (2) exports the recipe env and sets
+`PW_CHROMIUM_ARGS`, (3) verifies the effective renderer through the repo's own
+Playwright Chromium before the suite (the pre-flight-probe pattern already
+built in `experiments/42_kaggle_gpu_ci/kaggle_e2e_runner.py`), (4) runs the
+full Chromium suite (build + test, mirroring `test:smoke` semantics), and
+(5) reports hardware/fallback mode and the renderer string. Fallback = rerun
+path with default SwiftShader args and a loud warning.
+
+**Pros**: Zero change to default config behavior (the hook already exists and
+is proven default-inert); probing, env setup, assertion, fallback, and
+reporting are ordinary imperative code where they belong; the same wrapper is
+the natural home for the stability-evidence runs; smallest possible surface on
+the qualified gate.
+
+**Cons**: One more script to maintain; headed-mode plumbing (WSLg `DISPLAY`,
+Playwright `--headed`/env-gated `headless: false`) needs care; wrapper must
+avoid becoming a second source of truth for suite invocation (it should
+delegate to the existing scripts/config, not re-implement them).
+
+**Complexity**: Medium. **Risk**: Low.
+
+**Selected** — it is the only approach that satisfies adapter-agnostic
+probing, mandatory renderer verification, graceful fallback, and the
+untouched-gate invariant simultaneously, and it builds directly on the hook
+experiment 42 left for this purpose.
+
+## Functional Requirements
+
+### FR1 — One-command opt-in lane
+
+A single documented npm script (working name `test:e2e:gpu`; final name is a
+plan decision) runs the entire lane end-to-end: probe → env/flag injection →
+build + production server (same flow the existing suite uses) → renderer
+verification → full Chromium e2e suite → mode/renderer report. Invoking
+nothing ⇒ nothing changes anywhere (default-inert).
+
+### FR2 — Adapter-agnostic probe and recipe selection
+
+The lane detects the host capability class without vendor hard-coding:
+- WSL2 d3d12 path: presence of `/dev/dxg` and the WSL lib directory ⇒ Mesa
+  d3d12 recipe (any vendor adapter), with the documented optional multi-GPU
+  disambiguators.
+- Native-Linux path: a usable GL/Vulkan stack ⇒ ANGLE candidate flags (Vulkan
+  and/or GL backends, ordered by evidence).
+- Neither ⇒ software fallback (FR3).
+Selection logic and its candidate list must be data-driven enough that adding
+a future recipe does not restructure the lane.
+
+### FR3 — Mandatory renderer verification and graceful fallback
+
+Before trusting a hardware run, the lane launches the repo's own Playwright
+Chromium under the selected flags and reads `UNMASKED_RENDERER_WEBGL`:
+- Hardware mode: string logged; assert it does **not** match
+  SwiftShader/llvmpipe (deny-list assertion, full string recorded). On
+  assertion failure, try the next candidate; when candidates are exhausted,
+  fall back.
+- Fallback mode: the suite still runs (default SwiftShader args) with an
+  unmistakable warning at start **and** in the final report that this was a
+  software run, so fallback output can never be mistaken for hardware
+  evidence. The suite's own pass/fail exit semantics are preserved in both
+  modes.
+
+### FR4 — Full-suite execution, nothing dropped
+
+The lane runs the full Chromium e2e suite (`E2E_ENGINES=chromium`, all specs,
+`workers: 1`, no qualified wait trimmed, no test skipped because of the lane).
+Lane-mode retries policy: default expectation is `retries: 0` (the SwiftShader
+flake class should not exist on hardware; flakes must surface); if evidence
+during qualification forces a different policy it must be disclosed with the
+evidence (FR8), never silently mirrored from CI.
+
+### FR5 — Bounded headless investigation
+
+The proven config is **headed** via WSLg. Investigate whether headless
+Chromium (including `--headless=new`-class modes) + ANGLE can also reach
+hardware GL on this host; record the outcome (works / does not / partially,
+with renderer strings) in the review artifacts. If headless works, it may
+become the lane default with headed as documented alternative; if not, headed
+stays the default and the headless result is documented as attempted evidence.
+Timebox this — it must not balloon the project; a conclusive negative is a
+valid result.
+
+### FR6 — Canonical gate provably untouched
+
+- `.github/workflows/validation.yml` and the `validate` script chain do not
+  appear in the PR diff.
+- `playwright.config.ts` default behavior (all lane env unset): byte-identical
+  launch args and unchanged workers/retries/timeout/reporter/webServer
+  semantics, proven by loading the real config with env unset (the experiment
+  42 verification pattern) and/or zero-diff where no config change is needed.
+- CI on the PR (all shards + quality + gate) green under SwiftShader.
+
+### FR7 — Committed tests independent of the lane
+
+No committed test/harness change may make any default-path test depend on GPU
+presence, lane env vars, or the wrapper. Any lane-aware branch in shared
+harness code is env-gated and default-inert.
+
+### FR8 — Repeat-run stability evidence
+
+Before the lane is documented as trusted: **3+ consecutive full-suite lane
+runs** on hardware (renderer string asserted), each run's pass/fail per test,
+wall-clock, and retries policy recorded in the review artifacts, alongside at
+least one contemporaneous serial SwiftShader local baseline wall-clock for
+comparison. Instability findings (if any) are recorded as lane findings with
+the FR/decision-7 discipline (no canonical retuning). If the host has no
+adapter at qualification time this criterion cannot be met — the work is not
+done until hardware evidence exists (the fallback path is qualified by a
+software run of the same lane).
+
+### FR9 — Documentation
+
+README (and/or a codev resource, plan's choice — discoverability from README
+required) documents: the lane command and what it does, hardware vs fallback
+semantics and how to read the report, the WSL2 Mesa d3d12 environment recipe
+from PR #43 (including optional `MESA_D3D12_DEFAULT_ADAPTER_NAME` /
+`LIBGL_ALWAYS_SOFTWARE` disambiguators), the headless/headed outcome (FR5),
+the lane's explicitly **non-gate** status, and the #41 sequencing note
+(workers stay 1 until #41 qualifies parallelism on this lane).
+
+### FR10 — Honest reporting surface
+
+The lane's terminal output ends with a machine-greppable summary: mode
+(hardware/software-fallback), exact renderer string, engine, suite result,
+wall-clock. This is the artifact the stability evidence (FR8) and future #41
+qualification cite.
+
+## Non-Functional Requirements
+
+### Reproducibility
+No dependency, lockfile, or toolchain movement. The lane runs on the pinned
+Node/npm via the normal repo environment.
+
+### Behavior preservation
+Default-path behavior everywhere (config, tests, scripts, CI) is provably
+unchanged; the lane is pure addition.
+
+### Evidence honesty
+Renderer strings and per-run results recorded verbatim; software-fallback runs
+are always labeled as such; no hardware claim without the deny-list assertion
+passing.
+
+### Security
+GPU sandbox/blocklist relaxations are confined to the explicitly invoked local
+lane (Decision 10). No secrets, no third-party services, no network egress
+beyond what the existing suite already does.
+
+### Maintainability
+Wrapper delegates to the existing config/scripts (no duplicated suite
+invocation logic); recipe candidates are data, not scattered conditionals;
+comments in touched files updated to reflect the lane's existence (e.g. the
+`PW_CHROMIUM_ARGS` comment block's "#44 will consume this" note becomes "the
+lane consumes this").
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Hardware timing breaks qualified waits (camera-settle vs the 4 s enable window, hover-race guards were qualified under slow frames) | Medium | Medium | FR8 repeat-run qualification; Decision 7 (lane findings recorded, canonical waits untouched, lane-only accommodations env-gated + disclosed) |
+| Silent SwiftShader fallback masquerading as a hardware run | Medium | High | FR3 mandatory deny-list renderer assertion before the suite; FR10 report |
+| Headed WSLg runs prove awkward/flaky (focus, window management) | Medium | Medium | FR5 headless investigation; headed stays documented-proven fallback |
+| Config drift endangers the canonical gate | Low | High | Approach C keeps config changes ≈0; FR6 byte-identical default proof + CI green |
+| Host/driver variance (Mesa version, driver updates, other machines) breaks the recipe | Medium | Low | Adapter-agnostic probe with candidate list + graceful fallback (FR2/FR3); recipe documented as evidence-dated, not guaranteed |
+| Wrapper diverges from real suite invocation over time | Low | Medium | Delegation over duplication (NFR Maintainability) |
+| Lane accidentally influences #41 scope (workers) | Low | Medium | Decision 8: workers stay 1; explicit non-goal |
+
+## Acceptance Scenarios
+
+### Scenario 1 — Hardware run on the proven WSL2 host
+`npm run test:e2e:gpu` on the WSL2/RTX 3080 host: probe selects the d3d12
+recipe, renderer probe logs an ANGLE D3D12 string (≠ SwiftShader/llvmpipe),
+full Chromium suite runs and passes, final report says hardware + renderer +
+wall-clock.
+
+### Scenario 2 — Graceful fallback
+Same command on a GPU-less host (or with the adapter path unavailable): a
+clear warning states no adapter was found, the suite runs under SwiftShader,
+the final report unmistakably says software-fallback. Exit code reflects the
+suite result.
+
+### Scenario 3 — Canonical gate untouched
+`git diff` on the PR shows no change to `.github/workflows/validation.yml` or
+the `validate`/`test:smoke` chain; with lane env unset the resolved Playwright
+config is behavior-identical to main; PR CI (quality + 4 SwiftShader e2e
+shards + gate) is green.
+
+### Scenario 4 — Stability evidence recorded
+The review artifacts contain 3+ consecutive full-suite hardware runs (per-run
+results, renderer strings, wall-clocks, retries policy) plus a SwiftShader
+baseline wall-clock, and the headless-vs-headed investigation outcome.
+
+### Scenario 5 — Documentation
+A developer who has never read issues #22/#42/#44 can find the lane in
+README, understand its non-gate status, run it, and correctly interpret a
+hardware vs fallback report.
+
+## Dependencies
+
+- **Internal**: `playwright.config.ts` `PW_CHROMIUM_ARGS` hook (merged, PR
+  #46/#48 line of experiment 42); evidence sources
+  `codev/state/bugfix-22_thread.md`, `experiments/42_kaggle_gpu_ci/notes.md`,
+  `experiments/42_kaggle_gpu_ci/data/output/probe-run-5-evidence.md`.
+- **External services**: none (explicitly — the #42 lesson).
+- **Sequencing**: #41 consumes this lane's qualification; this spec must land
+  (or conclusively record hardware evidence) before #41's parallel
+  qualification can cite it.
+
+## References
+
+- Issue #44 (this spec), #41 (parallelization, sequenced after), #42 +
+  `experiments/42_kaggle_gpu_ci/notes.md` (Kaggle REJECT; hook provenance;
+  run #5 ANGLE-Vulkan evidence), #22 / PR #43 /
+  `codev/state/bugfix-22_thread.md` (WSL2 recipe + 3/3 item-11 native-GPU
+  evidence), #33 / #34 (SwiftShader flake class the lane sidesteps).
+- `codev/resources/arch.md` — Validation Baseline (canonical gate,
+  decomposition, "do not raise workers / trim waits").
+- `codev/resources/lessons-learned.md` — Validation Evidence (renderer/rate
+  evidence discipline), Toolchain and Worktree Hygiene (clean-checkout proof).

--- a/codev/specs/44-add-an-opt-in-native-gpu-local.md
+++ b/codev/specs/44-add-an-opt-in-native-gpu-local.md
@@ -128,8 +128,12 @@ Why this is worth building (from issue #44):
    flag set the suite will use, logs it, and asserts it is not
    SwiftShader/llvmpipe before trusting a hardware run. A hardware-mode run
    whose renderer probe returns software must not silently proceed as if it
-   were hardware (it either falls back loudly or fails the probe step,
-   depending on the fallback decision at runtime).
+   were hardware. The deterministic policy (see FR3): unusable or unverified
+   candidates are skipped/failed loudly and the next candidate is tried;
+   exhausting all candidates produces a loud software fallback. By default
+   the lane never hard-fails because hardware is absent or unverifiable;
+   an opt-in strict switch (for qualification runs) converts
+   fallback-on-exhaustion into a hard failure.
 5. **Chromium-only lane.** The proven configurations are Chromium+ANGLE.
    Firefox hardware GL is out of scope (its local qualification arm stays
    software, unchanged).
@@ -296,19 +300,45 @@ The lane detects the host capability class without vendor hard-coding:
 Selection logic and its candidate list must be data-driven enough that adding
 a future recipe does not restructure the lane.
 
+Two env controls (working names; final names are a plan decision) make the
+selection deterministic and testable on any host:
+- **Forced fallback** (e.g. `E2E_GPU_FORCE_FALLBACK=1`): skip all hardware
+  candidates and go straight to the software-fallback path. This is how
+  Scenario 2 is proven on a GPU-capable host — fallback qualification must
+  not require a second, GPU-less machine.
+- **Strict hardware** (e.g. `E2E_GPU_REQUIRE=1`): if no candidate passes
+  renderer verification, exit non-zero instead of falling back. This is the
+  integrity guard for FR8 qualification runs, where a silent fallback would
+  pollute hardware evidence.
+Both are lane-only: they are read by the wrapper, not by any committed test
+or by `playwright.config.ts` default behavior.
+
 ### FR3 — Mandatory renderer verification and graceful fallback
 
 Before trusting a hardware run, the lane launches the repo's own Playwright
-Chromium under the selected flags and reads `UNMASKED_RENDERER_WEBGL`:
-- Hardware mode: string logged; assert it does **not** match
-  SwiftShader/llvmpipe (deny-list assertion, full string recorded). On
-  assertion failure, try the next candidate; when candidates are exhausted,
-  fall back.
+Chromium under the selected flags and reads `UNMASKED_RENDERER_WEBGL`. The
+candidate lifecycle is deterministic:
+
+1. **Prerequisite check**: a candidate whose environment prerequisites are
+   missing (e.g. headed WSLg candidate with `DISPLAY` unset, WSL2 candidate
+   with `/usr/lib/wsl/lib` absent) is **skipped** with a one-line actionable
+   reason (FR11) — it is not attempted and cannot crash the lane.
+2. **Renderer verification**: the candidate's probe launch reads the renderer
+   string; it is logged verbatim. Assert it does **not** match
+   SwiftShader/llvmpipe (deny-list assertion, full string recorded). A probe
+   that crashes, hangs past its timeout, or returns a software string is a
+   **failed candidate** — logged, then the next candidate is tried.
+3. **Exhaustion**: when all candidates are skipped or failed, the lane falls
+   back to software — never a hard failure by default. Under the strict
+   switch (FR2), exhaustion exits non-zero with the per-candidate log instead.
+
+- Hardware mode: verification passed; the suite runs under the verified flags.
 - Fallback mode: the suite still runs (default SwiftShader args) with an
   unmistakable warning at start **and** in the final report that this was a
   software run, so fallback output can never be mistaken for hardware
   evidence. The suite's own pass/fail exit semantics are preserved in both
-  modes.
+  modes; lane-internal errors unrelated to hardware absence (build failure,
+  malformed invocation) remain hard failures in all modes.
 
 ### FR4 — Full-suite execution, nothing dropped
 
@@ -322,13 +352,22 @@ evidence (FR8), never silently mirrored from CI.
 ### FR5 — Bounded headless investigation
 
 The proven config is **headed** via WSLg. Investigate whether headless
-Chromium (including `--headless=new`-class modes) + ANGLE can also reach
-hardware GL on this host; record the outcome (works / does not / partially,
-with renderer strings) in the review artifacts. If headless works, it may
-become the lane default with headed as documented alternative; if not, headed
-stays the default and the headless result is documented as attempted evidence.
-Timebox this — it must not balloon the project; a conclusive negative is a
-valid result.
+Chromium + ANGLE can also reach hardware GL on this host. The investigation
+is bounded to a fixed candidate matrix — for the recipe the probe selected
+(d3d12 on this host), run the FR3 renderer probe once per combination of:
+- headless modes: Playwright default headless and explicit `--headless=new`
+  (if distinguishable in the pinned Playwright version);
+- ANGLE backends already in the candidate list (GL, plus Vulkan if the
+  native-Linux candidate is defined for this host class).
+
+That is ≤4 probe runs, each with the standard probe timeout. **Stop
+condition**: the matrix is exhausted. Conclusive positive = at least one
+combination passes the deny-list assertion (record which); conclusive
+negative = all combinations return software strings or fail (record each
+string/failure verbatim). No iteration beyond the matrix — novel flag hunting
+is out of scope. If headless works, it may become the lane default with
+headed as documented alternative; if not, headed stays the default and the
+headless result is documented as attempted evidence.
 
 ### FR6 — Canonical gate provably untouched
 
@@ -355,8 +394,10 @@ least one contemporaneous serial SwiftShader local baseline wall-clock for
 comparison. Instability findings (if any) are recorded as lane findings with
 the FR/decision-7 discipline (no canonical retuning). If the host has no
 adapter at qualification time this criterion cannot be met — the work is not
-done until hardware evidence exists (the fallback path is qualified by a
-software run of the same lane).
+done until hardware evidence exists. The fallback path is qualified by at
+least one forced-fallback run of the same lane (FR2 control) on the same
+host. Hardware qualification runs use the strict switch (FR2) so an
+unnoticed mid-qualification fallback cannot contaminate the evidence.
 
 ### FR9 — Documentation
 
@@ -374,6 +415,23 @@ The lane's terminal output ends with a machine-greppable summary: mode
 (hardware/software-fallback), exact renderer string, engine, suite result,
 wall-clock. This is the artifact the stability evidence (FR8) and future #41
 qualification cite.
+
+### FR11 — Actionable operator diagnostics
+
+Every skipped or failed candidate produces a one-line diagnostic naming the
+cause and a remedy hint. At minimum these common local failure modes are
+covered explicitly:
+- `DISPLAY` unset / WSLg socket absent while a headed candidate is selected
+  ("WSLg not active — headed hardware mode unavailable");
+- `/dev/dxg` present but `/usr/lib/wsl/lib` missing (WSL GPU libs not
+  mounted);
+- d3d12 candidate whose probe returns llvmpipe (Mesa d3d12 driver missing or
+  not selected — hint at the Mesa package / env recipe);
+- probe crash or timeout (report the candidate and where its output/log is).
+Diagnostics go to the terminal as they happen and are summarized before the
+FR10 report. They must make the difference between "no adapter on this host"
+and "adapter present but recipe prerequisite missing" obvious to an operator
+who has not read this spec.
 
 ## Non-Functional Requirements
 
@@ -423,10 +481,11 @@ full Chromium suite runs and passes, final report says hardware + renderer +
 wall-clock.
 
 ### Scenario 2 — Graceful fallback
-Same command on a GPU-less host (or with the adapter path unavailable): a
-clear warning states no adapter was found, the suite runs under SwiftShader,
-the final report unmistakably says software-fallback. Exit code reflects the
-suite result.
+Same command on a GPU-less host (or on any host with the forced-fallback
+control set, e.g. `E2E_GPU_FORCE_FALLBACK=1` — this is how the scenario is
+proven on the GPU-capable qualification host): a clear warning states why no
+hardware candidate ran, the suite runs under SwiftShader, the final report
+unmistakably says software-fallback. Exit code reflects the suite result.
 
 ### Scenario 3 — Canonical gate untouched
 `git diff` on the PR shows no change to `.github/workflows/validation.yml` or

--- a/codev/state/aspir-44_thread.md
+++ b/codev/state/aspir-44_thread.md
@@ -113,3 +113,19 @@
 - Next: clean-worktree `npm run validate` proof (local lint is polluted by the
   untracked .claude/hooks harness file — the documented environment-noise
   class), then porch done → phase-4 CMAP.
+- Clean-checkout validate: run 1 = 21/22 — single `[firefox] matrix.spec.ts:224`
+  background-drag flake (azimuth 0.0038 < floor 1; pre-existing #11/#33
+  software-input-race class, zero e2e/app changes on this branch; preserved
+  verbatim in the review, NOT skipped — spec forbids touching the canonical
+  suite). Run 2 = 22/22 exit 0. Phase-4 CMAP: 3× APPROVE.
+
+## Review phase
+
+- Review doc finalized (summary, spec compliance, deviations, lessons,
+  consultation log, Flaky Tests, follow-ups). Doc updates routed to cold tier:
+  arch.md Validation Baseline gained the GPU-lane paragraph;
+  lessons-learned.md Validation Evidence gained renderer-probe+strict-switch,
+  probe-before-assuming, and timeout-race-reap/DI lessons. Hot tier untouched.
+- **PR #50 opened** (branch builder/aspir-44 → main, Closes #44). Test-count
+  typo in PR body/review corrected (29 new tests, 68 total). Awaiting PR CMAP
+  + human pr gate.

--- a/codev/state/aspir-44_thread.md
+++ b/codev/state/aspir-44_thread.md
@@ -1,0 +1,16 @@
+# Builder thread — aspir-44 (issue #44: opt-in native-GPU local e2e lane)
+
+## Specify
+
+- Spawned in ASPIR strict mode. Spec was pre-written and committed by the architect
+  (`b3d50c3`, `codev/specs/44-add-an-opt-in-native-gpu-local.md`). Issue #44 has no
+  Baked Decisions section; the spec's "Confirmed Decisions" already pin the
+  architecture (wrapper-script lane over the existing `PW_CHROMIUM_ARGS` hook,
+  Approach C).
+- Verified the spec's factual premises against the tree: `PW_CHROMIUM_ARGS` hook is
+  live in `playwright.config.ts` (default-inert, comment block explicitly reserves it
+  for #44), `experiments/42_kaggle_gpu_ci/` evidence artifacts present, `scripts/`
+  exists for the wrapper.
+- Reviewed the spec per the specify prompt: complete against all issue acceptance
+  criteria and constraints. No edits needed. Signaling `porch done 44` to trigger the
+  3-way spec consultation.

--- a/codev/state/aspir-44_thread.md
+++ b/codev/state/aspir-44_thread.md
@@ -14,3 +14,102 @@
 - Reviewed the spec per the specify prompt: complete against all issue acceptance
   criteria and constraints. No edits needed. Signaling `porch done 44` to trigger the
   3-way spec consultation.
+- Spec CMAP iter-1: Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES (4 issues:
+  nondeterministic fallback policy, no way to exercise fallback on a GPU host,
+  under-specified FR5, missing operator-UX requirement). All four accepted — spec
+  updated (deterministic FR3 candidate lifecycle; `E2E_GPU_FORCE_FALLBACK` /
+  `E2E_GPU_REQUIRE` controls in FR2; fixed ≤4-probe FR5 matrix with stop condition;
+  new FR11 diagnostics). Rebuttal recorded; porch advanced to Plan.
+
+## Plan
+
+- Grounded the plan in the tree: `PW_CHROMIUM_ARGS` hook (playwright.config.ts),
+  `test:smoke` = build && playwright test, `npm test` glob `tests/*.test.mjs`
+  (new unit file rides it — no script-chain change), bugfix-22 thread (WSL2 d3d12
+  headed recipe + gl-egl alternate, vulkan→llvmpipe on WSL2), exp42 run #5
+  (native-Linux ANGLE-Vulkan) and the kaggle_e2e_runner.py preflight-probe pattern.
+- Plan committed (07df085): 4 phases — lane_wrapper_core (probe/candidates/policy
+  + GPU-free unit tests), full_lane_and_inertness_proof (npm script, comment-only
+  config sync, FR6 config-load proof), headless_investigation (FR5 matrix),
+  qualification_evidence_and_docs (FR8 runs + README). Key naming decisions:
+  `scripts/e2e-gpu-lane.mjs`, `test:e2e:gpu`, `E2E_GPU_FORCE_FALLBACK`,
+  `E2E_GPU_REQUIRE`. Forced-fallback full run doubles as the SwiftShader baseline
+  wall-clock. 3-way plan consultation running.
+- Plan CMAP iter-1: Gemini APPROVE, Claude APPROVE, Codex COMMENT (2 non-blocking:
+  name the probe-log destination; scrub fallback env). Both folded into the plan
+  (1afb375). Porch advanced to Implement.
+
+## Implement
+
+### Phase 1 — lane_wrapper_core (committed 314fca9)
+
+- Worktree had no local `node_modules` (typecheck was resolving the parent
+  checkout's unpatched tree) — ran a real `npm ci` here; no lockfile delta.
+- `npm run lint` shows 21 errors, ALL in untracked `.claude/hooks/worktree-write-guard.cjs`
+  — the documented environment-noise class (hot lesson). Lane files lint clean;
+  not suppressing in committed config; will prove the gate on a clean checkout at PR.
+- **Hardware verified through the lane on this host**: `--probe-only` selects
+  `wsl2-d3d12-angle-gl` and logs `ANGLE (Microsoft Corporation, D3D12 (NVIDIA
+  GeForce RTX 3080), OpenGL 4.6)` in ~2 s. Force-fallback, contradictory-controls
+  (exit 2), and transcript-log paths all exercised. Unit suite 58/58 (19 new),
+  build green, porch checks green. Impl CMAP iter-1 running.
+- Impl CMAP iter-1: Gemini/Claude APPROVE; Codex REQUEST_CHANGES — real defect:
+  watchdog win before `chromium.launch()` resolved orphaned the late browser.
+  Fixed (launch promise captured outside the race, bounded reap in finally,
+  lost-race rejection absorbed); probeRenderer made injectable; +3 timeout/crash
+  tests (61/61). Committed e9cb4d1; porch then loaded plan-phase tracking and the
+  phase-scoped CMAP for lane_wrapper_core came back 3× APPROVE. Phase 1 done.
+
+### Phase 2 — full_lane_and_inertness_proof (committed d78194b)
+
+- Wrapper now runs the full lane: build → suite via `npx playwright test`
+  (config webServer serves production build), hardware env injected via
+  PW_CHROMIUM_ARGS + recipe env per spawn; fallback spawns from pristine env
+  minus PW_CHROMIUM_ARGS with the loud banner at start and end. Suite exit code
+  = lane exit code. `test:e2e:gpu` npm script added; playwright.config.ts hook
+  comment synced (comment-only diff).
+- FR6 evidence captured: env-unset config-load asserts SwiftShader args /
+  2 projects / workers 1 / retries 0 / timeout 120000; hook-set sanity injects;
+  `git diff main -- playwright.config.ts` comment-only; validation.yml, .nvmrc,
+  lockfile absent from diff. Unit suite 66/66.
+- **Hardware full-suite run #1: 11/11 PASS in 1.6 m** (build 9 s, suite 97 s),
+  renderer `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080),
+  OpenGL 4.6)`, headed WSLg, retries 0, zero flakes on first attempt.
+- **Forced-fallback full-suite run: 11/11 PASS in 9.9 m** (suite 594 s) under
+  SwiftShader with correct loud banners/report — this is the contemporaneous
+  serial baseline. **Hardware suite is 6.1× faster** (97 s vs 594 s). Also
+  qualifies Scenario 2 (fallback path) on this host.
+- Both run logs captured (scratchpad gpu-lane-hw-run-1.log /
+  gpu-lane-fallback-run-1.log) for the FR8 review evidence. Phase-2 CMAP running.
+- Phase-2 CMAP: 3× APPROVE. Porch advanced to headless_investigation.
+
+### Phase 3 — headless_investigation (committed d62dd14)
+
+- **FR5 matrix conclusive POSITIVE, all 4 cells hardware**: {headless shell,
+  new-headless via --channel=chromium (distinguishable at pin 1.61.1: Chrome for
+  Testing 149 vs Chrome Headless Shell 149, both installed)} × {angle-gl,
+  angle-gl-egl} all reach the RTX 3080 through Mesa d3d12 — the d3d12 path needs
+  NO display. angle-gl reports OpenGL 4.6, angle-gl-egl reports OpenGL ES 3.1.
+- Full-suite headless validation: **11/11 in 1.6 m (97 s suite) — identical to
+  headed**. Lane default flipped to headless (headed via --mode=headed; DISPLAY
+  prereq applies only there). Big ergonomic win: no WSLg windows popping up, and
+  the lane now works on display-less WSL2 hosts.
+- Wrapper gained --mode/--candidate/--channel probe overrides (channel is
+  probe-only by construction). 68/68 unit tests. Phase-3 CMAP running.
+- Phase-3 CMAP iter-1: Gemini/Claude APPROVE, Codex REQUEST_CHANGES (process:
+  FR5 evidence must live in the review artifact, not just this thread). Fixed —
+  created codev/reviews/44-add-an-opt-in-native-gpu-local.md with FR5 matrix,
+  FR6 evidence, seeded FR8 table (bbc0f09). Iter-2 CMAP passed; porch advanced.
+
+### Phase 4 — qualification_evidence_and_docs
+
+- **FR8 qualification: 3/3 consecutive full-suite runs under E2E_GPU_REQUIRE=1,
+  all 11/11 pass** — suite 94/95/95 s, renderer asserted identical each run,
+  retries 0, zero flakes, per-test spread ≤1.0 s. Lane is 5-for-5 hardware
+  passes overall. Recorded with per-test table in the review artifact.
+- README: full lane section (command, report semantics, WSL2 d3d12 recipe,
+  headless outcome, env controls, non-gate status, #41 sequencing) + a
+  Validation-commands table row marked "Not part of the gate".
+- Next: clean-worktree `npm run validate` proof (local lint is polluted by the
+  untracked .claude/hooks harness file — the documented environment-noise
+  class), then porch done → phase-4 CMAP.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "node --test tests/*.test.mjs",
     "browser:install": "playwright install chromium firefox",
     "test:smoke": "npm run build && playwright test",
+    "test:e2e:gpu": "node scripts/e2e-gpu-lane.mjs",
     "validate": "npm run lint && npm run typecheck && npm run test:smoke",
     "audit:full": "npm audit",
     "audit:production": "npm audit --omit=dev"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,13 +12,15 @@ const baseURL = "http://127.0.0.1:3000";
 // deterministic software-WebGL rasterizer as before. This indirection does not
 // change any default behavior.
 //
-// OPT-IN: an opt-in lane may set PW_CHROMIUM_ARGS to a hardware-WebGL flag set
-// instead of software SwiftShader. Experiment 42 added this hook to run the suite
-// on a real GPU; the *Kaggle* path was REJECTED on Kaggle-AUP grounds (see
-// experiments/42_kaggle_gpu_ci/notes.md) and its dispatch workflow was removed.
-// The hook is retained to serve issue #44 (opt-in native-GPU LOCAL lane), which
-// can set PW_CHROMIUM_ARGS to the ANGLE-Vulkan flag set proven in experiment 42
-// run #5 — on real local hardware, with no third party or ToS exposure.
+// OPT-IN: the native-GPU local lane (`npm run test:e2e:gpu`, issue #44 —
+// scripts/e2e-gpu-lane.mjs) consumes this hook: it probes the host, VERIFIES
+// the effective renderer through this repo's own Chromium, and only then sets
+// PW_CHROMIUM_ARGS to the verified hardware-WebGL flag set (falling back to
+// leaving it unset — i.e. these SwiftShader defaults — when no adapter
+// verifies). Experiment 42 added the hook for a Kaggle GPU path that was
+// REJECTED on Kaggle-AUP grounds (see experiments/42_kaggle_gpu_ci/notes.md);
+// the lane runs on real local hardware with no third party or ToS exposure.
+// The lane is additional evidence, never the green gate.
 const SWIFTSHADER_CHROMIUM_ARGS = [
     "--use-angle=swiftshader",
     "--enable-unsafe-swiftshader",

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+// Opt-in native-GPU local e2e lane (issue #44, spec/plan 44).
+//
+// This wrapper is ADDITIONAL tooling, never the green gate: `npm run validate`
+// and CI stay on the qualified SwiftShader serial path. It probes the host for
+// a usable hardware-WebGL recipe, verifies the effective renderer through the
+// repo's own Playwright Chromium BEFORE trusting anything, and (phase 2) runs
+// the full Chromium e2e suite under the verified flags — falling back loudly
+// to default SwiftShader rendering when no hardware candidate verifies.
+//
+// Deterministic candidate lifecycle (spec FR3):
+//   1. prereq check   — unusable candidates are SKIPPED with an actionable
+//                       one-line diagnostic; they are never attempted.
+//   2. verification   — the candidate's renderer probe must return a string
+//                       that survives the deny-list (no SwiftShader/llvmpipe/
+//                       software rasterizer); crash/timeout/software ⇒ FAILED,
+//                       next candidate is tried.
+//   3. exhaustion     — all skipped/failed ⇒ loud software fallback. Never a
+//                       hard failure by default; E2E_GPU_REQUIRE=1 converts
+//                       exhaustion into a non-zero exit for qualification
+//                       integrity.
+//
+// Env controls (read ONLY by this wrapper; nothing committed elsewhere reads
+// them — spec FR2/FR7):
+//   E2E_GPU_FORCE_FALLBACK=1  skip all hardware candidates; go straight to the
+//                             software-fallback path (how Scenario 2 is proven
+//                             on a GPU-capable host).
+//   E2E_GPU_REQUIRE=1         exit non-zero instead of falling back when no
+//                             candidate verifies (hardware-evidence integrity).
+//
+// Recipe provenance: WSL2 Mesa d3d12 headed recipe proven end-to-end on this
+// host class in bugfix-22 / PR #43 (ANGLE→GL and ANGLE→GL-EGL both reached the
+// adapter; ANGLE→Vulkan is a known llvmpipe dead end on WSL2). Native-Linux
+// ANGLE-Vulkan proven on a Tesla T4 in experiment 42 run #5.
+
+import {existsSync, mkdirSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
+import {pathToFileURL} from "node:url";
+import process from "node:process";
+
+// ---------------------------------------------------------------------------
+// Constants and candidate data
+// ---------------------------------------------------------------------------
+
+const LOG_PREFIX = "[gpu-lane]";
+const WSL_LIB_DIR = "/usr/lib/wsl/lib";
+const WSLG_X11_SOCKET = "/mnt/wslg/.X11-unix";
+const DXG_DEVICE = "/dev/dxg";
+// Playwright wipes its own outputDir (test-results/) at suite start, so probe
+// transcripts live in a dedicated gitignored directory that survives the run.
+const PROBE_LOG_DIR = "gpu-lane-logs";
+// Launch-to-verdict budget per candidate. A probe that cannot produce a
+// renderer string inside this window is a failed candidate, not a hang.
+const PROBE_TOTAL_TIMEOUT_MS = 45_000;
+const PROBE_LAUNCH_TIMEOUT_MS = 30_000;
+
+// Renderer deny-list (spec FR3): any match ⇒ software rendering. Markers from
+// experiment 42's probe plus the proven local strings.
+const SOFTWARE_RENDERER_MARKERS = [
+    "swiftshader",
+    "llvmpipe",
+    "software",
+    "microsoft basic",
+];
+
+// Data-driven candidate list, ordered by evidence strength (spec FR2: adding a
+// future recipe means appending an entry, not restructuring the lane).
+// Shape: {id, summary, hostClass, flags, env, envPrepend, mode}.
+export const CANDIDATES = [
+    {
+        id: "wsl2-d3d12-angle-gl",
+        summary:
+            "WSL2 Mesa d3d12 via ANGLE native-GL (proven: bugfix-22 / PR #43)",
+        hostClass: "wsl2",
+        flags: [
+            "--use-gl=angle",
+            "--use-angle=gl",
+            "--ignore-gpu-blocklist",
+            "--disable-gpu-sandbox",
+        ],
+        env: {GALLIUM_DRIVER: "d3d12"},
+        envPrepend: {LD_LIBRARY_PATH: WSL_LIB_DIR},
+        mode: "headed",
+    },
+    {
+        id: "wsl2-d3d12-angle-gl-egl",
+        summary:
+            "WSL2 Mesa d3d12 via ANGLE GL-EGL (proven alternate, OpenGL ES 3.1)",
+        hostClass: "wsl2",
+        flags: [
+            "--use-gl=angle",
+            "--use-angle=gl-egl",
+            "--ignore-gpu-blocklist",
+            "--disable-gpu-sandbox",
+        ],
+        env: {GALLIUM_DRIVER: "d3d12"},
+        envPrepend: {LD_LIBRARY_PATH: WSL_LIB_DIR},
+        mode: "headed",
+    },
+    {
+        id: "native-linux-angle-vulkan",
+        summary:
+            "Native Linux via ANGLE-Vulkan (proven: experiment 42 run #5, Tesla T4)",
+        hostClass: "native-linux",
+        flags: [
+            "--use-gl=angle",
+            "--use-angle=vulkan",
+            "--enable-features=Vulkan",
+            "--ignore-gpu-blocklist",
+        ],
+        env: {},
+        envPrepend: {},
+        mode: "headless",
+    },
+    {
+        id: "native-linux-angle-gl",
+        summary: "Native Linux via ANGLE native-GL (untested variant)",
+        hostClass: "native-linux",
+        flags: ["--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist"],
+        env: {},
+        envPrepend: {},
+        mode: "headless",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Pure logic (unit-tested in tests/gpu-lane.test.mjs; no I/O, no Playwright)
+// ---------------------------------------------------------------------------
+
+// Lane misuse (contradictory controls, unknown CLI args) — a hard failure in
+// every mode, unlike hardware absence which is never one by default.
+export class LaneUsageError extends Error {}
+
+export function classifyRenderer(renderer) {
+    if (typeof renderer !== "string" || renderer.trim().length === 0) {
+        return "none";
+    }
+    const lower = renderer.toLowerCase();
+    return SOFTWARE_RENDERER_MARKERS.some((marker) => lower.includes(marker))
+        ? "software"
+        : "hardware";
+}
+
+export function parseControls(env) {
+    const enabled = (value) => value === "1" || value === "true";
+    const forceFallback = enabled(env.E2E_GPU_FORCE_FALLBACK);
+    const requireHardware = enabled(env.E2E_GPU_REQUIRE);
+    if (forceFallback && requireHardware) {
+        throw new LaneUsageError(
+            "E2E_GPU_FORCE_FALLBACK and E2E_GPU_REQUIRE are contradictory " +
+                "(cannot require hardware while forcing software fallback)",
+        );
+    }
+    return {forceFallback, requireHardware};
+}
+
+// Snapshot of the host facts the prereq checks read. Injected in unit tests;
+// built from the real fs/env by main().
+export function buildHostView({platform, exists, env}) {
+    return {
+        platform,
+        hasDxg: exists(DXG_DEVICE),
+        hasWslLib: exists(WSL_LIB_DIR),
+        hasWslgSocket: exists(WSLG_X11_SOCKET),
+        display: env.DISPLAY ?? null,
+    };
+}
+
+// Prereq check (FR3 step 1). Returns {usable, skipped}: usable entries carry
+// `extraEnv` (e.g. a defaulted DISPLAY) alongside the candidate; skipped
+// entries carry the FR11 cause + remedy diagnostic.
+export function partitionCandidates(hostView, candidates = CANDIDATES) {
+    const usable = [];
+    const skipped = [];
+    for (const candidate of candidates) {
+        if (hostView.platform !== "linux") {
+            skipped.push({
+                candidate,
+                diagnostic:
+                    `platform is ${hostView.platform} — the lane is qualified ` +
+                    "on Linux/WSL2 only (other platforms: untested, use the " +
+                    "default SwiftShader suite)",
+            });
+            continue;
+        }
+        if (candidate.hostClass === "wsl2") {
+            if (!hostView.hasDxg) {
+                skipped.push({
+                    candidate,
+                    diagnostic:
+                        `${DXG_DEVICE} absent — WSL2 GPU paravirtualization ` +
+                        "not available (not a WSL2 host, or WSL GPU support " +
+                        "is disabled)",
+                });
+                continue;
+            }
+            if (!hostView.hasWslLib) {
+                skipped.push({
+                    candidate,
+                    diagnostic:
+                        `${DXG_DEVICE} present but ${WSL_LIB_DIR} missing — ` +
+                        "WSL GPU driver libraries not mounted; update WSL " +
+                        "(`wsl --update`) and ensure GPU support is enabled",
+                });
+                continue;
+            }
+            let extraEnv = {};
+            if (candidate.mode === "headed") {
+                if (!hostView.display && !hostView.hasWslgSocket) {
+                    skipped.push({
+                        candidate,
+                        diagnostic:
+                            `DISPLAY unset and ${WSLG_X11_SOCKET} absent — ` +
+                            "WSLg not active, headed hardware mode " +
+                            "unavailable (start WSLg or export DISPLAY to a " +
+                            "reachable X server)",
+                    });
+                    continue;
+                }
+                if (!hostView.display) {
+                    // WSLg is present but the shell did not export DISPLAY;
+                    // default to WSLg's standard :0 (the PR #43 recipe).
+                    extraEnv = {DISPLAY: ":0"};
+                }
+            }
+            usable.push({candidate, extraEnv});
+            continue;
+        }
+        // native-linux candidates
+        if (hostView.hasDxg) {
+            skipped.push({
+                candidate,
+                diagnostic:
+                    `host is WSL2 (${DXG_DEVICE} present) — ANGLE-Vulkan/` +
+                    "native-GL is a known llvmpipe dead end under WSL2; the " +
+                    "d3d12 recipe covers this host",
+            });
+            continue;
+        }
+        usable.push({candidate, extraEnv: {}});
+    }
+    return {usable, skipped};
+}
+
+// Compose the spawn/launch env for a candidate from a base env, WITHOUT
+// mutating the base (fallback correctness depends on the base staying
+// pristine). Operator-set disambiguators (MESA_D3D12_DEFAULT_ADAPTER_NAME,
+// LIBGL_ALWAYS_SOFTWARE) simply pass through from the base.
+export function composeEnv(baseEnv, candidate, extraEnv = {}) {
+    const env = {...baseEnv, ...candidate.env, ...extraEnv};
+    for (const [key, value] of Object.entries(candidate.envPrepend)) {
+        env[key] = baseEnv[key] ? `${value}:${baseEnv[key]}` : value;
+    }
+    return env;
+}
+
+// Env for the software-fallback suite run: the pristine inherited env minus
+// PW_CHROMIUM_ARGS (guaranteeing the config's default SwiftShader args even
+// if the operator's shell had it exported). No lane recipe key can leak in
+// because recipe env is composed per-spawn, never written into process.env.
+export function fallbackEnv(baseEnv) {
+    const env = {...baseEnv};
+    delete env.PW_CHROMIUM_ARGS;
+    return env;
+}
+
+// FR11 diagnostic for a FAILED (attempted) candidate.
+export function failureDiagnostic(attempt) {
+    const {candidate, renderer, rendererClass, error, logPath} = attempt;
+    const where = logPath ? ` — probe transcript: ${logPath}` : "";
+    if (error) {
+        return (
+            `candidate ${candidate.id} FAILED (${error}) — probe crashed or ` +
+            `timed out under this flag/env set${where}`
+        );
+    }
+    if (rendererClass === "none") {
+        return (
+            `candidate ${candidate.id} produced no usable WebGL context / ` +
+            `empty renderer string${where}`
+        );
+    }
+    const mesaHint =
+        candidate.hostClass === "wsl2"
+            ? "Mesa d3d12 driver missing or not selected (needs Mesa with " +
+              "the d3d12 gallium driver; recipe env GALLIUM_DRIVER=d3d12, " +
+              `LD_LIBRARY_PATH=${WSL_LIB_DIR})`
+            : "adapter not reachable via this backend";
+    return (
+        `candidate ${candidate.id} returned SOFTWARE renderer ` +
+        `"${renderer}" — ${mesaHint}${where}`
+    );
+}
+
+// Machine-greppable final report (spec FR10). Stable keys — the FR8 stability
+// evidence and future #41 qualification grep these exact lines.
+export function formatReport({mode, renderer, suite, wallClock}) {
+    return [
+        "=== E2E GPU LANE REPORT ===",
+        `mode: ${mode}`,
+        `renderer: ${renderer ?? "(none — suite ran without a probe verdict)"}`,
+        "engine: chromium",
+        `suite: ${suite}`,
+        `wall-clock: ${wallClock}`,
+    ].join("\n");
+}
+
+// FR3 steps 2–3: try usable candidates in order with the injected probe until
+// one verifies as hardware; report every attempt. `probe` is injected so unit
+// tests never touch Playwright.
+export async function runSelection({usable, probe, log}) {
+    const attempts = [];
+    for (const {candidate, extraEnv} of usable) {
+        log(`probing candidate ${candidate.id} (${candidate.summary})`);
+        const attempt = await probe(candidate, extraEnv);
+        attempts.push(attempt);
+        if (!attempt.error && attempt.rendererClass === "hardware") {
+            log(
+                `candidate ${candidate.id} VERIFIED hardware renderer: ` +
+                    `"${attempt.renderer}"`,
+            );
+            return {status: "hardware", attempt, attempts};
+        }
+        log(failureDiagnostic(attempt));
+    }
+    return {status: "exhausted", attempts};
+}
+
+// ---------------------------------------------------------------------------
+// Side-effectful pieces (probe + CLI)
+// ---------------------------------------------------------------------------
+
+function timestamp() {
+    return new Date().toISOString();
+}
+
+// Launch the repo's own Playwright Chromium under the candidate's flags/env
+// and read the effective UNMASKED_RENDERER_WEBGL. The page-side body is a
+// string because it runs in the browser, not in Node (and the file's lint
+// scope is Node globals only).
+const PROBE_PAGE_SCRIPT = `(() => {
+    const canvas = document.createElement("canvas");
+    const gl =
+        canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    if (!gl) {
+        return {renderer: null, vendor: null};
+    }
+    const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+    return {
+        renderer: dbg
+            ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)
+            : gl.getParameter(gl.RENDERER),
+        vendor: dbg
+            ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL)
+            : gl.getParameter(gl.VENDOR),
+    };
+})()`;
+
+async function probeRenderer(candidate, extraEnv, {baseEnv, headless}) {
+    const startedAt = Date.now();
+    const transcript = [];
+    const logLine = (line) => transcript.push(`${timestamp()} ${line}`);
+    mkdirSync(PROBE_LOG_DIR, {recursive: true});
+    const logPath = join(PROBE_LOG_DIR, `probe-${candidate.id}.log`);
+    const env = composeEnv(baseEnv, candidate, extraEnv);
+    logLine(`candidate: ${candidate.id} (${candidate.summary})`);
+    logLine(`flags: ${candidate.flags.join(" ")}`);
+    logLine(
+        `env injected: ${JSON.stringify({
+            ...candidate.env,
+            ...extraEnv,
+            ...Object.fromEntries(
+                Object.keys(candidate.envPrepend).map((key) => [
+                    key,
+                    env[key],
+                ]),
+            ),
+        })}`,
+    );
+    logLine(`mode: ${headless ? "headless" : "headed"}`);
+
+    const attempt = {
+        candidate,
+        headless,
+        renderer: null,
+        vendor: null,
+        rendererClass: "none",
+        error: null,
+        logPath,
+        durationMs: 0,
+    };
+
+    let browser = null;
+    let timer = null;
+    try {
+        const {chromium} = await import("@playwright/test");
+        const work = (async () => {
+            browser = await chromium.launch({
+                headless,
+                args: candidate.flags,
+                env,
+                timeout: PROBE_LAUNCH_TIMEOUT_MS,
+            });
+            const page = await browser.newPage();
+            return page.evaluate(PROBE_PAGE_SCRIPT);
+        })();
+        const watchdog = new Promise((_, reject) => {
+            timer = setTimeout(
+                () =>
+                    reject(
+                        new Error(
+                            `probe timeout after ${PROBE_TOTAL_TIMEOUT_MS}ms`,
+                        ),
+                    ),
+                PROBE_TOTAL_TIMEOUT_MS,
+            );
+        });
+        const result = await Promise.race([work, watchdog]);
+        attempt.renderer = result.renderer;
+        attempt.vendor = result.vendor;
+        attempt.rendererClass = classifyRenderer(result.renderer);
+        logLine(`renderer: ${JSON.stringify(result.renderer)}`);
+        logLine(`vendor: ${JSON.stringify(result.vendor)}`);
+        logLine(`class: ${attempt.rendererClass}`);
+    } catch (error) {
+        attempt.error = error instanceof Error ? error.message : String(error);
+        logLine(`ERROR: ${attempt.error}`);
+        if (error instanceof Error && error.stack) {
+            logLine(error.stack);
+        }
+    } finally {
+        clearTimeout(timer);
+        if (browser) {
+            // Close must not wedge the lane on an already-hung browser.
+            await Promise.race([
+                browser.close().catch(() => {}),
+                new Promise((resolve) => setTimeout(resolve, 5_000)),
+            ]);
+        }
+        attempt.durationMs = Date.now() - startedAt;
+        logLine(`duration: ${attempt.durationMs}ms`);
+        writeFileSync(logPath, `${transcript.join("\n")}\n`);
+    }
+    return attempt;
+}
+
+function log(message) {
+    console.log(`${LOG_PREFIX} ${message}`);
+}
+
+function fallbackWarning(reason) {
+    const banner = "=".repeat(66);
+    for (const line of [
+        banner,
+        "WARNING: SOFTWARE FALLBACK — this run is NOT hardware WebGL",
+        `reason: ${reason}`,
+        "Its results must never be cited as hardware evidence.",
+        banner,
+    ]) {
+        log(line);
+    }
+}
+
+function parseArgs(argv) {
+    const args = {probeOnly: false};
+    for (const arg of argv) {
+        if (arg === "--probe-only") {
+            args.probeOnly = true;
+        } else {
+            throw new LaneUsageError(`unknown argument: ${arg}`);
+        }
+    }
+    return args;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const controls = parseControls(process.env);
+    const startedAt = Date.now();
+    const wallClock = () => `${Math.round((Date.now() - startedAt) / 1000)}s`;
+
+    if (!args.probeOnly) {
+        // Suite execution lands in plan phase 2 (full_lane_and_inertness_proof).
+        throw new LaneUsageError(
+            "full-suite execution is not wired yet — run with --probe-only",
+        );
+    }
+
+    if (controls.forceFallback) {
+        fallbackWarning("forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)");
+        console.log(
+            formatReport({
+                mode: "software-fallback",
+                renderer:
+                    "(not probed — default SwiftShader args would be used)",
+                suite: "skipped (--probe-only)",
+                wallClock: wallClock(),
+            }),
+        );
+        return 0;
+    }
+
+    const hostView = buildHostView({
+        platform: process.platform,
+        exists: existsSync,
+        env: process.env,
+    });
+    log(
+        `host: platform=${hostView.platform} dxg=${hostView.hasDxg} ` +
+            `wslLib=${hostView.hasWslLib} wslgSocket=${hostView.hasWslgSocket} ` +
+            `DISPLAY=${hostView.display ?? "(unset)"}`,
+    );
+    const {usable, skipped} = partitionCandidates(hostView);
+    for (const skip of skipped) {
+        log(`candidate ${skip.candidate.id} SKIPPED: ${skip.diagnostic}`);
+    }
+
+    const selection = await runSelection({
+        usable,
+        probe: (candidate, extraEnv) =>
+            probeRenderer(candidate, extraEnv, {
+                baseEnv: process.env,
+                headless: candidate.mode !== "headed",
+            }),
+        log,
+    });
+
+    if (selection.status === "hardware") {
+        console.log(
+            formatReport({
+                mode: "hardware",
+                renderer: selection.attempt.renderer,
+                suite: "skipped (--probe-only)",
+                wallClock: wallClock(),
+            }),
+        );
+        return 0;
+    }
+
+    // Exhausted. Summarize every skip/failure (FR11) before deciding.
+    log("no hardware candidate verified; summary:");
+    for (const skip of skipped) {
+        log(`  SKIPPED ${skip.candidate.id}: ${skip.diagnostic}`);
+    }
+    for (const attempt of selection.attempts) {
+        log(`  FAILED  ${failureDiagnostic(attempt)}`);
+    }
+    if (controls.requireHardware) {
+        log("E2E_GPU_REQUIRE=1 — exiting non-zero instead of falling back");
+        return 1;
+    }
+    fallbackWarning(
+        "no usable hardware candidate (see per-candidate diagnostics above)",
+    );
+    console.log(
+        formatReport({
+            mode: "software-fallback",
+            renderer:
+                "(no hardware renderer — default SwiftShader args would be used)",
+            suite: "skipped (--probe-only)",
+            wallClock: wallClock(),
+        }),
+    );
+    return 0;
+}
+
+const isMain =
+    process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+    main()
+        .then((code) => {
+            process.exitCode = code;
+        })
+        .catch((error) => {
+            if (error instanceof LaneUsageError) {
+                console.error(`${LOG_PREFIX} usage error: ${error.message}`);
+                process.exitCode = 2;
+            } else {
+                console.error(`${LOG_PREFIX} internal error:`, error);
+                process.exitCode = 1;
+            }
+        });
+}

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -356,11 +356,34 @@ const PROBE_PAGE_SCRIPT = `(() => {
     };
 })()`;
 
-async function probeRenderer(candidate, extraEnv, {baseEnv, headless}) {
+function writeTranscriptFile(logPath, text) {
+    mkdirSync(PROBE_LOG_DIR, {recursive: true});
+    writeFileSync(logPath, text);
+}
+
+async function importChromium() {
+    const {chromium} = await import("@playwright/test");
+    return chromium;
+}
+
+// Exported for the timed-out-probe cleanup tests: `launcher`, timeouts, and
+// transcript writing are injectable; defaults are the real Playwright path.
+export async function probeRenderer(
+    candidate,
+    extraEnv,
+    {
+        baseEnv,
+        headless,
+        launcher = importChromium,
+        totalTimeoutMs = PROBE_TOTAL_TIMEOUT_MS,
+        launchTimeoutMs = PROBE_LAUNCH_TIMEOUT_MS,
+        closeTimeoutMs = 5_000,
+        writeTranscript = writeTranscriptFile,
+    },
+) {
     const startedAt = Date.now();
     const transcript = [];
     const logLine = (line) => transcript.push(`${timestamp()} ${line}`);
-    mkdirSync(PROBE_LOG_DIR, {recursive: true});
     const logPath = join(PROBE_LOG_DIR, `probe-${candidate.id}.log`);
     const env = composeEnv(baseEnv, candidate, extraEnv);
     logLine(`candidate: ${candidate.id} (${candidate.summary})`);
@@ -390,29 +413,36 @@ async function probeRenderer(candidate, extraEnv, {baseEnv, headless}) {
         durationMs: 0,
     };
 
-    let browser = null;
+    // The launch promise is captured OUTSIDE the raced work so a watchdog win
+    // can still reap a late-resolving browser: without this, a timeout firing
+    // before launch resolves would orphan the Chromium process and keep the
+    // lane alive (Codex impl-review, iteration 1).
+    let launchPromise = null;
     let timer = null;
     try {
-        const {chromium} = await import("@playwright/test");
+        const chromium = await launcher();
         const work = (async () => {
-            browser = await chromium.launch({
+            launchPromise = chromium.launch({
                 headless,
                 args: candidate.flags,
                 env,
-                timeout: PROBE_LAUNCH_TIMEOUT_MS,
+                timeout: launchTimeoutMs,
             });
+            const browser = await launchPromise;
             const page = await browser.newPage();
             return page.evaluate(PROBE_PAGE_SCRIPT);
         })();
+        // If the watchdog settles the race first, `work` may still reject
+        // later (launch failure, closed browser); absorb it so a lost race
+        // can never surface as an unhandled rejection.
+        work.catch(() => {});
         const watchdog = new Promise((_, reject) => {
             timer = setTimeout(
                 () =>
                     reject(
-                        new Error(
-                            `probe timeout after ${PROBE_TOTAL_TIMEOUT_MS}ms`,
-                        ),
+                        new Error(`probe timeout after ${totalTimeoutMs}ms`),
                     ),
-                PROBE_TOTAL_TIMEOUT_MS,
+                totalTimeoutMs,
             );
         });
         const result = await Promise.race([work, watchdog]);
@@ -430,16 +460,21 @@ async function probeRenderer(candidate, extraEnv, {baseEnv, headless}) {
         }
     } finally {
         clearTimeout(timer);
-        if (browser) {
-            // Close must not wedge the lane on an already-hung browser.
+        if (launchPromise) {
+            // Reap the browser even when the watchdog won the race: await the
+            // (possibly still-pending) launch and close its browser, bounded
+            // so cleanup can never wedge the lane on a hung launch — the
+            // launch's own timeout eventually rejects and is absorbed.
             await Promise.race([
-                browser.close().catch(() => {}),
-                new Promise((resolve) => setTimeout(resolve, 5_000)),
+                launchPromise.then((browser) => browser.close()).catch(
+                    () => {},
+                ),
+                new Promise((resolve) => setTimeout(resolve, closeTimeoutMs)),
             ]);
         }
         attempt.durationMs = Date.now() - startedAt;
         logLine(`duration: ${attempt.durationMs}ms`);
-        writeFileSync(logPath, `${transcript.join("\n")}\n`);
+        writeTranscript(logPath, `${transcript.join("\n")}\n`);
     }
     return attempt;
 }

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -4,9 +4,10 @@
 // This wrapper is ADDITIONAL tooling, never the green gate: `npm run validate`
 // and CI stay on the qualified SwiftShader serial path. It probes the host for
 // a usable hardware-WebGL recipe, verifies the effective renderer through the
-// repo's own Playwright Chromium BEFORE trusting anything, and (phase 2) runs
-// the full Chromium e2e suite under the verified flags — falling back loudly
-// to default SwiftShader rendering when no hardware candidate verifies.
+// repo's own Playwright Chromium BEFORE trusting anything, and runs the full
+// Chromium e2e suite under the verified flags (build → production server →
+// suite, mirroring `test:smoke`) — falling back loudly to default SwiftShader
+// rendering when no hardware candidate verifies.
 //
 // Deterministic candidate lifecycle (spec FR3):
 //   1. prereq check   — unusable candidates are SKIPPED with an actionable
@@ -33,6 +34,7 @@
 // adapter; ANGLE→Vulkan is a known llvmpipe dead end on WSL2). Native-Linux
 // ANGLE-Vulkan proven on a Tesla T4 in experiment 42 run #5.
 
+import {spawn} from "node:child_process";
 import {existsSync, mkdirSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
 import {pathToFileURL} from "node:url";
@@ -305,6 +307,37 @@ export function formatReport({mode, renderer, suite, wallClock}) {
     ].join("\n");
 }
 
+// Env for the actual suite run (spec FR4: full Chromium suite, workers/
+// retries/timeouts untouched — those stay the config's own defaults).
+// Hardware mode injects the verified recipe via the merged PW_CHROMIUM_ARGS
+// hook; fallback mode guarantees the config's default SwiftShader args.
+export function suiteEnvFor(mode, baseEnv, candidate = null, extraEnv = {}) {
+    if (mode === "hardware") {
+        const env = composeEnv(baseEnv, candidate, extraEnv);
+        env.E2E_ENGINES = "chromium";
+        env.PW_CHROMIUM_ARGS = candidate.flags.join(" ");
+        return env;
+    }
+    const env = fallbackEnv(baseEnv);
+    env.E2E_ENGINES = "chromium";
+    return env;
+}
+
+// Headed mode reaches Playwright through the CLI flag — no config change.
+export function playwrightTestArgs(headed) {
+    return headed ? ["playwright", "test", "--headed"] : ["playwright", "test"];
+}
+
+export function suiteResultLabel(exitCode) {
+    return exitCode === 0 ? "pass" : `fail (exit ${exitCode})`;
+}
+
+export function formatWallClock(totalSeconds, buildSeconds, suiteSeconds) {
+    return (
+        `${totalSeconds}s (build ${buildSeconds}s, suite ${suiteSeconds}s)`
+    );
+}
+
 // FR3 steps 2–3: try usable candidates in order with the injected probe until
 // one verifies as hardware; report every attempt. `probe` is injected so unit
 // tests never touch Playwright.
@@ -508,31 +541,33 @@ function parseArgs(argv) {
     return args;
 }
 
-async function main() {
-    const args = parseArgs(process.argv.slice(2));
-    const controls = parseControls(process.env);
+// Run one delegated stage (build or suite) with inherited stdio so its own
+// output streams through; the lane never re-implements what the stage does.
+function runStage(label, command, commandArgs, env) {
+    log(`running ${label}: ${command} ${commandArgs.join(" ")}`);
     const startedAt = Date.now();
-    const wallClock = () => `${Math.round((Date.now() - startedAt) / 1000)}s`;
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, commandArgs, {env, stdio: "inherit"});
+        child.on("error", reject);
+        child.on("close", (code) => {
+            resolve({
+                code: code ?? 1,
+                seconds: Math.round((Date.now() - startedAt) / 1000),
+            });
+        });
+    });
+}
 
-    if (!args.probeOnly) {
-        // Suite execution lands in plan phase 2 (full_lane_and_inertness_proof).
-        throw new LaneUsageError(
-            "full-suite execution is not wired yet — run with --probe-only",
-        );
-    }
-
+// Probe the host and settle on the run mode (FR2/FR3). Returns
+// {mode: "hardware", candidate, extraEnv, renderer} |
+// {mode: "software-fallback", renderer} | {mode: "abort"} (E2E_GPU_REQUIRE).
+async function resolveMode(controls) {
     if (controls.forceFallback) {
         fallbackWarning("forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)");
-        console.log(
-            formatReport({
-                mode: "software-fallback",
-                renderer:
-                    "(not probed — default SwiftShader args would be used)",
-                suite: "skipped (--probe-only)",
-                wallClock: wallClock(),
-            }),
-        );
-        return 0;
+        return {
+            mode: "software-fallback",
+            renderer: "(not probed — default SwiftShader args used)",
+        };
     }
 
     const hostView = buildHostView({
@@ -561,15 +596,16 @@ async function main() {
     });
 
     if (selection.status === "hardware") {
-        console.log(
-            formatReport({
-                mode: "hardware",
-                renderer: selection.attempt.renderer,
-                suite: "skipped (--probe-only)",
-                wallClock: wallClock(),
-            }),
-        );
-        return 0;
+        return {
+            mode: "hardware",
+            candidate: selection.attempt.candidate,
+            extraEnv:
+                usable.find(
+                    (entry) =>
+                        entry.candidate === selection.attempt.candidate,
+                )?.extraEnv ?? {},
+            renderer: selection.attempt.renderer,
+        };
     }
 
     // Exhausted. Summarize every skip/failure (FR11) before deciding.
@@ -582,21 +618,88 @@ async function main() {
     }
     if (controls.requireHardware) {
         log("E2E_GPU_REQUIRE=1 — exiting non-zero instead of falling back");
-        return 1;
+        return {mode: "abort"};
     }
     fallbackWarning(
         "no usable hardware candidate (see per-candidate diagnostics above)",
     );
+    return {
+        mode: "software-fallback",
+        renderer: "(no hardware renderer — default SwiftShader args used)",
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const controls = parseControls(process.env);
+    const startedAt = Date.now();
+    const elapsedSeconds = () => Math.round((Date.now() - startedAt) / 1000);
+
+    const outcome = await resolveMode(controls);
+    if (outcome.mode === "abort") {
+        return 1;
+    }
+
+    if (args.probeOnly) {
+        console.log(
+            formatReport({
+                mode: outcome.mode,
+                renderer: outcome.renderer,
+                suite: "skipped (--probe-only)",
+                wallClock: `${elapsedSeconds()}s`,
+            }),
+        );
+        return 0;
+    }
+
+    // Full lane: build + suite, mirroring `test:smoke` (build && playwright
+    // test; the production server comes from the config's webServer block).
+    // The build never needs recipe env; it runs under the untouched
+    // inherited env in both modes.
+    const build = await runStage("build", "npm", ["run", "build"], process.env);
+    if (build.code !== 0) {
+        // A failed build is a lane-internal hard failure in every mode (FR3).
+        log(`build FAILED (exit ${build.code}) — not running the suite`);
+        console.log(
+            formatReport({
+                mode: outcome.mode,
+                renderer: outcome.renderer,
+                suite: `not-run (build failed, exit ${build.code})`,
+                wallClock: `${elapsedSeconds()}s (build ${build.seconds}s)`,
+            }),
+        );
+        return build.code;
+    }
+
+    const headed =
+        outcome.mode === "hardware" && outcome.candidate.mode === "headed";
+    const suite = await runStage(
+        "suite",
+        "npx",
+        playwrightTestArgs(headed),
+        suiteEnvFor(outcome.mode, process.env, outcome.candidate,
+            outcome.extraEnv),
+    );
+
+    if (outcome.mode === "software-fallback") {
+        // FR3: the fallback notice appears at start AND with the final
+        // report, so fallback output can never read as hardware evidence.
+        fallbackWarning("this suite ran under SOFTWARE rendering (see above)");
+    }
     console.log(
         formatReport({
-            mode: "software-fallback",
-            renderer:
-                "(no hardware renderer — default SwiftShader args would be used)",
-            suite: "skipped (--probe-only)",
-            wallClock: wallClock(),
+            mode: outcome.mode,
+            renderer: outcome.renderer,
+            suite: suiteResultLabel(suite.code),
+            wallClock: formatWallClock(
+                elapsedSeconds(),
+                build.seconds,
+                suite.seconds,
+            ),
         }),
     );
-    return 0;
+    // The suite's own pass/fail semantics are the lane's exit code (FR3).
+    return suite.code;
 }
 
 const isMain =

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -29,10 +29,15 @@
 //   E2E_GPU_REQUIRE=1         exit non-zero instead of falling back when no
 //                             candidate verifies (hardware-evidence integrity).
 //
-// Recipe provenance: WSL2 Mesa d3d12 headed recipe proven end-to-end on this
-// host class in bugfix-22 / PR #43 (ANGLE→GL and ANGLE→GL-EGL both reached the
+// Recipe provenance: WSL2 Mesa d3d12 recipe proven end-to-end on this host
+// class in bugfix-22 / PR #43 (ANGLE→GL and ANGLE→GL-EGL both reached the
 // adapter; ANGLE→Vulkan is a known llvmpipe dead end on WSL2). Native-Linux
-// ANGLE-Vulkan proven on a Tesla T4 in experiment 42 run #5.
+// ANGLE-Vulkan proven on a Tesla T4 in experiment 42 run #5. The FR5 matrix
+// (spec 44) then proved the d3d12 recipe does NOT need a display: default
+// headless (headless shell), new-headless (--channel=chromium), and headed
+// WSLg all reach the adapter with identical renderer strings and identical
+// full-suite timing — so the lane defaults to HEADLESS and headed remains one
+// `--mode=headed` away.
 
 import {spawn} from "node:child_process";
 import {existsSync, mkdirSync, writeFileSync} from "node:fs";
@@ -72,7 +77,8 @@ export const CANDIDATES = [
     {
         id: "wsl2-d3d12-angle-gl",
         summary:
-            "WSL2 Mesa d3d12 via ANGLE native-GL (proven: bugfix-22 / PR #43)",
+            "WSL2 Mesa d3d12 via ANGLE native-GL (proven: bugfix-22 / PR #43; " +
+            "headless validated by the spec-44 FR5 matrix + full-suite run)",
         hostClass: "wsl2",
         flags: [
             "--use-gl=angle",
@@ -82,12 +88,13 @@ export const CANDIDATES = [
         ],
         env: {GALLIUM_DRIVER: "d3d12"},
         envPrepend: {LD_LIBRARY_PATH: WSL_LIB_DIR},
-        mode: "headed",
+        mode: "headless",
     },
     {
         id: "wsl2-d3d12-angle-gl-egl",
         summary:
-            "WSL2 Mesa d3d12 via ANGLE GL-EGL (proven alternate, OpenGL ES 3.1)",
+            "WSL2 Mesa d3d12 via ANGLE GL-EGL (proven alternate, OpenGL ES " +
+            "3.1; headless validated by the spec-44 FR5 matrix)",
         hostClass: "wsl2",
         flags: [
             "--use-gl=angle",
@@ -97,7 +104,7 @@ export const CANDIDATES = [
         ],
         env: {GALLIUM_DRIVER: "d3d12"},
         envPrepend: {LD_LIBRARY_PATH: WSL_LIB_DIR},
-        mode: "headed",
+        mode: "headless",
     },
     {
         id: "native-linux-angle-vulkan",
@@ -169,12 +176,19 @@ export function buildHostView({platform, exists, env}) {
 }
 
 // Prereq check (FR3 step 1). Returns {usable, skipped}: usable entries carry
-// `extraEnv` (e.g. a defaulted DISPLAY) alongside the candidate; skipped
-// entries carry the FR11 cause + remedy diagnostic.
-export function partitionCandidates(hostView, candidates = CANDIDATES) {
+// `extraEnv` (e.g. a defaulted DISPLAY) and the `effectiveMode` (the
+// candidate's own mode unless overridden — the FR5 matrix probes headless
+// variants of headed candidates via the override). Skipped entries carry the
+// FR11 cause + remedy diagnostic.
+export function partitionCandidates(
+    hostView,
+    candidates = CANDIDATES,
+    modeOverride = null,
+) {
     const usable = [];
     const skipped = [];
     for (const candidate of candidates) {
+        const effectiveMode = modeOverride ?? candidate.mode;
         if (hostView.platform !== "linux") {
             skipped.push({
                 candidate,
@@ -207,7 +221,7 @@ export function partitionCandidates(hostView, candidates = CANDIDATES) {
                 continue;
             }
             let extraEnv = {};
-            if (candidate.mode === "headed") {
+            if (effectiveMode === "headed") {
                 if (!hostView.display && !hostView.hasWslgSocket) {
                     skipped.push({
                         candidate,
@@ -225,7 +239,7 @@ export function partitionCandidates(hostView, candidates = CANDIDATES) {
                     extraEnv = {DISPLAY: ":0"};
                 }
             }
-            usable.push({candidate, extraEnv});
+            usable.push({candidate, extraEnv, effectiveMode});
             continue;
         }
         // native-linux candidates
@@ -239,7 +253,7 @@ export function partitionCandidates(hostView, candidates = CANDIDATES) {
             });
             continue;
         }
-        usable.push({candidate, extraEnv: {}});
+        usable.push({candidate, extraEnv: {}, effectiveMode});
     }
     return {usable, skipped};
 }
@@ -343,9 +357,9 @@ export function formatWallClock(totalSeconds, buildSeconds, suiteSeconds) {
 // tests never touch Playwright.
 export async function runSelection({usable, probe, log}) {
     const attempts = [];
-    for (const {candidate, extraEnv} of usable) {
+    for (const {candidate, extraEnv, effectiveMode} of usable) {
         log(`probing candidate ${candidate.id} (${candidate.summary})`);
-        const attempt = await probe(candidate, extraEnv);
+        const attempt = await probe(candidate, extraEnv, effectiveMode);
         attempts.push(attempt);
         if (!attempt.error && attempt.rendererClass === "hardware") {
             log(
@@ -407,6 +421,7 @@ export async function probeRenderer(
     {
         baseEnv,
         headless,
+        channel = null,
         launcher = importChromium,
         totalTimeoutMs = PROBE_TOTAL_TIMEOUT_MS,
         launchTimeoutMs = PROBE_LAUNCH_TIMEOUT_MS,
@@ -417,7 +432,14 @@ export async function probeRenderer(
     const startedAt = Date.now();
     const transcript = [];
     const logLine = (line) => transcript.push(`${timestamp()} ${line}`);
-    const logPath = join(PROBE_LOG_DIR, `probe-${candidate.id}.log`);
+    // One transcript per matrix cell: mode (and channel, when probing the
+    // full-binary new-headless variant) distinguish repeat probes of the same
+    // candidate from each other instead of overwriting.
+    const logPath = join(
+        PROBE_LOG_DIR,
+        `probe-${candidate.id}-${headless ? "headless" : "headed"}` +
+            `${channel ? `-${channel}` : ""}.log`,
+    );
     const env = composeEnv(baseEnv, candidate, extraEnv);
     logLine(`candidate: ${candidate.id} (${candidate.summary})`);
     logLine(`flags: ${candidate.flags.join(" ")}`);
@@ -434,6 +456,15 @@ export async function probeRenderer(
         })}`,
     );
     logLine(`mode: ${headless ? "headless" : "headed"}`);
+    logLine(
+        `binary: ${
+            channel
+                ? `channel "${channel}" (full Chromium, new headless)`
+                : headless
+                  ? "playwright default headless (chromium headless shell)"
+                  : "playwright chromium (full binary, headed)"
+        }`,
+    );
 
     const attempt = {
         candidate,
@@ -457,6 +488,7 @@ export async function probeRenderer(
         const work = (async () => {
             launchPromise = chromium.launch({
                 headless,
+                ...(channel ? {channel} : {}),
                 args: candidate.flags,
                 env,
                 timeout: launchTimeoutMs,
@@ -529,14 +561,46 @@ function fallbackWarning(reason) {
     }
 }
 
-function parseArgs(argv) {
-    const args = {probeOnly: false};
+// Exported for tests. --mode/--candidate/--channel exist for the FR5
+// headless-vs-headed matrix and recipe debugging; a plain `npm run
+// test:e2e:gpu` uses none of them.
+export function parseArgs(argv) {
+    const args = {probeOnly: false, mode: null, candidate: null, channel: null};
     for (const arg of argv) {
         if (arg === "--probe-only") {
             args.probeOnly = true;
+        } else if (arg.startsWith("--mode=")) {
+            const value = arg.slice("--mode=".length);
+            if (value !== "headed" && value !== "headless") {
+                throw new LaneUsageError(
+                    `--mode must be "headed" or "headless", got "${value}"`,
+                );
+            }
+            args.mode = value;
+        } else if (arg.startsWith("--candidate=")) {
+            const value = arg.slice("--candidate=".length);
+            if (!CANDIDATES.some((candidate) => candidate.id === value)) {
+                throw new LaneUsageError(
+                    `unknown candidate "${value}" (known: ${CANDIDATES.map(
+                        (candidate) => candidate.id,
+                    ).join(", ")})`,
+                );
+            }
+            args.candidate = value;
+        } else if (arg.startsWith("--channel=")) {
+            args.channel = arg.slice("--channel=".length);
         } else {
             throw new LaneUsageError(`unknown argument: ${arg}`);
         }
+    }
+    if (args.channel && !args.probeOnly) {
+        // PW_CHROMIUM_ARGS injects launch args only — the suite cannot switch
+        // Playwright channel without config changes, so a channel probe must
+        // not pretend its result transfers to a suite run.
+        throw new LaneUsageError(
+            "--channel is probe-only (--probe-only): the suite cannot inject " +
+                "a Playwright channel through PW_CHROMIUM_ARGS",
+        );
     }
     return args;
 }
@@ -559,9 +623,9 @@ function runStage(label, command, commandArgs, env) {
 }
 
 // Probe the host and settle on the run mode (FR2/FR3). Returns
-// {mode: "hardware", candidate, extraEnv, renderer} |
+// {mode: "hardware", candidate, extraEnv, effectiveMode, renderer} |
 // {mode: "software-fallback", renderer} | {mode: "abort"} (E2E_GPU_REQUIRE).
-async function resolveMode(controls) {
+async function resolveMode(controls, args) {
     if (controls.forceFallback) {
         fallbackWarning("forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)");
         return {
@@ -580,30 +644,40 @@ async function resolveMode(controls) {
             `wslLib=${hostView.hasWslLib} wslgSocket=${hostView.hasWslgSocket} ` +
             `DISPLAY=${hostView.display ?? "(unset)"}`,
     );
-    const {usable, skipped} = partitionCandidates(hostView);
+    const candidates = args.candidate
+        ? CANDIDATES.filter((candidate) => candidate.id === args.candidate)
+        : CANDIDATES;
+    const {usable, skipped} = partitionCandidates(
+        hostView,
+        candidates,
+        args.mode,
+    );
     for (const skip of skipped) {
         log(`candidate ${skip.candidate.id} SKIPPED: ${skip.diagnostic}`);
     }
 
     const selection = await runSelection({
         usable,
-        probe: (candidate, extraEnv) =>
+        probe: (candidate, extraEnv, effectiveMode) =>
             probeRenderer(candidate, extraEnv, {
                 baseEnv: process.env,
-                headless: candidate.mode !== "headed",
+                headless: effectiveMode !== "headed",
+                channel: args.channel,
             }),
         log,
     });
 
     if (selection.status === "hardware") {
+        const usableEntry = usable.find(
+            (entry) => entry.candidate === selection.attempt.candidate,
+        );
         return {
             mode: "hardware",
             candidate: selection.attempt.candidate,
-            extraEnv:
-                usable.find(
-                    (entry) =>
-                        entry.candidate === selection.attempt.candidate,
-                )?.extraEnv ?? {},
+            extraEnv: usableEntry?.extraEnv ?? {},
+            effectiveMode:
+                usableEntry?.effectiveMode ??
+                selection.attempt.candidate.mode,
             renderer: selection.attempt.renderer,
         };
     }
@@ -635,7 +709,7 @@ async function main() {
     const startedAt = Date.now();
     const elapsedSeconds = () => Math.round((Date.now() - startedAt) / 1000);
 
-    const outcome = await resolveMode(controls);
+    const outcome = await resolveMode(controls, args);
     if (outcome.mode === "abort") {
         return 1;
     }
@@ -672,7 +746,7 @@ async function main() {
     }
 
     const headed =
-        outcome.mode === "hardware" && outcome.candidate.mode === "headed";
+        outcome.mode === "hardware" && outcome.effectiveMode === "headed";
     const suite = await runStage(
         "suite",
         "npx",

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -17,6 +17,7 @@ import {
     formatReport,
     parseControls,
     partitionCandidates,
+    probeRenderer,
     runSelection,
 } from "../scripts/e2e-gpu-lane.mjs";
 
@@ -361,6 +362,93 @@ test("formatReport emits the exact greppable FR10 contract", () => {
     assert.equal(lines[3], "engine: chromium");
     assert.equal(lines[4], "suite: skipped (--probe-only)");
     assert.equal(lines[5], "wall-clock: 12s");
+});
+
+test("probeRenderer: a watchdog timeout still reaps a late-resolving browser", async () => {
+    // The launch resolves AFTER the watchdog has already failed the probe;
+    // the lane must close that late browser instead of orphaning a Chromium
+    // process that would keep the run alive.
+    let closed = false;
+    const fakeBrowser = {
+        close: async () => {
+            closed = true;
+        },
+        newPage: async () => ({
+            evaluate: async () => ({renderer: "late", vendor: "late"}),
+        }),
+    };
+    const launcher = async () => ({
+        launch: () =>
+            new Promise((resolve) => {
+                setTimeout(() => resolve(fakeBrowser), 100);
+            }),
+    });
+    const transcripts = [];
+    const attempt = await probeRenderer(
+        candidateById("wsl2-d3d12-angle-gl"),
+        {},
+        {
+            baseEnv: {},
+            headless: true,
+            launcher,
+            totalTimeoutMs: 10,
+            closeTimeoutMs: 2_000,
+            writeTranscript: (path, text) => transcripts.push({path, text}),
+        },
+    );
+    assert.match(attempt.error, /probe timeout after 10ms/);
+    assert.equal(attempt.rendererClass, "none");
+    assert.equal(closed, true, "late-resolving browser must be closed");
+    // The transcript was written via the injected writer, with the error.
+    assert.equal(transcripts.length, 1);
+    assert.match(transcripts[0].path, /probe-wsl2-d3d12-angle-gl\.log/);
+    assert.match(transcripts[0].text, /ERROR: probe timeout/);
+});
+
+test("probeRenderer: cleanup is bounded when the launch never resolves", async () => {
+    // A launch that hangs past its own timeout must not wedge the lane: the
+    // close race gives up after closeTimeoutMs and the attempt still returns.
+    const launcher = async () => ({
+        launch: () => new Promise(() => {}),
+    });
+    const attempt = await probeRenderer(
+        candidateById("wsl2-d3d12-angle-gl"),
+        {},
+        {
+            baseEnv: {},
+            headless: true,
+            launcher,
+            totalTimeoutMs: 10,
+            closeTimeoutMs: 20,
+            writeTranscript: () => {},
+        },
+    );
+    assert.match(attempt.error, /probe timeout after 10ms/);
+    assert.equal(attempt.rendererClass, "none");
+});
+
+test("probeRenderer: a launch failure is a failed candidate with the error recorded", async () => {
+    const launcher = async () => ({
+        launch: async () => {
+            throw new Error("browser crashed on startup");
+        },
+    });
+    const transcripts = [];
+    const attempt = await probeRenderer(
+        candidateById("wsl2-d3d12-angle-gl"),
+        {},
+        {
+            baseEnv: {},
+            headless: true,
+            launcher,
+            totalTimeoutMs: 1_000,
+            closeTimeoutMs: 20,
+            writeTranscript: (path, text) => transcripts.push({path, text}),
+        },
+    );
+    assert.match(attempt.error, /browser crashed on startup/);
+    assert.equal(attempt.rendererClass, "none");
+    assert.equal(transcripts.length, 1);
 });
 
 test("candidate data invariants: sandbox relaxations stay lane-only and evidence-ordered", () => {

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -1,0 +1,381 @@
+// Unit coverage for the opt-in native-GPU lane's pure logic (issue #44).
+//
+// Everything here is GPU-free, browser-free, and lane-env-free (spec FR7):
+// the probe is injected as a plain async function, host facts are injected as
+// a fake view, and importing the wrapper module must never launch anything.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    CANDIDATES,
+    LaneUsageError,
+    buildHostView,
+    classifyRenderer,
+    composeEnv,
+    failureDiagnostic,
+    fallbackEnv,
+    formatReport,
+    parseControls,
+    partitionCandidates,
+    runSelection,
+} from "../scripts/e2e-gpu-lane.mjs";
+
+// Host-view fixtures mirroring the shapes the lane must handle.
+const wsl2Host = {
+    platform: "linux",
+    hasDxg: true,
+    hasWslLib: true,
+    hasWslgSocket: true,
+    display: ":0",
+};
+const nativeLinuxHost = {
+    platform: "linux",
+    hasDxg: false,
+    hasWslLib: false,
+    hasWslgSocket: false,
+    display: null,
+};
+
+function candidateById(id) {
+    const candidate = CANDIDATES.find((entry) => entry.id === id);
+    assert.ok(candidate, `unknown candidate fixture id: ${id}`);
+    return candidate;
+}
+
+test("classifyRenderer: proven hardware strings survive the deny-list", () => {
+    // The exact strings recorded in bugfix-22 (WSL2 d3d12) and experiment 42
+    // run #5 (Kaggle T4).
+    assert.equal(
+        classifyRenderer(
+            "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
+        ),
+        "hardware",
+    );
+    assert.equal(
+        classifyRenderer("ANGLE (NVIDIA Corporation, Tesla T4/PCIe/SSE2, OpenGL ES 3.2)"),
+        "hardware",
+    );
+});
+
+test("classifyRenderer: software rasterizers are denied", () => {
+    assert.equal(
+        classifyRenderer(
+            "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)",
+        ),
+        "software",
+    );
+    assert.equal(
+        classifyRenderer("llvmpipe (LLVM 15.0.7, 256 bits)"),
+        "software",
+    );
+    assert.equal(classifyRenderer("Microsoft Basic Render Driver"), "software");
+    assert.equal(
+        classifyRenderer("Google SwiftShader"),
+        "software",
+    );
+});
+
+test("classifyRenderer: empty/absent strings are 'none', never hardware", () => {
+    assert.equal(classifyRenderer(null), "none");
+    assert.equal(classifyRenderer(undefined), "none");
+    assert.equal(classifyRenderer(""), "none");
+    assert.equal(classifyRenderer("   "), "none");
+});
+
+test("parseControls: E2E_GPU_FORCE_FALLBACK and E2E_GPU_REQUIRE parse strictly", () => {
+    assert.deepEqual(parseControls({}), {
+        forceFallback: false,
+        requireHardware: false,
+    });
+    assert.deepEqual(parseControls({E2E_GPU_FORCE_FALLBACK: "1"}), {
+        forceFallback: true,
+        requireHardware: false,
+    });
+    assert.deepEqual(parseControls({E2E_GPU_REQUIRE: "true"}), {
+        forceFallback: false,
+        requireHardware: true,
+    });
+    // Explicitly-disabled values stay off.
+    assert.deepEqual(
+        parseControls({E2E_GPU_FORCE_FALLBACK: "0", E2E_GPU_REQUIRE: ""}),
+        {forceFallback: false, requireHardware: false},
+    );
+});
+
+test("parseControls: contradictory controls are a usage error", () => {
+    assert.throws(
+        () =>
+            parseControls({
+                E2E_GPU_FORCE_FALLBACK: "1",
+                E2E_GPU_REQUIRE: "1",
+            }),
+        LaneUsageError,
+    );
+});
+
+test("buildHostView reads the injected fs/env snapshot", () => {
+    const checked = [];
+    const view = buildHostView({
+        platform: "linux",
+        exists: (path) => {
+            checked.push(path);
+            return path === "/dev/dxg";
+        },
+        env: {DISPLAY: ":0"},
+    });
+    assert.deepEqual(view, {
+        platform: "linux",
+        hasDxg: true,
+        hasWslLib: false,
+        hasWslgSocket: false,
+        display: ":0",
+    });
+    assert.ok(checked.includes("/dev/dxg"));
+    assert.ok(checked.includes("/usr/lib/wsl/lib"));
+    assert.ok(checked.includes("/mnt/wslg/.X11-unix"));
+});
+
+test("partitionCandidates: WSL2 host keeps d3d12 candidates, skips native-linux", () => {
+    const {usable, skipped} = partitionCandidates(wsl2Host);
+    assert.deepEqual(
+        usable.map(({candidate}) => candidate.id),
+        ["wsl2-d3d12-angle-gl", "wsl2-d3d12-angle-gl-egl"],
+    );
+    const skippedIds = skipped.map(({candidate}) => candidate.id);
+    assert.deepEqual(skippedIds, [
+        "native-linux-angle-vulkan",
+        "native-linux-angle-gl",
+    ]);
+    for (const skip of skipped) {
+        assert.match(skip.diagnostic, /WSL2/);
+        assert.match(skip.diagnostic, /llvmpipe dead end/);
+    }
+});
+
+test("partitionCandidates: native Linux host keeps ANGLE candidates, skips WSL2", () => {
+    const {usable, skipped} = partitionCandidates(nativeLinuxHost);
+    assert.deepEqual(
+        usable.map(({candidate}) => candidate.id),
+        ["native-linux-angle-vulkan", "native-linux-angle-gl"],
+    );
+    const wsl2Skips = skipped.filter(
+        ({candidate}) => candidate.hostClass === "wsl2",
+    );
+    assert.equal(wsl2Skips.length, 2);
+    for (const skip of wsl2Skips) {
+        assert.match(skip.diagnostic, /\/dev\/dxg absent/);
+    }
+});
+
+test("partitionCandidates: /dev/dxg without WSL libs is an actionable skip", () => {
+    const {usable, skipped} = partitionCandidates({
+        ...wsl2Host,
+        hasWslLib: false,
+    });
+    assert.equal(usable.length, 0);
+    const wsl2Skips = skipped.filter(
+        ({candidate}) => candidate.hostClass === "wsl2",
+    );
+    for (const skip of wsl2Skips) {
+        assert.match(skip.diagnostic, /\/usr\/lib\/wsl\/lib missing/);
+        assert.match(skip.diagnostic, /wsl --update/);
+    }
+});
+
+test("partitionCandidates: headed candidates need a display; WSLg socket defaults DISPLAY=:0", () => {
+    // No DISPLAY, no WSLg socket: headed d3d12 candidates are skipped with the
+    // FR11 WSLg diagnostic.
+    const noDisplay = partitionCandidates({
+        ...wsl2Host,
+        display: null,
+        hasWslgSocket: false,
+    });
+    assert.equal(noDisplay.usable.length, 0);
+    const headedSkips = noDisplay.skipped.filter(
+        ({candidate}) => candidate.hostClass === "wsl2",
+    );
+    assert.equal(headedSkips.length, 2);
+    for (const skip of headedSkips) {
+        assert.match(skip.diagnostic, /DISPLAY unset/);
+        assert.match(skip.diagnostic, /WSLg not active/);
+    }
+    // No DISPLAY but the WSLg socket exists: usable, with DISPLAY defaulted to
+    // the PR #43 recipe value.
+    const socketOnly = partitionCandidates({...wsl2Host, display: null});
+    assert.equal(socketOnly.usable.length, 2);
+    for (const entry of socketOnly.usable) {
+        assert.deepEqual(entry.extraEnv, {DISPLAY: ":0"});
+    }
+});
+
+test("partitionCandidates: non-linux platforms skip everything", () => {
+    const {usable, skipped} = partitionCandidates({
+        ...wsl2Host,
+        platform: "darwin",
+    });
+    assert.equal(usable.length, 0);
+    assert.equal(skipped.length, CANDIDATES.length);
+    for (const skip of skipped) {
+        assert.match(skip.diagnostic, /untested/);
+    }
+});
+
+test("composeEnv injects recipe env and prepends LD_LIBRARY_PATH without mutating the base", () => {
+    const base = {
+        PATH: "/usr/bin",
+        LD_LIBRARY_PATH: "/opt/lib",
+        MESA_D3D12_DEFAULT_ADAPTER_NAME: "NVIDIA",
+    };
+    const frozen = JSON.stringify(base);
+    const env = composeEnv(base, candidateById("wsl2-d3d12-angle-gl"), {
+        DISPLAY: ":0",
+    });
+    assert.equal(env.GALLIUM_DRIVER, "d3d12");
+    assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib:/opt/lib");
+    assert.equal(env.DISPLAY, ":0");
+    // Operator-set disambiguators pass through untouched.
+    assert.equal(env.MESA_D3D12_DEFAULT_ADAPTER_NAME, "NVIDIA");
+    assert.equal(env.PATH, "/usr/bin");
+    assert.equal(JSON.stringify(base), frozen);
+});
+
+test("composeEnv sets LD_LIBRARY_PATH outright when the base has none", () => {
+    const env = composeEnv({PATH: "/usr/bin"}, candidateById("wsl2-d3d12-angle-gl"));
+    assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib");
+});
+
+test("fallbackEnv strips PW_CHROMIUM_ARGS and nothing else, without mutating the base", () => {
+    const base = {
+        PATH: "/usr/bin",
+        PW_CHROMIUM_ARGS: "--use-gl=angle",
+        DISPLAY: ":0",
+    };
+    const frozen = JSON.stringify(base);
+    const env = fallbackEnv(base);
+    assert.equal(Object.hasOwn(env, "PW_CHROMIUM_ARGS"), false);
+    assert.equal(env.PATH, "/usr/bin");
+    assert.equal(env.DISPLAY, ":0");
+    assert.equal(JSON.stringify(base), frozen);
+});
+
+test("runSelection: first hardware verdict wins and stops probing", async () => {
+    const calls = [];
+    const usable = partitionCandidates(wsl2Host).usable;
+    const selection = await runSelection({
+        usable,
+        probe: async (candidate) => {
+            calls.push(candidate.id);
+            return {
+                candidate,
+                renderer:
+                    "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
+                rendererClass: "hardware",
+                error: null,
+                logPath: "gpu-lane-logs/probe-x.log",
+            };
+        },
+        log: () => {},
+    });
+    assert.equal(selection.status, "hardware");
+    assert.equal(selection.attempt.candidate.id, "wsl2-d3d12-angle-gl");
+    assert.deepEqual(calls, ["wsl2-d3d12-angle-gl"]);
+});
+
+test("runSelection: a failed candidate falls through to the next; exhaustion reports all attempts", async () => {
+    const usable = partitionCandidates(wsl2Host).usable;
+    const verdicts = {
+        "wsl2-d3d12-angle-gl": {
+            renderer: "llvmpipe (LLVM 15.0.7, 256 bits)",
+            rendererClass: "software",
+            error: null,
+        },
+        "wsl2-d3d12-angle-gl-egl": {
+            renderer: null,
+            rendererClass: "none",
+            error: "probe timeout after 45000ms",
+        },
+    };
+    const logged = [];
+    const selection = await runSelection({
+        usable,
+        probe: async (candidate) => ({
+            candidate,
+            logPath: `gpu-lane-logs/probe-${candidate.id}.log`,
+            ...verdicts[candidate.id],
+        }),
+        log: (line) => logged.push(line),
+    });
+    assert.equal(selection.status, "exhausted");
+    assert.equal(selection.attempts.length, 2);
+    // Both failure diagnostics were surfaced as they happened.
+    assert.ok(logged.some((line) => /SOFTWARE renderer "llvmpipe/.test(line)));
+    assert.ok(logged.some((line) => /probe timeout/.test(line)));
+});
+
+test("failureDiagnostic covers the FR11 cases with cause + remedy + log path", () => {
+    const d3d12 = candidateById("wsl2-d3d12-angle-gl");
+    const softwareLine = failureDiagnostic({
+        candidate: d3d12,
+        renderer: "llvmpipe (LLVM 15.0.7, 256 bits)",
+        rendererClass: "software",
+        error: null,
+        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+    });
+    assert.match(softwareLine, /SOFTWARE renderer "llvmpipe/);
+    assert.match(softwareLine, /Mesa/);
+    assert.match(softwareLine, /GALLIUM_DRIVER=d3d12/);
+    assert.match(softwareLine, /gpu-lane-logs\/probe-wsl2-d3d12-angle-gl\.log/);
+
+    const crashLine = failureDiagnostic({
+        candidate: d3d12,
+        renderer: null,
+        rendererClass: "none",
+        error: "browser crashed",
+        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+    });
+    assert.match(crashLine, /FAILED \(browser crashed\)/);
+    assert.match(crashLine, /probe transcript: gpu-lane-logs\//);
+
+    const noContextLine = failureDiagnostic({
+        candidate: d3d12,
+        renderer: "",
+        rendererClass: "none",
+        error: null,
+        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+    });
+    assert.match(noContextLine, /no usable WebGL context/);
+});
+
+test("formatReport emits the exact greppable FR10 contract", () => {
+    const report = formatReport({
+        mode: "hardware",
+        renderer:
+            "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
+        suite: "skipped (--probe-only)",
+        wallClock: "12s",
+    });
+    const lines = report.split("\n");
+    assert.equal(lines[0], "=== E2E GPU LANE REPORT ===");
+    assert.equal(lines[1], "mode: hardware");
+    assert.match(lines[2], /^renderer: ANGLE \(Microsoft Corporation/);
+    assert.equal(lines[3], "engine: chromium");
+    assert.equal(lines[4], "suite: skipped (--probe-only)");
+    assert.equal(lines[5], "wall-clock: 12s");
+});
+
+test("candidate data invariants: sandbox relaxations stay lane-only and evidence-ordered", () => {
+    // The first candidate must remain the proven bugfix-22 recipe — selection
+    // order is evidence strength (spec FR2).
+    assert.equal(CANDIDATES[0].id, "wsl2-d3d12-angle-gl");
+    for (const candidate of CANDIDATES) {
+        // Every candidate must carry the shape the lane's lifecycle relies on.
+        assert.ok(Array.isArray(candidate.flags) && candidate.flags.length > 0);
+        assert.ok(["wsl2", "native-linux"].includes(candidate.hostClass));
+        assert.ok(["headed", "headless"].includes(candidate.mode));
+        // The forced-SwiftShader default args must never appear in a hardware
+        // candidate (that would re-verify software as "hardware mode").
+        for (const flag of candidate.flags) {
+            assert.ok(!flag.includes("swiftshader"), `${candidate.id}: ${flag}`);
+        }
+    }
+});

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -16,6 +16,7 @@ import {
     fallbackEnv,
     formatReport,
     formatWallClock,
+    parseArgs,
     parseControls,
     partitionCandidates,
     playwrightTestArgs,
@@ -187,16 +188,14 @@ test("partitionCandidates: /dev/dxg without WSL libs is an actionable skip", () 
     }
 });
 
-test("partitionCandidates: headed candidates need a display; WSLg socket defaults DISPLAY=:0", () => {
-    // No DISPLAY, no WSLg socket: headed d3d12 candidates are skipped with the
-    // FR11 WSLg diagnostic.
-    const noDisplay = partitionCandidates({
-        ...wsl2Host,
-        display: null,
-        hasWslgSocket: false,
-    });
-    assert.equal(noDisplay.usable.length, 0);
-    const headedSkips = noDisplay.skipped.filter(
+test("partitionCandidates: headed mode (override) needs a display; WSLg socket defaults DISPLAY=:0", () => {
+    // The lane default is headless (FR5 outcome), so a display-less WSL2 host
+    // is fine naturally — but probed/run headed (--mode=headed), the display
+    // prereq applies: no DISPLAY, no WSLg socket ⇒ FR11 WSLg diagnostic.
+    const displayless = {...wsl2Host, display: null, hasWslgSocket: false};
+    const headed = partitionCandidates(displayless, CANDIDATES, "headed");
+    assert.equal(headed.usable.length, 0);
+    const headedSkips = headed.skipped.filter(
         ({candidate}) => candidate.hostClass === "wsl2",
     );
     assert.equal(headedSkips.length, 2);
@@ -204,12 +203,17 @@ test("partitionCandidates: headed candidates need a display; WSLg socket default
         assert.match(skip.diagnostic, /DISPLAY unset/);
         assert.match(skip.diagnostic, /WSLg not active/);
     }
-    // No DISPLAY but the WSLg socket exists: usable, with DISPLAY defaulted to
-    // the PR #43 recipe value.
-    const socketOnly = partitionCandidates({...wsl2Host, display: null});
+    // No DISPLAY but the WSLg socket exists: headed is usable, with DISPLAY
+    // defaulted to the PR #43 recipe value.
+    const socketOnly = partitionCandidates(
+        {...wsl2Host, display: null},
+        CANDIDATES,
+        "headed",
+    );
     assert.equal(socketOnly.usable.length, 2);
     for (const entry of socketOnly.usable) {
         assert.deepEqual(entry.extraEnv, {DISPLAY: ":0"});
+        assert.equal(entry.effectiveMode, "headed");
     }
 });
 
@@ -405,7 +409,7 @@ test("probeRenderer: a watchdog timeout still reaps a late-resolving browser", a
     assert.equal(closed, true, "late-resolving browser must be closed");
     // The transcript was written via the injected writer, with the error.
     assert.equal(transcripts.length, 1);
-    assert.match(transcripts[0].path, /probe-wsl2-d3d12-angle-gl\.log/);
+    assert.match(transcripts[0].path, /probe-wsl2-d3d12-angle-gl-headless\.log/);
     assert.match(transcripts[0].text, /ERROR: probe timeout/);
 });
 
@@ -453,6 +457,51 @@ test("probeRenderer: a launch failure is a failed candidate with the error recor
     assert.match(attempt.error, /browser crashed on startup/);
     assert.equal(attempt.rendererClass, "none");
     assert.equal(transcripts.length, 1);
+});
+
+test("parseArgs: matrix flags parse and validate; channel is probe-only", () => {
+    assert.deepEqual(parseArgs([]), {
+        probeOnly: false,
+        mode: null,
+        candidate: null,
+        channel: null,
+    });
+    assert.deepEqual(
+        parseArgs([
+            "--probe-only",
+            "--mode=headless",
+            "--candidate=wsl2-d3d12-angle-gl-egl",
+            "--channel=chromium",
+        ]),
+        {
+            probeOnly: true,
+            mode: "headless",
+            candidate: "wsl2-d3d12-angle-gl-egl",
+            channel: "chromium",
+        },
+    );
+    assert.throws(() => parseArgs(["--mode=windowed"]), LaneUsageError);
+    assert.throws(() => parseArgs(["--candidate=no-such-id"]), LaneUsageError);
+    assert.throws(() => parseArgs(["--bogus"]), LaneUsageError);
+    // A channel probe result does not transfer to a suite run (the config
+    // hook injects args only), so --channel without --probe-only must refuse.
+    assert.throws(() => parseArgs(["--channel=chromium"]), LaneUsageError);
+});
+
+test("partitionCandidates: headless default has no display prereq (FR5 outcome)", () => {
+    // The d3d12 recipe needs no display headless — a display-less WSL2 host
+    // (no WSLg at all) still gets both hardware candidates.
+    const displayless = {...wsl2Host, display: null, hasWslgSocket: false};
+    const natural = partitionCandidates(displayless);
+    assert.equal(natural.usable.length, 2);
+    for (const entry of natural.usable) {
+        assert.equal(entry.effectiveMode, "headless");
+        assert.deepEqual(entry.extraEnv, {});
+    }
+    // Without an override, entries carry the candidate's own mode.
+    for (const entry of partitionCandidates(wsl2Host).usable) {
+        assert.equal(entry.effectiveMode, entry.candidate.mode);
+    }
 });
 
 test("suiteEnvFor hardware: recipe env + PW_CHROMIUM_ARGS + chromium-only engine", () => {

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -15,10 +15,14 @@ import {
     failureDiagnostic,
     fallbackEnv,
     formatReport,
+    formatWallClock,
     parseControls,
     partitionCandidates,
+    playwrightTestArgs,
     probeRenderer,
     runSelection,
+    suiteEnvFor,
+    suiteResultLabel,
 } from "../scripts/e2e-gpu-lane.mjs";
 
 // Host-view fixtures mirroring the shapes the lane must handle.
@@ -449,6 +453,62 @@ test("probeRenderer: a launch failure is a failed candidate with the error recor
     assert.match(attempt.error, /browser crashed on startup/);
     assert.equal(attempt.rendererClass, "none");
     assert.equal(transcripts.length, 1);
+});
+
+test("suiteEnvFor hardware: recipe env + PW_CHROMIUM_ARGS + chromium-only engine", () => {
+    const base = {PATH: "/usr/bin", LD_LIBRARY_PATH: "/opt/lib"};
+    const env = suiteEnvFor(
+        "hardware",
+        base,
+        candidateById("wsl2-d3d12-angle-gl"),
+        {DISPLAY: ":0"},
+    );
+    assert.equal(env.E2E_ENGINES, "chromium");
+    assert.equal(
+        env.PW_CHROMIUM_ARGS,
+        "--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox",
+    );
+    assert.equal(env.GALLIUM_DRIVER, "d3d12");
+    assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib:/opt/lib");
+    assert.equal(env.DISPLAY, ":0");
+    // The base env object stays pristine for a later fallback spawn.
+    assert.equal(Object.hasOwn(base, "PW_CHROMIUM_ARGS"), false);
+    assert.equal(base.LD_LIBRARY_PATH, "/opt/lib");
+});
+
+test("suiteEnvFor fallback: default SwiftShader args guaranteed, no recipe leakage", () => {
+    // Even a shell-exported PW_CHROMIUM_ARGS must not survive into the
+    // fallback suite — fallback means the config's own SwiftShader defaults.
+    const base = {
+        PATH: "/usr/bin",
+        PW_CHROMIUM_ARGS: "--use-gl=angle",
+        LD_LIBRARY_PATH: "/opt/lib",
+    };
+    const env = suiteEnvFor("software-fallback", base);
+    assert.equal(Object.hasOwn(env, "PW_CHROMIUM_ARGS"), false);
+    assert.equal(env.E2E_ENGINES, "chromium");
+    assert.equal(Object.hasOwn(env, "GALLIUM_DRIVER"), false);
+    // Operator-owned values pass through untouched.
+    assert.equal(env.LD_LIBRARY_PATH, "/opt/lib");
+});
+
+test("playwrightTestArgs: headed reaches Playwright via the CLI flag only", () => {
+    assert.deepEqual(playwrightTestArgs(false), ["playwright", "test"]);
+    assert.deepEqual(playwrightTestArgs(true), [
+        "playwright",
+        "test",
+        "--headed",
+    ]);
+});
+
+test("suiteResultLabel preserves the suite's own exit semantics", () => {
+    assert.equal(suiteResultLabel(0), "pass");
+    assert.equal(suiteResultLabel(1), "fail (exit 1)");
+    assert.equal(suiteResultLabel(3), "fail (exit 3)");
+});
+
+test("formatWallClock breaks out build and suite stages", () => {
+    assert.equal(formatWallClock(312, 45, 267), "312s (build 45s, suite 267s)");
 });
 
 test("candidate data invariants: sandbox relaxations stay lane-only and evidence-ordered", () => {


### PR DESCRIPTION
## Summary

Productizes the hardware-WebGL configuration proven in PR #43 / experiment 42 into a one-command, opt-in local lane: `npm run test:e2e:gpu` (`scripts/e2e-gpu-lane.mjs`). The lane probes the host, **verifies `UNMASKED_RENDERER_WEBGL` through the repo's own Playwright Chromium before trusting anything** (deny-list: SwiftShader/llvmpipe/software), injects the verified recipe through the merged `PW_CHROMIUM_ARGS` hook, runs the **full** Chromium e2e suite, and ends with a machine-greppable mode/renderer/wall-clock report. No usable adapter ⇒ the suite still runs under SwiftShader with an unmissable software-fallback banner.

Closes #44

## Headline results (qualification host: WSL2, RTX 3080, Mesa d3d12)

- **Hardware suite 94–97 s vs 594 s SwiftShader baseline — 6.1× faster**; 5/5 full-suite hardware passes at `retries: 0`, zero flakes, per-test spread ≤ 1 s (3 consecutive runs under `E2E_GPU_REQUIRE=1` + 2 earlier runs).
- **Headless works**: the bounded FR5 matrix (4 cells) showed the Mesa d3d12 path needs no display — lane defaults to headless (headed WSLg via `--mode=headed`). Renderer in all hardware runs: `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)`.
- **Canonical gate untouched**: `.github/workflows/validation.yml`, `validate`/`test:smoke`, lockfile, deps — absent from this diff. `playwright.config.ts` diff is comment-only; env-unset config-load proves byte-identical SwiftShader defaults. Clean-checkout (`git worktree add --detach` + `npm ci`) `npm run validate`: exit 0.

## Changes

- `scripts/e2e-gpu-lane.mjs` (new): data-driven candidates (WSL2 d3d12 ANGLE-GL/GL-EGL proven; native-Linux ANGLE-Vulkan/GL from exp42 run 5), deterministic FR3 lifecycle (prereq-skip with cause+remedy diagnostics → deny-list verify → loud fallback on exhaustion), env controls `E2E_GPU_FORCE_FALLBACK=1` / `E2E_GPU_REQUIRE=1`, probe transcripts in gitignored `gpu-lane-logs/`, `--probe-only` / `--mode` / `--candidate` / `--channel` (probe-only) flags.
- `tests/gpu-lane.test.mjs` (new): 29 GPU-free unit tests over the exported pure logic (classification, prereqs, env compose/scrub, lifecycle, timeout-cleanup paths, report contract) — rides the existing `npm test` glob, green on SwiftShader-only CI.
- `package.json`: one script line (`test:e2e:gpu`). `playwright.config.ts`: comment-only hook-note sync. `.gitignore`: `gpu-lane-logs/`.
- `README.md`: lane docs (command, honest-report semantics, WSL2 Mesa d3d12 recipe + multi-GPU disambiguators, headless outcome, env controls, explicit non-gate status, #41 sequencing).
- `codev/`: spec/plan/review (full FR5/FR6/FR8 evidence tables), arch.md + lessons-learned.md cold-tier updates, builder thread.

## Testing

- Unit: 68 tests green (`npm test`), incl. 29 new — no GPU/browser/lane env needed.
- FR8: 3 consecutive `E2E_GPU_REQUIRE=1` full-suite hardware runs, 11/11 each (94/95/95 s); forced-fallback full run 11/11 (594 s) doubling as the SwiftShader baseline; per-test tables in the review.
- Clean-checkout `npm run validate`: run 1 = 21/22 (single pre-existing-class Firefox background-drag flake, preserved verbatim + attributed in the review's Flaky Tests section; zero `tests/e2e`/`app` changes in this diff), run 2 = 22/22 exit 0.

## Spec
codev/specs/44-add-an-opt-in-native-gpu-local.md

## Review
codev/reviews/44-add-an-opt-in-native-gpu-local.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
