### PR TITLE
[Spec 44] Post-merge: verify evidence + porch protocol-complete state

### DIFF
--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -43,10 +43,12 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:52:27.928Z'
+updated_at: '2026-07-21T23:59:20.299Z'
 pr_history:
   - phase: review
     pr_number: 50
     branch: builder/aspir-44
     created_at: '2026-07-21T23:41:13.960Z'
+    merged: true
+    merged_at: '2026-07-21T23:59:20.299Z'
 pr_ready_for_human: false

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -23,6 +23,7 @@ gates:
     approved_at: '2026-07-21T23:52:02.238Z'
   verify-approval:
     status: pending
+    requested_at: '2026-07-22T00:02:02.387Z'
 iteration: 1
 build_complete: false
 history:
@@ -43,7 +44,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-21T23:59:20.299Z'
+updated_at: '2026-07-22T00:02:02.387Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -1,7 +1,7 @@
 id: '44'
 title: add-an-opt-in-native-gpu-local
 protocol: aspir
-phase: verify
+phase: verified
 plan_phases:
   - id: lane_wrapper_core
     title: 'Lane wrapper core: probe engine, candidate data, deterministic policy, unit tests'
@@ -45,7 +45,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-22T00:02:26.302Z'
+updated_at: '2026-07-22T00:02:27.444Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -25,7 +25,7 @@ gates:
     status: pending
     requested_at: '2026-07-22T00:02:02.387Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: headless_investigation
@@ -44,7 +44,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-22T00:02:02.387Z'
+updated_at: '2026-07-22T00:02:25.114Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
+++ b/codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml
@@ -22,8 +22,9 @@ gates:
     requested_at: '2026-07-21T23:44:13.207Z'
     approved_at: '2026-07-21T23:52:02.238Z'
   verify-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T00:02:02.387Z'
+    approved_at: '2026-07-22T00:02:26.302Z'
 iteration: 1
 build_complete: true
 history:
@@ -44,7 +45,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/aspir-44/codev/projects/44-add-an-opt-in-native-gpu-local/44-headless_investigation-iter1-claude.txt
 started_at: '2026-07-21T22:00:59.724Z'
-updated_at: '2026-07-22T00:02:25.114Z'
+updated_at: '2026-07-22T00:02:26.302Z'
 pr_history:
   - phase: review
     pr_number: 50

--- a/codev/state/aspir-44_thread.md
+++ b/codev/state/aspir-44_thread.md
@@ -127,5 +127,18 @@
   lessons-learned.md Validation Evidence gained renderer-probe+strict-switch,
   probe-before-assuming, and timeout-race-reap/DI lessons. Hot tier untouched.
 - **PR #50 opened** (branch builder/aspir-44 → main, Closes #44). Test-count
-  typo in PR body/review corrected (29 new tests, 68 total). Awaiting PR CMAP
-  + human pr gate.
+  typo in PR body/review corrected (29 new tests, 68 total). PR CMAP: Gemini/
+  Claude APPROVE, Codex COMMENT (plan status marked complete; porch chore
+  commits are protocol machinery). pr gate approved by architect.
+
+## Verify phase
+
+- **PR #50 MERGED** (merge commit 51ee918, 2026-07-21T23:59Z) with CI fully
+  green on the final head (4 SwiftShader shards + Quality + Validation gate),
+  porch protocol commits included in the merged history per architect
+  sequencing.
+- Integrated-tree verification in this worktree after merging origin/main:
+  unit suite 68/68; full `npm run test:e2e:gpu` — **11/11 pass, hardware mode,
+  renderer `ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080),
+  OpenGL 4.6)`, 105 s total (build 10 s, suite 94 s)**. The lane works on
+  integrated main exactly as qualified. Signaling porch done → verify-approval.


### PR DESCRIPTION
## Summary

Follow-up to PR #50 (merged as 51ee918): lands the post-merge tail of project 44 on `main` — the integrated-tree verification record in the builder thread and porch's verify/protocol-complete state commits (verify build-complete, verify-approval gate-approved, protocol complete).

A direct fast-forward push (`git push origin builder/aspir-44:main`) was declined by repository rules, so this PR carries the same commits instead. Docs/state only — no code changes.

Refs #44 (already closed by PR #50)

## Changes
- `codev/state/aspir-44_thread.md`: verify-phase record (post-merge lane run 11/11 hardware, 105 s, renderer asserted)
- `codev/projects/44-add-an-opt-in-native-gpu-local/status.yaml`: porch state through `protocol complete`

## Testing
- No code changes. On the integrated tree: unit suite 68/68; full `npm run test:e2e:gpu` 11/11 (hardware, ANGLE D3D12 RTX 3080).

🤖 Generated with [Claude Code](https://claude.com/claude-code)