### PR TITLE
[Spec 52] Add Firefox hardware WebGL to the native-GPU local e2e lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
 
    ```
    === E2E GPU LANE REPORT ===
-   mode: hardware | software-fallback | skipped
+   mode: hardware | software-fallback | skipped | abort
    engines: chromium,firefox
    renderer.chromium: <verbatim string | (software-fallback — SwiftShader)>
    renderer.firefox: <verbatim string | skipped (unverified — <reason>) | not run (<reason>)>
@@ -220,10 +220,10 @@ set recorded in review 52. If it recurs, it is dispositioned there, never hidden
 | --- | --- |
 | `--engine=chromium\|firefox\|all` | Select the engine set to probe and run. `all` (default) is the two-engine lane; single-engine values preserve targeted diagnostics and obey the same honesty rules. |
 | `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware probing; take the honest fallback path (Chromium SwiftShader, Firefox skipped) deterministically. With `--engine=firefox` alone it is a benign no-op skip (Firefox has no software path), exit 0. |
-| `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when **any requested engine** does not verify hardware — use for hardware-evidence runs so a silent fallback can't pollute results. |
-| `--probe-only` | Probe + verify + report the requested engine set without building or running the suite. |
+| `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when **any requested engine** does not verify hardware — use for hardware-evidence runs so a silent fallback can't pollute results. With `--probe-only` the per-engine report is still printed (`mode: abort`) **before** the non-zero exit — the probe already did its work. |
+| `--probe-only` | Probe + verify + report the requested engine set without building or running the suite. Always prints the report, even on a `E2E_GPU_REQUIRE=1` abort. |
 | `--mode=headed\|headless` | Override the run mode. Default is **headless** (proven equivalent; see below). Headed needs WSLg/X (`DISPLAY`). |
-| `--candidate=<id>` / `--channel=<name>` | Probe a specific Chromium recipe / a specific Playwright channel (`--channel` is probe-only). Used by the FR5 matrix. |
+| `--candidate=<id>` / `--channel=<name>` | Probe a specific Chromium recipe / a specific Playwright channel (`--channel` is probe-only). Chromium-only — rejected with `--engine=firefox`. Used by the FR5 matrix. |
 
 Pass flags through npm like `npm run test:e2e:gpu -- --probe-only`.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run browser:install
 | `npm run build` | Create the production Next.js build. |
 | `npm run start` | Start a previously built production application. |
 | `npm run test:smoke` | Build, start the production server, and run the Chromium and Firefox WebGL smoke. |
-| `npm run test:e2e:gpu` | Opt-in: run the full Chromium e2e suite on verified hardware WebGL when a GPU adapter is usable, with loud software fallback otherwise. **Not part of the gate.** See [Opt-in native-GPU e2e lane](#opt-in-native-gpu-e2e-lane). |
+| `npm run test:e2e:gpu` | Opt-in: run the full two-engine (Chromium + Firefox) e2e suite on verified hardware WebGL when a GPU adapter is usable, with honest software fallback otherwise. **Not part of the gate.** See [Opt-in native-GPU e2e lane](#opt-in-native-gpu-e2e-lane). |
 | `npm run validate` | Fail fast through lint, typecheck, and the `test:smoke` browser suite (build plus the Chromium + Firefox WebGL smoke). |
 | `npm run audit:full` | Report findings in the complete dependency graph. |
 | `npm run audit:production` | Report findings with development dependencies omitted. |
@@ -141,58 +141,89 @@ per-shard `playwright-test-results-<n>` artifacts.
 npm run test:e2e:gpu
 ```
 
-An **opt-in, local-only** lane (issue #44) that runs the *full* Chromium e2e
-suite on **genuine hardware-accelerated WebGL** instead of SwiftShader. It is
-additional tooling and evidence, **never the green gate**: `npm run validate`,
-`test:smoke`, CI, and every committed test are unchanged and stay on the
-qualified SwiftShader serial path. Nothing in the repo behaves differently
-unless you invoke the lane.
+An **opt-in, local-only** lane (issue #44 Chromium, issue #52 Firefox) that runs
+the *full* **two-engine (Chromium + Firefox)** e2e suite on **genuine
+hardware-accelerated WebGL** instead of SwiftShader. It is additional tooling and
+evidence, **never the green gate**: `npm run validate`, `test:smoke`, CI, and
+every committed test are unchanged and stay on the qualified SwiftShader serial
+path (CI stays `E2E_ENGINES=chromium` SwiftShader-only — Firefox has no
+SwiftShader equivalent and the Firefox arm is a **local** qualification lane, not
+a CI gate). Nothing in the repo behaves differently unless you invoke the lane.
 
 What one invocation does (`scripts/e2e-gpu-lane.mjs`):
 
-1. **Probes the host** and picks a hardware recipe from an evidence-ordered
-   candidate list (WSL2 Mesa d3d12 for any vendor adapter; ANGLE-Vulkan/GL on
-   native Linux). Unusable candidates are skipped with a one-line cause +
-   remedy diagnostic.
-2. **Verifies the renderer before trusting anything**: launches the repo's own
-   Playwright Chromium under the candidate flags and reads
-   `UNMASKED_RENDERER_WEBGL`; the string must not match
-   SwiftShader/llvmpipe/software. Failed candidates fall through to the next
-   (per-candidate transcripts land in `gpu-lane-logs/`).
-3. **Runs the suite** — `npm run build`, then `npx playwright test` with
-   `E2E_ENGINES=chromium` and the verified flags injected through the
-   config's `PW_CHROMIUM_ARGS` hook. Same production server, same
+1. **Probes the host per engine** and picks a hardware recipe from an
+   evidence-ordered candidate list. **Chromium** uses ANGLE launch flags + the
+   WSL2 Mesa d3d12 env (or ANGLE-Vulkan/GL on native Linux). **Firefox** uses the
+   *same* Mesa d3d12 env with **no ANGLE flags** (Firefox reaches the adapter
+   through the Mesa env alone). Unusable candidates are skipped with a one-line
+   cause + remedy diagnostic.
+2. **Verifies the renderer per engine before trusting anything**: launches the
+   repo's own Playwright browser and reads `UNMASKED_RENDERER_WEBGL`; the string
+   must not match the software deny-list (SwiftShader, llvmpipe, softpipe,
+   lavapipe, swrast, software, Microsoft Basic). **Firefox renderer sanitization**:
+   Firefox privacy-sanitizes the unmasked renderer to `Generic Renderer`, so the
+   raw string is read through an **ephemeral, probe-only** preference
+   `webgl.sanitize-unmasked-renderer: false` (Chromium's deny-list alone is too
+   weak here — `Generic Renderer` matches no software marker, so it would
+   false-pass as hardware; the lane classifies it as **unverifiable**, never
+   hardware). This pref lives **only** in the probe browser — the application
+   suite's Firefox profile keeps its normal `webgl.force-enabled: true` only.
+   Failed candidates fall through (per-engine transcripts land in
+   `gpu-lane-logs/probe-<engine>-….log`).
+3. **Runs the suite** — `npm run build`, then one `npx playwright test` with
+   `E2E_ENGINES=chromium,firefox`. Chromium's verified flags are injected through
+   the config's `PW_CHROMIUM_ARGS` hook; **Firefox inherits the same Mesa env**
+   from the suite process (no new config hook). Same production server, same
    `workers: 1`, same `retries: 0`, same timeouts as the normal local suite.
-4. **Reports honestly.** The run ends with a machine-greppable block:
+4. **Reports honestly, per engine.** The run ends with a machine-greppable block:
 
    ```
    === E2E GPU LANE REPORT ===
-   mode: hardware | software-fallback
-   renderer: <verbatim UNMASKED_RENDERER_WEBGL>
-   engine: chromium
-   suite: pass | fail (exit n)
+   mode: hardware | software-fallback | skipped
+   engines: chromium,firefox
+   renderer.chromium: <verbatim string | (software-fallback — SwiftShader)>
+   renderer.firefox: <verbatim string | skipped (unverified — <reason>)>
+   suite: pass | fail (exit n) | skipped (no verified engine)
    wall-clock: <total>s (build <n>s, suite <n>s)
    ```
 
-   `mode: hardware` is only ever printed after the deny-list assertion
-   passed. When no adapter is usable the lane still runs the suite under the
-   default SwiftShader args with an unmissable `SOFTWARE FALLBACK` banner at
-   the start and before the report — a fallback run can never be mistaken for
-   hardware evidence. The suite's own pass/fail is the lane's exit code.
+   `mode: hardware` is only ever printed after **every requested engine's**
+   deny-list assertion passed. **Honest fallback** (no Firefox software
+   masquerade): when the two engines cannot both verify hardware, Chromium runs
+   under its deterministic SwiftShader fallback and **Firefox is skipped** with a
+   stated reason (Firefox has no portable software-WebGL equivalent, so an
+   unverified `llvmpipe` run is *never* presented as a qualified fallback), under
+   an unmissable `SOFTWARE FALLBACK` banner at the start and before the report.
+   Under `E2E_GPU_REQUIRE=1` the lane instead exits non-zero before build/suite if
+   either engine is unverified. The suite's own pass/fail is the lane's exit code.
 
-Measured on the qualification host (WSL2, RTX 3080): hardware suite ≈ 97 s vs
-≈ 594 s for the same suite under SwiftShader — about **6× faster**, with the
-SwiftShader-only hover/timing flake class absent.
+Measured on the qualification host (WSL2, RTX 3080): the full **two-engine**
+hardware suite (22 tests) runs in ≈ 196 s (≈ 208 s total incl. build) at
+`retries: 0`, versus the Chromium-only SwiftShader path measured in
+`codev/reviews/52-firefox-hardware-webgl-gpu-lane.md` — the hardware lane runs
+**twice the tests (both engines)** in a fraction of the software time, with the
+SwiftShader-only hover/timing flake class absent. Full per-run / per-test
+evidence and the software baseline live in that review (as the #44 lane's
+evidence lives in `codev/reviews/44-add-an-opt-in-native-gpu-local.md`).
+
+**Known Firefox flake**: `[firefox] tests/e2e/matrix.spec.ts:224` ("zooms in with
+the wheel and rotates with a background drag") is a pre-existing Firefox
+synthetic-input-delivery nondeterminism (not a software-WebGL timing problem — it
+survives on hardware). It is **not masked with retries** and the canonical
+assertion is **not weakened**; it did not recur across the three-run qualification
+set recorded in review 52. If it recurs, it is dispositioned there, never hidden.
 
 ### Env controls and flags
 
 | Control | Effect |
 | --- | --- |
-| `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware candidates; run the software-fallback path deterministically (how the fallback is exercised on a GPU-capable machine). |
-| `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when no candidate verifies — use for hardware-evidence runs so a silent fallback can't pollute results. |
-| `--probe-only` | Probe + verify + report without building or running the suite. |
+| `--engine=chromium\|firefox\|all` | Select the engine set to probe and run. `all` (default) is the two-engine lane; single-engine values preserve targeted diagnostics and obey the same honesty rules. |
+| `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware probing; take the honest fallback path (Chromium SwiftShader, Firefox skipped) deterministically. With `--engine=firefox` alone it is a benign no-op skip (Firefox has no software path), exit 0. |
+| `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when **any requested engine** does not verify hardware — use for hardware-evidence runs so a silent fallback can't pollute results. |
+| `--probe-only` | Probe + verify + report the requested engine set without building or running the suite. |
 | `--mode=headed\|headless` | Override the run mode. Default is **headless** (proven equivalent; see below). Headed needs WSLg/X (`DISPLAY`). |
-| `--candidate=<id>` / `--channel=<name>` | Probe a specific recipe / a specific Playwright channel (`--channel` is probe-only). Used by the FR5 matrix. |
+| `--candidate=<id>` / `--channel=<name>` | Probe a specific Chromium recipe / a specific Playwright channel (`--channel` is probe-only). Used by the FR5 matrix. |
 
 Pass flags through npm like `npm run test:e2e:gpu -- --probe-only`.
 
@@ -216,6 +247,27 @@ them: `MESA_D3D12_DEFAULT_ADAPTER_NAME=<vendor>` (pick the adapter) and
 `LIBGL_ALWAYS_SOFTWARE=false`. The sandbox/blocklist relaxations above exist
 **only** inside this explicitly invoked lane — never in default launch args or
 CI.
+
+**Firefox** uses the *same* `GALLIUM_DRIVER=d3d12` + `LD_LIBRARY_PATH` Mesa env
+and **no ANGLE flags** (no `--use-gl`/`--use-angle`; those are Chromium-only). In
+the combined suite Firefox inherits that Mesa env from the suite process, so it
+needs **no `playwright.config.ts` change**. The renderer probe launches Firefox
+with two probe-only preferences and nothing else:
+
+```js
+firefoxUserPrefs: {
+    "webgl.force-enabled": true,             // also the committed suite default
+    "webgl.sanitize-unmasked-renderer": false, // PROBE ONLY — reveals the raw renderer
+}
+```
+
+`webgl.sanitize-unmasked-renderer: false` is applied **only** to the ephemeral
+renderer-probe browser (it changes renderer-string *disclosure*, not renderer
+*selection*); the committed `firefox` Playwright project keeps
+`webgl.force-enabled: true` only. On hardware the raw Firefox renderer reads
+`D3D12 (NVIDIA GeForce RTX 3080)`; without the recipe it is `llvmpipe …`
+(software), and without the sanitize pref it is the privacy-sanitized
+`Generic Renderer` (treated as unverifiable, never hardware).
 
 **Headless works** (2026-07 investigation): default Playwright headless
 (headless shell), new headless (`--channel=chromium`), and headed WSLg all

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
    mode: hardware | software-fallback | skipped
    engines: chromium,firefox
    renderer.chromium: <verbatim string | (software-fallback — SwiftShader)>
-   renderer.firefox: <verbatim string | skipped (unverified — <reason>)>
+   renderer.firefox: <verbatim string | skipped (unverified — <reason>) | not run (<reason>)>
    suite: pass | fail (exit n) | skipped (no verified engine)
    wall-clock: <total>s (build <n>s, suite <n>s)
    ```

--- a/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
@@ -171,6 +171,18 @@ verbatim. (Note: the existing `software` marker does not match `softpipe`/
 no software marker, which is exactly why the explicit sanitized verdict is
 required to avoid a false-hardware pass.)
 
+**Per-engine FR11 diagnostics (explicit `failureDiagnostic` update).**
+`failureDiagnostic` gains an explicit **`unverifiable`** branch so a Firefox
+`Generic Renderer` verdict produces the FR11 "probe returned the sanitized
+renderer — set/verify the probe-only `webgl.sanitize-unmasked-renderer: false`
+preference" hint, **not** the software branch's Mesa/adapter hint. Without this new
+branch, `unverifiable` would fall through to the software default (lines ~299–308
+today) and mislead the operator. Crash/timeout and software diagnostics name the
+**engine** (Chromium vs Firefox) and point at the engine-tagged transcript path.
+The existing Chromium diagnostics (Mesa d3d12 not selected, no-context, WSL libs
+missing, crash/timeout) keep their current wording and remedy hints unchanged; the
+Firefox recipe reuses the same host-prereq skip diagnostics.
+
 **Two-engine verification gating (pure decision function).** Given the requested
 engine set (`all` ⇒ {chromium, firefox}) and each engine's verdict, decide the run
 shape — a pure function, unit-tested:
@@ -216,12 +228,30 @@ unknown throws, default `all`); the verification-gating decision function across
 all branches above (both-verify, non-strict fallback with/without Chromium in the
 set, REQUIRE abort, force-fallback with/without Chromium, empty-set skip); the
 per-engine `formatReport` contract (hardware two-engine, fallback, skip-empty);
-Firefox recipe host-prereq gating reusing the fake host view. Existing Chromium
-tests are preserved or consciously migrated to the new report keys (documented in
-the Change Log).
+Firefox recipe host-prereq gating reusing the fake host view; and the **per-engine
+FR11 diagnostics** — a dedicated case asserting the Firefox sanitized-`Generic
+Renderer` `unverifiable` diagnostic emits the probe-only-preference hint (and
+**not** the Mesa hint), plus engine-named crash/timeout wording and engine-tagged
+transcript paths — so the operator-facing failure surface cannot silently regress
+during the refactor.
+
+**Existing Chromium CLI/debug surface must stay green (regression guard).** The
+engine-aware refactor MUST preserve the current single-engine Chromium behavior and
+its existing tests, not merely "migrate" them: `--mode=headed|headless`,
+`--candidate=<id>`, `--channel=<name>` (probe-only), the candidate-data invariants,
+the probe matrix/`runSelection` ordering, and the `composeEnv`/`fallbackEnv`/
+`partitionCandidates` semantics all keep working. Every existing test in
+`tests/gpu-lane.test.mjs` remains present and green, **except** those asserting the
+old single `engine: chromium` / `renderer:` report lines, which are deliberately
+updated to the new per-engine keys (FR10). The only intended test deltas are (a)
+the report-key contract change and (b) additive new cases; any other pre-existing
+Chromium test going red is a refactor regression to fix, not a migration — each
+such change is itemized in the Change Log.
 
 #### Acceptance Criteria
-- [ ] `npm test` green (migrated + new cases) with no GPU/browser/lane env.
+- [ ] `npm test` green with no GPU/browser/lane env — **every** pre-existing
+      Chromium test still present and green (only the report-key assertions
+      updated), plus the new Firefox/selector/gating/FR11 cases.
 - [ ] `node scripts/e2e-gpu-lane.mjs --probe-only` on this host reports **both**
       `renderer.chromium` (ANGLE D3D12) and `renderer.firefox`
       (`D3D12 (NVIDIA GeForce RTX 3080)`), both classified hardware.
@@ -512,11 +542,35 @@ artifact future #41 qualification cites). No persistent telemetry.
 
 ## Expert Review
 
-**Date**: (pending — porch runs 3-way consultation on this plan draft)
-**Model**: Gemini, Codex, Claude
-**Key Feedback**: (to be recorded after consultation)
+**Date**: 2026-07-21 (plan iteration 1)
+**Model**: Gemini (APPROVE, HIGH), Codex (COMMENT, HIGH), Claude (APPROVE, HIGH)
 
-**Plan Adjustments**: (to be recorded after consultation)
+**Key Feedback**: All three independently verified the plan's codebase claims
+against `scripts/e2e-gpu-lane.mjs` and `playwright.config.ts` and found complete
+FR/Decision/Scenario coverage, clean phase isolation, and a sound "engine dimension
+as data" approach; no blocking issues and no architecture concerns. Non-blocking
+refinements raised:
+- **Claude**: `failureDiagnostic` needs an explicit `unverifiable` branch, else a
+  Firefox `Generic Renderer` verdict falls into the software default branch and
+  emits the wrong Mesa hint instead of the FR11 probe-preference hint.
+- **Codex (1)**: explicitly require unit coverage for the new Firefox-specific FR11
+  diagnostics (sanitized renderer, per-engine crash/timeout wording, engine-tagged
+  transcript naming) so the operator-facing failure surface doesn't regress.
+- **Codex (2)**: Phase 1 should explicitly preserve **and keep green** the existing
+  Chromium `--mode`/`--candidate`/`--channel` debug surface and its tests, not just
+  "consciously migrate" them.
+
+**Plan Adjustments**:
+- Added a "Per-engine FR11 diagnostics (explicit `failureDiagnostic` update)"
+  paragraph to Phase 1 requiring the new `unverifiable` branch + engine-named
+  crash/timeout wording (Claude, Codex 1).
+- Expanded the Phase 1 unit-test targets to require a dedicated FR11 diagnostic case
+  (sanitized ⇒ probe-preference hint, not Mesa) plus engine-tagged transcript
+  assertions (Codex 1).
+- Added an "Existing Chromium CLI/debug surface must stay green (regression guard)"
+  paragraph and tightened the Phase 1 acceptance criterion so every pre-existing
+  Chromium test stays present/green (only report-key assertions updated); any other
+  red is a refactor regression, not a migration (Codex 2).
 
 ## Approval
 
@@ -528,6 +582,7 @@ human-approved.
 | Date | Change | Reason | Author |
 |------|--------|--------|--------|
 | 2026-07-21 | Initial implementation plan | Draft from approved spec 52 | Builder spir-52 |
+| 2026-07-21 | Explicit `failureDiagnostic` `unverifiable` branch + FR11 diagnostic test coverage + Chromium CLI/debug regression guard | Plan iter-1 consultation (Claude, Codex) | Builder spir-52 |
 
 ## Notes
 

--- a/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
@@ -1,0 +1,546 @@
+# Plan: Add Firefox Hardware WebGL to the Native-GPU Local E2E Lane (Two-Engine)
+
+## Metadata
+- **ID**: plan-2026-07-21-firefox-hardware-webgl-gpu-lane
+- **Status**: draft
+- **Specification**: [codev/specs/52-firefox-hardware-webgl-gpu-lane.md](../specs/52-firefox-hardware-webgl-gpu-lane.md)
+- **Created**: 2026-07-21
+
+## Executive Summary
+
+Implements the spec's selected **Approach C**: generalize the existing #44 lane
+wrapper (`scripts/e2e-gpu-lane.mjs`, `npm run test:e2e:gpu`) from Chromium-only to
+an **engine-aware** two-engine (Chromium + Firefox) lane, expressing the engine
+dimension as **data** rather than scattered `if (engine === "firefox")` branches
+(spec NFR Maintainability). The wrapper probes and independently verifies a
+hardware renderer for each requested engine, then runs **one** combined
+`E2E_ENGINES=chromium,firefox` Playwright suite (one build, one invocation,
+`workers: 1`, `retries: 0`) and ends with a per-engine machine-greppable report.
+
+The single genuinely new technical element is **Firefox renderer verification**:
+Firefox privacy-sanitizes the unmasked renderer to `Generic Renderer` /
+`Microsoft Corporation`, so the raw renderer is read through an **ephemeral,
+probe-only** preference (`webgl.sanitize-unmasked-renderer: false`) that never
+touches the application-suite Firefox profile. A sanitized string is treated as
+**unverifiable** (never hardware). Firefox's probe uses the **same Mesa d3d12
+environment** as Chromium with **no ANGLE flags**; in the combined suite Firefox
+inherits that Mesa env from the suite process while `PW_CHROMIUM_ARGS` stays
+Chromium-scoped — so Firefox needs **no new `playwright.config.ts` hook**.
+
+The canonical SwiftShader serial gate is untouched by construction: no committed
+test, no CI file, no default config behavior changes; `playwright.config.ts`'s
+`firefox` project prefs (`webgl.force-enabled: true` only) are unchanged. Honest
+fallback semantics are preserved: Firefox has no portable software equivalent, so
+on exhaustion Chromium keeps its deterministic SwiftShader fallback while Firefox
+is **skipped** (never a llvmpipe masquerade); under `E2E_GPU_REQUIRE=1` any
+unverified requested engine fails before build/suite.
+
+Three phases isolate the pure engine-aware core (unit-testable, GPU-free) from the
+two-engine suite wiring + inertness proof, from the qualification-evidence +
+documentation work — so each commit is small, independently testable, and
+independently revertible. This lane is additional tooling, **never** the green
+gate (arch-critical: Validation Baseline).
+
+Evidence base this plan builds on (no rediscovery needed):
+- The feasibility report `firefox-native-gpu-e2e-feasibility.md` (2026-07-21, go
+  verdict): headless Firefox under the Mesa d3d12 recipe reaches
+  `D3D12 (NVIDIA GeForce RTX 3080)`; without the recipe it is
+  `llvmpipe (LLVM 21.1.8, 256 bits)`; the sanitize pref exposes the true string;
+  a combined Chromium+Firefox run passed 22/22 in ~3.2 min.
+- The #44 lane (`scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`) with its
+  injected-probe test pattern, `PW_CHROMIUM_ARGS` hook, and `E2E_ENGINES`
+  handling in `playwright.config.ts` (already accepts `chromium,firefox`).
+
+## Success Metrics
+
+Copied from the spec's acceptance scenarios and made implementation-checkable:
+
+- [ ] `npm run test:e2e:gpu` on this WSL2/RTX 3080 host verifies hardware
+      renderers **independently** for Chromium (ANGLE D3D12 string) and Firefox
+      (raw `D3D12 (NVIDIA GeForce RTX 3080)` via the probe-only pref), both ≠ the
+      expanded deny-list, then runs the full `E2E_ENGINES=chromium,firefox` suite
+      (22 tests) in one invocation; report shows `mode: hardware`,
+      `engines: chromium,firefox`, and both `renderer.chromium`/`renderer.firefox`
+      lines with wall-clock (Scenario 1; FR1–FR5, FR10).
+- [ ] Firefox's raw probe renderer is collected through
+      `webgl.sanitize-unmasked-renderer: false` (probe browser only) and rejects
+      known software renderers; a sanitized `Generic Renderer` is treated as
+      **unverifiable**, not hardware (FR3).
+- [ ] Expanded deny-list rejects at least SwiftShader, llvmpipe, softpipe,
+      lavapipe, swrast, generic software rasterizers, and Microsoft Basic Render
+      Driver, for both engines' raw strings; the Chromium deny-list is not
+      weakened (FR3, Decision 7).
+- [ ] `--engine=chromium|firefox|all` selects the probe/suite engine set; `all`
+      is default; unknown values are a hard usage error (FR7).
+- [ ] Default (`all`) non-strict, not both verify ⇒ Chromium SwiftShader +
+      Firefox **skipped** with a loud reason at start and in the report; never a
+      Firefox software masquerade (Scenario 2; FR4, Decision 6).
+- [ ] `E2E_GPU_REQUIRE=1` with either requested engine unverified ⇒ non-zero exit
+      **before** build/suite, with the per-engine log (Scenario 3; FR4/Decision 5).
+- [ ] `--engine=firefox` non-strict with no verified hardware (incl.
+      `E2E_GPU_FORCE_FALLBACK=1 --engine=firefox`) ⇒ empty engine set is **never**
+      passed to Playwright; skip build/suite, report
+      `renderer.firefox: skipped (unverified — <reason>)` +
+      `suite: skipped (no verified engine)`, exit 0 (Scenario 7; FR4).
+- [ ] FR8: ≥3 consecutive full **two-engine** hardware runs under
+      `E2E_GPU_REQUIRE=1` (per-test results, both renderer strings, per-run and
+      combined wall-clock, `retries: 0`) + one forced-fallback run + a
+      contemporaneous baseline recorded in the review; the known Firefox
+      background-drag flake dispositioned per Decision 10 (never masked)
+      (Scenario 5).
+- [ ] FR6: `.github/workflows/validation.yml` and the `validate`/`test:smoke`
+      chain absent from the PR diff; `playwright.config.ts` default behavior with
+      lane env unset is unchanged (config-load proof), incl. the `firefox` project
+      prefs; PR CI green under `E2E_ENGINES=chromium` SwiftShader (Scenario 4).
+- [ ] FR9: the README "Opt-in native-GPU e2e lane" section is updated **in place**
+      to the two-engine reality (Scenario 6).
+- [ ] No dependency/lockfile/toolchain movement; `tests/gpu-lane.test.mjs` green
+      with no GPU, no browser, no lane env (arch-critical: reproducibility).
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "engine_aware_core", "title": "Engine-aware core: per-engine probe recipes, Firefox probe + sanitize pref, expanded deny-list, --engine selector, per-engine report, unit tests"},
+    {"id": "two_engine_suite_and_inertness", "title": "Two-engine suite wiring, honest fallback + empty-engine-set skip, FR6 default-inert proof"},
+    {"id": "qualification_evidence_and_docs", "title": "Firefox-inclusive repeat-run evidence (FR8), flake disposition (Decision 10), README docs (FR9)"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: `engine_aware_core` — per-engine probe recipes, Firefox probe, expanded deny-list, `--engine` selector, per-engine report, unit tests
+**Dependencies**: None
+
+#### Objectives
+- Make the lane's pure logic and probe **engine-aware** without changing suite
+  wiring yet: introduce a per-engine probe-recipe model, generalize the probe to
+  launch Firefox (with the probe-only sanitize pref) as well as Chromium, expand
+  the software deny-list, add the `--engine` selector, add the two-engine
+  verification-gating decision function, and migrate the report to per-engine
+  keys — all runnable standalone via `--probe-only` before the suite wiring
+  changes, and fully unit-testable with no GPU/browser/lane env.
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs` — engine-aware core (details below); no new
+      dependency, Node built-ins + `@playwright/test` only; no side effects on
+      import.
+- [ ] `--engine=chromium|firefox|all` parsed by `parseArgs` (default `all`);
+      unknown value ⇒ `LaneUsageError`.
+- [ ] `--probe-only` probes the **requested engine set** and emits the per-engine
+      report.
+- [ ] `tests/gpu-lane.test.mjs` migrated to the new report contract and extended
+      for the new logic (rides the existing `npm test` glob).
+
+#### Implementation Details
+
+**Per-engine probe-recipe model (engine dimension as data).** Keep the existing
+Chromium `CANDIDATES` list (ANGLE flags + Mesa env, iterated by evidence strength)
+as the Chromium recipe set. Add a **single Firefox probe recipe** describing:
+the same Mesa env (`GALLIUM_DRIVER=d3d12`,
+`LD_LIBRARY_PATH=/usr/lib/wsl/lib` prepended), **no ANGLE flags**, WSL2 host
+prereqs (reuse `partitionCandidates`' `/dev/dxg` + `/usr/lib/wsl/lib` gating), and
+probe-only `firefoxUserPrefs: { "webgl.force-enabled": true,
+"webgl.sanitize-unmasked-renderer": false }`. Firefox is not forced into the
+Chromium candidate shape (it has prefs, not launch `flags`); instead the
+verification layer dispatches per engine to the right recipe/launcher. Chromium's
+data and iteration are unchanged (Decision 2).
+
+**Generalized probe.** Extend `probeRenderer` (or add a thin per-engine wrapper
+around the shared timeout/transcript/reap machinery) so the launcher is chosen by
+engine: Chromium via `chromium.launch({ args, env, ... })` (unchanged); Firefox
+via `firefox.launch({ firefoxUserPrefs, env, ... })` from `@playwright/test`. Both
+read the raw `UNMASKED_RENDERER_WEBGL` / `UNMASKED_VENDOR_WEBGL` via the existing
+`PROBE_PAGE_SCRIPT`. The injected-launcher pattern and the watchdog/late-reap/
+bounded-close logic are preserved (they are engine-independent). Transcript
+filenames gain the engine so Chromium and Firefox probes don't overwrite each
+other (`probe-<engine>-<candidate|firefox>-<mode>.log`).
+
+**Renderer classification (expanded, plus sanitized detection).** Expand
+`SOFTWARE_RENDERER_MARKERS` to at least: `swiftshader`, `llvmpipe`, `softpipe`,
+`lavapipe`, `swrast`, `software`, `microsoft basic` (Decision 7). Add a distinct
+**sanitized/unverifiable** verdict for Firefox: a raw renderer of
+`Generic Renderer` (case-insensitive; the sanitized string that appears when the
+probe pref did **not** take) classifies as `unverifiable`, **not** `hardware`
+(FR3). `classifyRenderer` returns one of `none | software | unverifiable |
+hardware`; only `hardware` is trusted. The full raw string is always recorded
+verbatim. (Note: the existing `software` marker does not match `softpipe`/
+`lavapipe`/`swrast`, so these are genuinely new; and `Generic Renderer` matches
+no software marker, which is exactly why the explicit sanitized verdict is
+required to avoid a false-hardware pass.)
+
+**Two-engine verification gating (pure decision function).** Given the requested
+engine set (`all` ⇒ {chromium, firefox}) and each engine's verdict, decide the run
+shape — a pure function, unit-tested:
+- All requested engines `hardware` ⇒ `{mode: "hardware", engines: <requested>,
+  chromiumCandidate, chromiumRenderer, firefoxRenderer}`.
+- Not all verify, **non-strict**, and Chromium is in the requested set ⇒
+  `{mode: "software-fallback", engines: ["chromium"], firefox: "skipped:<reason>"}`
+  (Chromium SwiftShader; Firefox skipped — Decision 6).
+- Not all verify, **non-strict**, Chromium **not** requested (i.e.
+  `--engine=firefox`) ⇒ `{mode: "skip-empty", firefox: "skipped:<reason>"}` — the
+  empty-engine-set rule (FR4/Scenario 7): no suite is run.
+- `E2E_GPU_REQUIRE=1` and any requested engine unverified ⇒ `{mode: "abort"}`
+  (exit non-zero before build/suite — Decision 5).
+- `E2E_GPU_FORCE_FALLBACK=1`: skip probing. For a set containing Chromium ⇒
+  Chromium SwiftShader + Firefox skipped. For `--engine=firefox` alone ⇒
+  `skip-empty` (vacuous no-op, exit 0 — FR4), **not** a usage error. The existing
+  `FORCE_FALLBACK=1 + REQUIRE=1` contradiction stays a `LaneUsageError`.
+
+**Per-engine report (FR10 migration).** Replace the single `engine: chromium` /
+`renderer:` lines with a per-engine contract; keys stable and documented:
+
+```text
+=== E2E GPU LANE REPORT ===
+mode: hardware | software-fallback | skipped
+engines: chromium,firefox
+renderer.chromium: <verbatim string | skipped (unverified — <reason>) | (software-fallback — SwiftShader)>
+renderer.firefox: <verbatim string | skipped (unverified — <reason>)>
+suite: pass | fail (exit n) | skipped (no verified engine)
+wall-clock: <total>s (build <n>s, suite <n>s)
+```
+
+Only engines in the run's engine set get a `renderer.<engine>` line; a skipped
+engine is represented explicitly (never omitted silently). `tests/gpu-lane.test.mjs`
+and any report-key consumer are updated to the new contract (the only in-repo
+consumer today is the unit test and the README example, updated in Phase 3).
+
+**Unit test targets** (all pure, no browser/GPU/lane env — arch-critical
+reproducibility): expanded `classifyRenderer` (softpipe/lavapipe/swrast/swiftshader/
+llvmpipe/software/microsoft-basic ⇒ software; `Generic Renderer` ⇒ unverifiable;
+proven ANGLE D3D12 and raw `D3D12 (NVIDIA GeForce RTX 3080)` ⇒ hardware;
+empty/null ⇒ none); `parseArgs` `--engine` validation (all/chromium/firefox valid,
+unknown throws, default `all`); the verification-gating decision function across
+all branches above (both-verify, non-strict fallback with/without Chromium in the
+set, REQUIRE abort, force-fallback with/without Chromium, empty-set skip); the
+per-engine `formatReport` contract (hardware two-engine, fallback, skip-empty);
+Firefox recipe host-prereq gating reusing the fake host view. Existing Chromium
+tests are preserved or consciously migrated to the new report keys (documented in
+the Change Log).
+
+#### Acceptance Criteria
+- [ ] `npm test` green (migrated + new cases) with no GPU/browser/lane env.
+- [ ] `node scripts/e2e-gpu-lane.mjs --probe-only` on this host reports **both**
+      `renderer.chromium` (ANGLE D3D12) and `renderer.firefox`
+      (`D3D12 (NVIDIA GeForce RTX 3080)`), both classified hardware.
+- [ ] `--probe-only --engine=chromium` and `--engine=firefox` each probe only that
+      engine and report it.
+- [ ] `--engine=bogus` exits with a usage error (exit 2).
+- [ ] `npm run lint` and `npm run typecheck` clean.
+
+#### Test Plan
+- **Unit**: as above (this phase's main deliverable).
+- **Manual (this host)**: `--probe-only` runs — `all`, `--engine=chromium`,
+  `--engine=firefox`; record both raw renderer strings and the Firefox
+  sanitized-vs-unsanitized contrast (with the pref off vs on) as evidence.
+
+#### Rollback Strategy
+Two files (`scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`); revert the
+commit. Suite wiring is unchanged in this phase, so a revert leaves the
+Chromium-only lane exactly as #44 shipped.
+
+#### Risks
+- **Risk**: Firefox probe pref does not take and the probe reports the sanitized
+  `Generic Renderer`.
+  - **Mitigation**: FR3 sanitized verdict ⇒ `unverifiable` (a failed verdict with
+    the FR11 "hint the probe-only preference" diagnostic), never a false hardware
+    pass.
+- **Risk**: report-key change breaks the unit test / README consumer.
+  - **Mitigation**: contained migration — update `tests/gpu-lane.test.mjs` this
+    phase, README in Phase 3; keys documented and stable thereafter.
+
+---
+
+### Phase 2: `two_engine_suite_and_inertness` — two-engine suite wiring, honest fallback + empty-set skip, FR6 default-inert proof
+**Dependencies**: Phase 1
+
+#### Objectives
+- Turn the engine-aware core into a working end-to-end two-engine lane run and
+  prove the canonical gate is untouched (FR1, FR4, FR5, FR6, FR10).
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs` extended: engine-set-aware `suiteEnvFor`, the
+      `main()`/`resolveMode` orchestration for two-engine gating, honest fallback,
+      REQUIRE abort, and the empty-engine-set skip; per-engine final report.
+- [ ] FR6 default-inert evidence recorded in the review draft.
+- [ ] `playwright.config.ts`: **no code change expected** (Firefox needs no new
+      hook — Decision 9). If any change proves truly necessary it must be
+      comment-only and default-inert, proven so; the `firefox` project prefs stay
+      `webgl.force-enabled: true` (the probe-only sanitize pref lives only in the
+      wrapper).
+
+#### Implementation Details
+
+**Engine-set-aware suite env.** Generalize `suiteEnvFor` to take the run's engine
+set and (for hardware) the verified Chromium candidate:
+- **Hardware, engine set includes Chromium**: `E2E_ENGINES = <requested set>`
+  (e.g. `chromium,firefox`); `PW_CHROMIUM_ARGS = chromiumCandidate.flags.join(" ")`
+  (Chromium-scoped, unchanged); inject the Mesa recipe env
+  (`composeEnv(baseEnv, chromiumCandidate, extraEnv)`) into the suite process so
+  **Firefox inherits the same Mesa env** with no extra wiring (Decision 9).
+- **Hardware, `--engine=firefox` only**: `E2E_ENGINES = "firefox"`; **no**
+  `PW_CHROMIUM_ARGS`; inject the Firefox recipe's Mesa env directly (same
+  GALLIUM_DRIVER + LD_LIBRARY_PATH values) so Firefox reaches the adapter.
+- **Software-fallback**: `fallbackEnv(baseEnv)` (strip `PW_CHROMIUM_ARGS`) with
+  `E2E_ENGINES = "chromium"` (Firefox is skipped, not run — Decision 6), exactly
+  the #44 fallback.
+- **skip-empty** (`--engine=firefox`, unverified, non-strict): **no suite is
+  spawned at all** — the lane must never invoke `playwright test` with an empty or
+  invalid `E2E_ENGINES` (an empty set trips `playwright.config.ts`'s
+  `projects.length === 0` guard and throws). Emit the report with
+  `suite: skipped (no verified engine)` and exit 0.
+
+`workers`/`retries`/timeouts are never touched (config defaults: `workers: 1`,
+local `retries: 0`); the lane runs one build then one `npx playwright test`,
+mirroring `test:smoke`. Suite exit code is the lane exit code in every run-mode
+except `abort` (exit 1) and `skip-empty` (exit 0).
+
+**Orchestration.** `resolveMode` produces the gating decision (Phase 1 function)
+from the requested engine set, controls, and per-engine probe verdicts; `main()`
+dispatches: `abort` ⇒ return 1 before build; `skip-empty` ⇒ report + return 0
+before build; otherwise build then suite, with the loud fallback banner (start
+**and** before the report) whenever an engine is on software/skipped, so a
+non-hardware run can never read as two-engine hardware evidence.
+
+**FR6 proof procedure** (recorded verbatim in the review artifact):
+1. `git diff main -- playwright.config.ts` — empty, or comment-only (no code
+   tokens; the `firefox` project prefs unchanged).
+2. `.github/workflows/validation.yml` and the `validate`/`test:smoke` script
+   entries absent from `git diff main --stat`.
+3. Config-load check with **all lane env unset**: load the resolved config and
+   assert the `firefox` project prefs are exactly `{ "webgl.force-enabled": true }`
+   (no sanitize pref), Chromium `launchOptions.args` are exactly
+   `["--use-angle=swiftshader","--enable-unsafe-swiftshader"]`, `E2E_ENGINES`
+   handling / `workers === 1` / `retries === 0` (non-CI) / timeout / reporter /
+   webServer shapes are value-equal to `main`. Record output verbatim.
+4. PR CI (quality + SwiftShader Chromium shards + gate) green under
+   `E2E_ENGINES=chromium` — collected at Review.
+
+#### Acceptance Criteria
+- [ ] `npm run test:e2e:gpu` on this host: two-engine hardware mode, full 22-test
+      suite in one invocation, per-engine report, exit code = suite result.
+- [ ] `E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu`: Chromium SwiftShader +
+      Firefox skipped, loud warnings, per-engine software-fallback report.
+- [ ] `E2E_GPU_REQUIRE=1` with a forced Firefox miss ⇒ non-zero exit before
+      build/suite with the per-engine log.
+- [ ] `--engine=firefox` on a non-verifying setup (or with
+      `E2E_GPU_FORCE_FALLBACK=1`) ⇒ no `playwright test` spawned, report shows
+      `suite: skipped (no verified engine)`, exit 0.
+- [ ] FR6 items 1–3 recorded clean; `npm test`/`lint`/`typecheck` green; no
+      lockfile diff.
+
+#### Test Plan
+- **Unit**: extend `tests/gpu-lane.test.mjs` for the engine-set `suiteEnvFor`
+  branches (two-engine env, firefox-only env, fallback env, and that skip-empty
+  produces no suite invocation).
+- **Integration (manual, this host)**: one two-engine hardware full run; one
+  forced-fallback full run; one `--engine=firefox` skip-empty run (feeds Phase 3
+  evidence).
+- **Gate**: FR6 procedure.
+
+#### Rollback Strategy
+Revert the phase commit; suite wiring returns to the Chromium-only Phase 1 state.
+Default behavior was never altered (no config code change).
+
+#### Risks
+- **Risk**: the Mesa env injected into the suite process perturbs the webServer or
+  Chromium arm.
+  - **Mitigation**: the #44 lane already injects this exact Mesa env into the
+    suite process for the Chromium hardware run with no server interference
+    (`/usr/lib/wsl/lib` is GPU libs only); this phase adds Firefox as a consumer of
+    the *same* env, not a new env. Any interference is recorded as a lane finding;
+    canonical config untouched.
+- **Risk**: the combined two-engine suite surfaces the known Firefox background-drag
+  flake.
+  - **Mitigation**: Decision 10 — recorded as a lane finding and dispositioned in
+    Phase 3; never masked with retries, assertion never weakened.
+
+---
+
+### Phase 3: `qualification_evidence_and_docs` — FR8 two-engine evidence, flake disposition, FR9 documentation
+**Dependencies**: Phase 2
+
+#### Objectives
+- Produce the Firefox-inclusive repeat-run stability evidence that makes the
+  two-engine lane trustworthy, disposition the known Firefox flake honestly, and
+  update the documentation so the lane is discoverable and interpretable
+  (FR8, FR9, Decision 10, Scenarios 5–6).
+
+#### Deliverables
+- [ ] **≥3 consecutive full two-engine hardware runs** under `E2E_GPU_REQUIRE=1`
+      (each: per-test pass/fail for both projects, both engines' verbatim raw
+      renderer strings, per-run and combined wall-clock, `retries: 0`) recorded in
+      `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`, alongside a
+      contemporaneous baseline for comparison.
+- [ ] One **forced-fallback** full run recorded (Chromium SwiftShader + Firefox
+      skipped) — qualifies the fallback path.
+- [ ] **Flake disposition (Decision 10)**: the known Firefox background-drag
+      synthetic-input flake (`tests/e2e/matrix.spec.ts:224`) is either fixed +
+      requalified, **or** explicitly accepted and documented as a local
+      qualification flake with its recurrence rate from these runs. Either way it
+      is **never** masked with retries and the canonical assertion is never
+      weakened. The FR8 two-branch merge gate governs: green, or
+      green-except-this-one-documented-flake; any other failure blocks and is
+      root-caused first.
+- [ ] **README** "Opt-in native-GPU e2e lane" section updated **in place**: the
+      two-engine command; the Firefox probe recipe (Mesa env + probe-only prefs)
+      and the `webgl.sanitize-unmasked-renderer` rationale (why Chromium's
+      deny-list alone is too weak for Firefox); the per-engine report block
+      (`renderer.chromium`/`renderer.firefox`); the `--engine=chromium|firefox|all`
+      selector in the env/flags table; honest-fallback semantics (Firefox skipped,
+      never a software masquerade); the known flake and its disposition; the
+      unchanged non-gate status and #41 sequencing note; a link to review 52 for
+      the run evidence (as the section currently links #44's review).
+
+#### Implementation Details
+Runs use the lane exactly as shipped (no special harness), with
+`E2E_GPU_REQUIRE=1` so an unnoticed mid-qualification fallback cannot contaminate
+the evidence (FR8). Record a wall-clock comparison: the combined two-engine
+hardware runs vs the baseline, and note the feasibility report's ~3.2 min combined
+figure as historical context. If the background-drag flake recurs, capture the
+verbatim failure (expected vs observed camera delta) and its rate across the runs;
+choose and document the Decision-10 disposition explicitly in the review. Do not
+edit `tests/e2e/matrix.spec.ts` unless the chosen disposition is a genuine fix
+(and if so, requalify with a fresh ≥3-run set).
+
+#### Acceptance Criteria
+- [ ] FR8 evidence complete and honest (per-run detail, both renderer strings,
+      failures preserved verbatim, no aggregation-only claims); the merge gate is
+      satisfied per FR8's two branches.
+- [ ] The Firefox flake has an explicit, documented disposition; no retries added,
+      no assertion weakened.
+- [ ] A developer who never read this spec can find, run, and correctly interpret
+      the two-engine lane (hardware vs Chromium-fallback+Firefox-skipped) from the
+      README alone (Scenario 6).
+- [ ] `npm run validate` green locally on the final tree; clean-worktree proof
+      (`git worktree add --detach HEAD` + real `npm ci`) if any gate check is
+      polluted only by untracked builder-harness files (lessons-critical).
+
+#### Test Plan
+- **Manual/evidence**: the qualification runs themselves.
+- **Regression**: full `npm run validate` (SwiftShader, both engines) on the final
+  tree before PR.
+
+#### Rollback Strategy
+Docs + evidence only (plus any genuine flake fix, which reverts with its commit);
+revert restores the pre-doc tree. Lane behavior unchanged by this phase unless a
+disclosed fix was made.
+
+#### Risks
+- **Risk**: a two-engine hardware run flakes on something other than the known
+  background-drag test, breaking "≥3 consecutive".
+  - **Mitigation**: FR8 gate — any failure beyond the one known documented flake
+    blocks; root-cause it (fix, or qualify as a genuinely new flake), then restart
+    the consecutive count. Never trim canonical waits, never hide runs.
+
+## Dependency Map
+
+```
+Phase 1 (engine-aware core + probe + deny-list + selector + report + unit tests)
+   ↓
+Phase 2 (two-engine suite wiring + honest fallback + empty-set skip + FR6 proof)
+   ↓
+Phase 3 (FR8 two-engine evidence + flake disposition + FR9 README docs)
+```
+
+## Resource Requirements
+
+- **Environment**: the pinned toolchain (Node 22.23.1 / npm 10.9.8, `npm ci`);
+  this WSL2 host with RTX 3080 for the two-engine hardware evidence; Playwright's
+  already-bundled Firefox (no new dependency, service, or infrastructure).
+- **Files touched (whole project)**: `scripts/e2e-gpu-lane.mjs`,
+  `tests/gpu-lane.test.mjs`, `README.md`,
+  `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`,
+  `codev/state/spir-52_thread.md`. `playwright.config.ts` only if a comment-only,
+  proven-inert change proves necessary (not expected). `package.json` unchanged
+  (the `test:e2e:gpu` script already exists).
+
+## Integration Points
+
+- **Internal**: the `PW_CHROMIUM_ARGS` hook (Chromium-scoped, unchanged); the
+  `firefox` Playwright project and `E2E_ENGINES` handling in `playwright.config.ts`
+  (already accepts `chromium,firefox`); the `webServer` production-server flow via
+  `playwright test`; the #44 wrapper's injected-probe test pattern.
+- **External systems**: none (explicitly — the #42 lesson).
+
+## Risk Analysis
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Firefox sanitized `Generic Renderer` mistaken for hardware | M | H | FR3 `unverifiable` verdict tied to the probe-only sanitize pref; sanitized ⇒ failed verdict, never hardware |
+| Firefox background-drag synthetic-input flake recurs on hardware | M | M | Decision 10 + FR8 two-branch gate: fix/qualify or accept+document; never masked with retries or by weakening the assertion |
+| Report-key change breaks a consumer/unit test | M | M | FR10 contained migration in Phase 1 (test) + Phase 3 (README); stable documented keys |
+| Probe-only Firefox pref leaks into the suite profile | L | H | Pref confined to the ephemeral probe launch; suite `firefox` project prefs unchanged (FR6 config-load proof) |
+| Config drift endangers the canonical gate | L | H | Firefox needs no new config hook (Decision 9); FR6 default-inert proof + CI green |
+| Two-engine wrapper duplicates suite-invocation logic | L | M | Delegate over duplicate; engine set is data; one build + one `playwright test` |
+| Mesa env in the suite process perturbs Firefox/server | L | M | Same env #44 already injects for Chromium; Firefox is a new consumer of the same env; findings recorded, config untouched |
+
+## Validation Checkpoints
+
+1. **After Phase 1**: `npm test` green with zero lane env/GPU; `--probe-only`
+   reports both engines' hardware renderers on this host; `--engine` selector and
+   sanitized-verdict behavior verified.
+2. **After Phase 2**: one two-engine hardware full run + one forced-fallback run +
+   one `--engine=firefox` skip-empty run behave per spec with correct reports/exit
+   codes; FR6 items 1–3 evidence recorded.
+3. **Before PR**: FR8 two-engine evidence complete and gate satisfied; flake
+   dispositioned; README updated; `npm run validate` green (clean worktree if
+   needed); no lockfile diff; `.github/workflows/validation.yml` absent from the
+   diff.
+
+## Monitoring and Observability
+
+Terminal-only tooling: per-engine/per-candidate FR11 diagnostics as they happen, a
+pre-report diagnostics summary, and the FR10 per-engine greppable report (the
+artifact future #41 qualification cites). No persistent telemetry.
+
+## Documentation Updates Required
+
+- [ ] README "Opt-in native-GPU e2e lane" section — updated in place (FR9, Phase 3).
+- [ ] Review artifact with FR6/FR8 evidence and the flake disposition (Phase 2–3).
+- [ ] `playwright.config.ts` hook comment — only if a comment touch proves needed
+      (not expected).
+
+## Post-Implementation Tasks
+
+- [ ] #41 may consume the two-engine FR8 evidence and lane for its parallel-workers
+      qualification (out of scope here; `workers: 1` everywhere).
+- [ ] Possible future arch.md/lessons update at MAINTAIN time (not this PR unless
+      the Review phase directs it).
+
+## Expert Review
+
+**Date**: (pending — porch runs 3-way consultation on this plan draft)
+**Model**: Gemini, Codex, Claude
+**Key Feedback**: (to be recorded after consultation)
+
+**Plan Adjustments**: (to be recorded after consultation)
+
+## Approval
+
+SPIR: `plan-approval` is a human gate (after 3-way consultation). PR gate remains
+human-approved.
+
+## Change Log
+
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-07-21 | Initial implementation plan | Draft from approved spec 52 | Builder spir-52 |
+
+## Notes
+
+- Names fixed by this plan: engine selector `--engine=chromium|firefox|all`
+  (default `all`); the existing env controls (`E2E_GPU_FORCE_FALLBACK=1`,
+  `E2E_GPU_REQUIRE=1`), script name `scripts/e2e-gpu-lane.mjs`, and npm script
+  `test:e2e:gpu` are unchanged.
+- The engine dimension is expressed as **data** (Chromium candidate list + a single
+  Firefox probe recipe) with per-engine launcher dispatch — not scattered
+  `if (engine === "firefox")` branches (spec NFR Maintainability).
+- The probe-only Firefox pref `webgl.sanitize-unmasked-renderer: false` lives
+  **only** in the ephemeral probe launch inside the wrapper; the committed
+  `firefox` project keeps `webgl.force-enabled: true` only (Decision 3, FR6).
+- No committed file may read the lane env/`--engine` selector except the wrapper;
+  `playwright.config.ts` continues to read only `PW_CHROMIUM_ARGS` and
+  `E2E_ENGINES` (already-merged behavior).

--- a/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/plans/52-firefox-hardware-webgl-gpu-lane.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - **ID**: plan-2026-07-21-firefox-hardware-webgl-gpu-lane
-- **Status**: draft
+- **Status**: completed (all three implement phases built, reviewed, and committed; PR #53)
 - **Specification**: [codev/specs/52-firefox-hardware-webgl-gpu-lane.md](../specs/52-firefox-hardware-webgl-gpu-lane.md)
 - **Created**: 2026-07-21
 

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/52-review-iter1-rebuttals.md
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/52-review-iter1-rebuttals.md
@@ -1,0 +1,84 @@
+# Rebuttal — Review phase (PR consult), iteration 1
+
+**Verdicts**: Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES.
+
+## Codex issue 1 — Firefox reported `skipped (unverified — unverified)` when Chromium failed but Firefox verified (ACCEPTED, FIXED)
+
+Correct, and a real per-engine reporting-honesty bug. In the non-strict fallback,
+when `chromium.verified === false` but `firefox.verified === true`, `computeRunPlan`
+set the Firefox outcome to `{state: "skipped", reason: verdicts.firefox?.reason ??
+"unverified"}`. A *verified* Firefox verdict carries no `reason`, so the reason
+collapsed to the literal `"unverified"`, and `engineReportLine` prefixes another
+`"unverified — "`, producing `skipped (unverified — unverified)` — which both
+mislabels a hardware-verified engine as unverified and reads as nonsense.
+
+**Fix** (`scripts/e2e-gpu-lane.mjs`):
+- Added a distinct `not-run` verdict state for an engine that **verified hardware
+  but is not run** because the combined two-engine hardware run needs both engines
+  and the sibling (Chromium) failed — so the run fell back to Chromium SwiftShader
+  (Decision 6: Firefox has no software equivalent to pair with the fallback).
+- `computeRunPlan`'s non-strict fallback now branches on `verdicts.firefox.verified`:
+  verified ⇒ `not-run` with an honest reason (`not run (Chromium unverified — a
+  two-engine hardware run needs both engines…)`); unverified ⇒ the existing
+  `skipped (unverified — <its own reason>)`.
+- `engineReportLine` renders `not-run` as `not run (<reason>)`.
+- Unit test added: `computeRunPlan: default 'all', Chromium fails but Firefox
+  VERIFIES ⇒ Firefox reported 'not run', never 'unverified'` (asserts the line
+  does not match `unverified — unverified` or `skipped (unverified`).
+- README report block gains the `not run (<reason>)` variant.
+
+**Scope note**: all other skip outputs are byte-identical — a genuinely
+unverified Firefox still reads `skipped (unverified — software renderer "…")`, and
+the forced-fallback path still reads `skipped (unverified — forced fallback,
+Firefox has no software equivalent)` (verified against the running code). So the
+recorded FB-1 evidence and the existing tests remain accurate.
+
+## Codex issue 2 — `npm test` fails in `tests/audit-report.test.mjs` (DISPUTED: environment artifact, not a regression)
+
+This is a Codex-sandbox environment artifact, not a defect in this branch:
+
+- **Untouched by this branch**: `git diff main..HEAD -- tests/audit-report.test.mjs
+  package.json package-lock.json` is empty. This branch changes only
+  `scripts/e2e-gpu-lane.mjs` + `tests/gpu-lane.test.mjs` (plus docs).
+- **The test shells out to the environment**: it uses `spawnSync` to run the audit
+  validator and asserts on `npm audit` report shapes, including an explicit
+  `EAI_AGAIN` "registry unavailable" case — i.e. it is sensitive to subprocess /
+  registry availability that differs in a sandboxed reviewer environment.
+- **Green here and on the gate**: on the qualification host `npm test` is **95/95**
+  (audit-report.test.mjs **4/4**), and porch's own `tests` check
+  (`npm test -- --exclude='**/e2e/**'`) passed at every phase. The GPU-lane suite
+  Codex itself confirmed passes (`node --test tests/gpu-lane.test.mjs`).
+
+No code change is warranted; re-proof is recorded above and in the review.
+
+## Codex issue 3 — plan says `Status: draft` (ACCEPTED, FIXED)
+
+`codev/plans/52-firefox-hardware-webgl-gpu-lane.md` line 5 updated to
+`Status: completed (all three implement phases built, reviewed, and committed;
+PR #53)`.
+
+## Additional fixes — architect integration review (PR #53)
+
+Folded into this iteration alongside the Codex fixes:
+
+- **Blocking**: `runProbeOnly()` returned `1` on a `E2E_GPU_REQUIRE=1` abort
+  **without** printing `formatReport()`, violating the "probe-only always reports"
+  contract (README / plan / the function's own doc comment). Unlike the full lane
+  (which aborts before doing any build/suite work), a probe-only run has already
+  produced its verdicts — the report is the deliverable, most useful exactly when
+  an engine failed. Fixed by extracting a pure `probeOnlyOutcome(...)` →
+  `{report, exitCode}` that always builds the per-engine report (`mode: abort` on
+  a REQUIRE abort) and is called before returning the exit code. Unit-tested
+  (`probeOnlyOutcome: probe-only ALWAYS reports, even when E2E_GPU_REQUIRE
+  aborts` — asserts the full report AND `exitCode === 1`).
+- **Minor**: `--candidate` / `--channel` are Chromium-only; `parseArgs` now
+  rejects them with `--engine=firefox` (usage error) instead of silently ignoring
+  them. Unit-tested; `--engine=all --candidate=…` stays valid.
+
+## Verification after fixes
+
+`npm test` 95/95 (→ with the new cases); `npx eslint scripts/e2e-gpu-lane.mjs
+tests/gpu-lane.test.mjs` clean; `npm run typecheck` clean. Verified end-to-end:
+`E2E_GPU_REQUIRE=1 --probe-only` with an unverified engine prints the per-engine
+report (`mode: abort`) then exits 1; `--engine=firefox --candidate=…` exits 2.
+Canonical gate still byte-identical to `main` (`playwright.config.ts` unchanged).

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -10,11 +10,11 @@ plan_phases:
     status: complete
   - id: two_engine_suite_and_inertness
     title: Two-engine suite wiring, honest fallback + empty-engine-set skip, FR6 default-inert proof
-    status: in_progress
+    status: complete
   - id: qualification_evidence_and_docs
     title: Firefox-inclusive repeat-run evidence (FR8), flake disposition (Decision 10), README docs (FR9)
-    status: pending
-current_plan_phase: two_engine_suite_and_inertness
+    status: in_progress
+current_plan_phase: qualification_evidence_and_docs
 gates:
   spec-approval:
     status: approved
@@ -28,8 +28,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: two_engine_suite_and_inertness
@@ -48,4 +48,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:38:00.946Z'
+updated_at: '2026-07-22T03:41:03.690Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -30,9 +30,10 @@ gates:
     approved_at: '2026-07-22T05:05:43.969Z'
   verify-approval:
     status: pending
+    requested_at: '2026-07-22T05:08:42.471Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T05:05:51.683Z'
+updated_at: '2026-07-22T05:08:42.471Z'
 pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T02:28:48.071Z'
+    approved_at: '2026-07-22T02:29:48.445Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:28:48.071Z'
+updated_at: '2026-07-22T02:29:48.445Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -11,6 +11,7 @@ gates:
     approved_at: '2026-07-22T02:29:48.445Z'
   plan-approval:
     status: pending
+    requested_at: '2026-07-22T02:39:33.597Z'
   pr:
     status: pending
   verify-approval:
@@ -19,4 +20,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:34:48.756Z'
+updated_at: '2026-07-22T02:39:33.597Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:07:48.135Z'
+updated_at: '2026-07-22T03:29:55.976Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -7,14 +7,14 @@ plan_phases:
     title: >-
       Engine-aware core: per-engine probe recipes, Firefox probe + sanitize pref, expanded deny-list, --engine selector,
       per-engine report, unit tests
-    status: in_progress
+    status: complete
   - id: two_engine_suite_and_inertness
     title: Two-engine suite wiring, honest fallback + empty-engine-set skip, FR6 default-inert proof
-    status: pending
+    status: in_progress
   - id: qualification_evidence_and_docs
     title: Firefox-inclusive repeat-run evidence (FR8), flake disposition (Decision 10), README docs (FR9)
     status: pending
-current_plan_phase: engine_aware_core
+current_plan_phase: two_engine_suite_and_inertness
 gates:
   spec-approval:
     status: approved
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:03:54.617Z'
+updated_at: '2026-07-22T03:07:48.135Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -26,6 +26,7 @@ gates:
     approved_at: '2026-07-22T02:42:26.015Z'
   pr:
     status: pending
+    requested_at: '2026-07-22T04:58:23.267Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -48,4 +49,5 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T04:41:47.147Z'
+updated_at: '2026-07-22T04:58:23.268Z'
+pr_ready_for_human: true

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:42:36.681Z'
+updated_at: '2026-07-22T03:03:54.617Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -25,8 +25,9 @@ gates:
     requested_at: '2026-07-22T02:39:33.597Z'
     approved_at: '2026-07-22T02:42:26.015Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T04:58:23.267Z'
+    approved_at: '2026-07-22T05:05:43.969Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -49,5 +50,5 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T04:58:23.268Z'
-pr_ready_for_human: true
+updated_at: '2026-07-22T05:05:43.969Z'
+pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,7 +1,7 @@
 id: '52'
 title: add-firefox-hardware-webgl-to-
 protocol: spir
-phase: verify
+phase: verified
 plan_phases:
   - id: engine_aware_core
     title: >-
@@ -36,5 +36,5 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T05:09:38.637Z'
+updated_at: '2026-07-22T05:09:39.824Z'
 pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,9 +1,20 @@
 id: '52'
 title: add-firefox-hardware-webgl-to-
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: engine_aware_core
+    title: >-
+      Engine-aware core: per-engine probe recipes, Firefox probe + sanitize pref, expanded deny-list, --engine selector,
+      per-engine report, unit tests
+    status: in_progress
+  - id: two_engine_suite_and_inertness
+    title: Two-engine suite wiring, honest fallback + empty-engine-set skip, FR6 default-inert proof
+    status: pending
+  - id: qualification_evidence_and_docs
+    title: Firefox-inclusive repeat-run evidence (FR8), flake disposition (Decision 10), README docs (FR9)
+    status: pending
+current_plan_phase: engine_aware_core
 gates:
   spec-approval:
     status: approved
@@ -18,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:42:26.015Z'
+updated_at: '2026-07-22T02:42:36.681Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:29:53.119Z'
+updated_at: '2026-07-22T02:34:48.756Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -28,8 +28,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: two_engine_suite_and_inertness
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:29:55.976Z'
+updated_at: '2026-07-22T03:37:12.046Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,11 +29,12 @@ gates:
     requested_at: '2026-07-22T04:58:23.267Z'
     approved_at: '2026-07-22T05:05:43.969Z'
   verify-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T05:08:42.471Z'
+    approved_at: '2026-07-22T05:09:38.637Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T05:09:37.490Z'
+updated_at: '2026-07-22T05:09:38.637Z'
 pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: two_engine_suite_and_inertness
@@ -48,4 +48,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T04:36:13.451Z'
+updated_at: '2026-07-22T04:41:47.147Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,7 +1,7 @@
 id: '52'
 title: add-firefox-hardware-webgl-to-
 protocol: spir
-phase: review
+phase: verify
 plan_phases:
   - id: engine_aware_core
     title: >-
@@ -31,24 +31,8 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
-history:
-  - iteration: 1
-    plan_phase: two_engine_suite_and_inertness
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
+build_complete: false
+history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T05:05:43.969Z'
+updated_at: '2026-07-22T05:05:51.683Z'
 pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -32,8 +32,8 @@ gates:
     status: pending
     requested_at: '2026-07-22T05:08:42.471Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T05:08:42.471Z'
+updated_at: '2026-07-22T05:09:37.490Z'
 pr_ready_for_human: false

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,0 +1,20 @@
+id: '52'
+title: add-firefox-hardware-webgl-to-
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-22T02:21:18.654Z'
+updated_at: '2026-07-22T02:21:18.655Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,7 +1,7 @@
 id: '52'
 title: add-firefox-hardware-webgl-to-
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: engine_aware_core
     title: >-
@@ -13,8 +13,8 @@ plan_phases:
     status: complete
   - id: qualification_evidence_and_docs
     title: Firefox-inclusive repeat-run evidence (FR8), flake disposition (Decision 10), README docs (FR9)
-    status: in_progress
-current_plan_phase: qualification_evidence_and_docs
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: two_engine_suite_and_inertness
@@ -48,4 +48,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T04:33:40.275Z'
+updated_at: '2026-07-22T04:36:13.451Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: two_engine_suite_and_inertness
@@ -48,4 +48,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:41:03.690Z'
+updated_at: '2026-07-22T04:33:40.275Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -1,7 +1,7 @@
 id: '52'
 title: add-firefox-hardware-webgl-to-
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:29:48.445Z'
+updated_at: '2026-07-22T02:29:53.119Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:21:18.655Z'
+updated_at: '2026-07-22T02:22:35.322Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -29,7 +29,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: two_engine_suite_and_inertness
@@ -48,4 +48,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-52/codev/projects/52-add-firefox-hardware-webgl-to-/52-two_engine_suite_and_inertness-iter1-claude.txt
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T03:37:12.046Z'
+updated_at: '2026-07-22T03:38:00.946Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-07-22T02:28:48.071Z'
   plan-approval:
     status: pending
   pr:
@@ -17,4 +18,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:22:35.322Z'
+updated_at: '2026-07-22T02:28:48.071Z'

--- a/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
+++ b/codev/projects/52-add-firefox-hardware-webgl-to-/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-07-22T02:28:48.071Z'
     approved_at: '2026-07-22T02:29:48.445Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T02:39:33.597Z'
+    approved_at: '2026-07-22T02:42:26.015Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T02:21:18.654Z'
-updated_at: '2026-07-22T02:39:33.597Z'
+updated_at: '2026-07-22T02:42:26.015Z'

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -26,22 +26,33 @@ totals into a zero-findings gate. Contributor commands and artifact names live i
 `playwright.config.ts`, and `scripts/validate-audit-report.mjs`.
 
 An **opt-in native-GPU local lane** (`npm run test:e2e:gpu`,
-`scripts/e2e-gpu-lane.mjs`, spec 44) sits beside this gate, never inside it:
-it probes the host (WSL2 Mesa d3d12 for any vendor adapter; ANGLE
-Vulkan/GL on native Linux), verifies the effective
-`UNMASKED_RENDERER_WEBGL` against a SwiftShader/llvmpipe deny-list BEFORE
-trusting a run, then injects the verified flags through the config's
-env-gated `PW_CHROMIUM_ARGS` hook (env unset ⇒ byte-identical SwiftShader
-defaults) and runs the full Chromium suite — headless by default (the d3d12
-path needs no display; headed WSLg via `--mode=headed`) and ~6× faster than
-the SwiftShader serial baseline (qualified 2026-07 on WSL2/RTX 3080, 5/5
-full-suite passes at `retries: 0`). No usable adapter ⇒ the suite still runs
-under SwiftShader with a loud software-fallback banner; `E2E_GPU_REQUIRE=1`
-hard-fails instead (hardware-evidence integrity) and
-`E2E_GPU_FORCE_FALLBACK=1` exercises the fallback deterministically. The
-lane keeps `workers: 1` — parallelizing on top of it is issue #41's
-qualification, sequenced after spec 44. Recipe and evidence: `README.md`
-("Opt-in native-GPU e2e lane") and `codev/reviews/44-add-an-opt-in-native-gpu-local.md`.
+`scripts/e2e-gpu-lane.mjs`, specs 44 + 52) sits beside this gate, never inside
+it: it probes the host **per engine** and verifies the effective
+`UNMASKED_RENDERER_WEBGL` against a software deny-list (SwiftShader, llvmpipe,
+softpipe, lavapipe, swrast, software, Microsoft Basic) BEFORE trusting a run,
+then runs the full **two-engine (Chromium + Firefox)** suite
+(`E2E_ENGINES=chromium,firefox`) in one invocation. Chromium injects verified
+ANGLE flags through the config's env-gated `PW_CHROMIUM_ARGS` hook (env unset ⇒
+byte-identical SwiftShader defaults); Firefox uses the **same** WSL2 Mesa d3d12
+env with **no ANGLE flags** and inherits it from the suite process, so it needs
+no `playwright.config.ts` change. Because Firefox privacy-sanitizes the unmasked
+renderer to `Generic Renderer`, the lane reads Firefox's raw renderer through an
+ephemeral **probe-only** `webgl.sanitize-unmasked-renderer:false` preference (the
+committed `firefox` project keeps `webgl.force-enabled:true` only); a sanitized
+string classifies as *unverifiable*, never hardware. Headless by default (the
+d3d12 path needs no display; headed WSLg via `--mode=headed`),
+`--engine=chromium|firefox|all` selects the engine set, and the two-engine
+hardware suite runs ~6× faster per test than the SwiftShader baseline (qualified
+2026-07 on WSL2/RTX 3080: 4 fully-green two-engine runs at `retries: 0`). Honest
+fallback: no usable adapter ⇒ Chromium runs under SwiftShader with a loud banner
+while Firefox is **skipped** (no portable software equivalent — never an llvmpipe
+masquerade); `E2E_GPU_REQUIRE=1` hard-fails if any requested engine is
+unverified, `E2E_GPU_FORCE_FALLBACK=1` exercises the fallback deterministically.
+CI stays `E2E_ENGINES=chromium` SwiftShader-only; the lane keeps `workers: 1`
+(parallelizing on top is issue #41's qualification, sequenced after). Recipe and
+evidence: `README.md` ("Opt-in native-GPU e2e lane") and
+`codev/reviews/44-add-an-opt-in-native-gpu-local.md` +
+`codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`.
 
 ## Dependency Classification and Lint Config
 

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -10,6 +10,13 @@ gotcha, or constraint.
   waits expensive. Pause animation first; if the initial pause requires a forced
   click, prove the control's center receives pointer events and keep later
   interactions on ordinary Playwright clicks.
+- When a browser privacy-sanitizes a capability string (e.g. Firefox sanitizes the
+  unmasked WebGL renderer to `Generic Renderer`), a known-bad deny-list is
+  insufficient — the sanitized value passes it and false-reads as good. Read the
+  raw value through the un-sanitizing path (Firefox's probe-only
+  `webgl.sanitize-unmasked-renderer:false`, confined to an ephemeral probe browser,
+  never the committed profile) and classify the sanitized string as explicitly
+  *unverifiable*, distinct from both hardware and known-software.
 - When a diagnostic command intentionally returns nonzero for findings, do not
   normalize status blindly. Preserve the original exit and validate the
   machine-readable report structure so advisory evidence remains distinct from

--- a/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
@@ -3,8 +3,9 @@
 ## Metadata
 - **Spec**: [codev/specs/52-firefox-hardware-webgl-gpu-lane.md](../specs/52-firefox-hardware-webgl-gpu-lane.md)
 - **Plan**: [codev/plans/52-firefox-hardware-webgl-gpu-lane.md](../plans/52-firefox-hardware-webgl-gpu-lane.md)
-- **Status**: draft (accumulating through the implement phases; FR8 evidence, flake
-  disposition, and lessons completed in plan phase `qualification_evidence_and_docs`)
+- **Status**: complete (all three implement phases; FR6 proof, FR8 two-engine
+  hardware evidence, flake disposition, README, and the clean-checkout gate proof
+  recorded)
 - **Follows**: [Review 44](./44-add-an-opt-in-native-gpu-local.md) (the Chromium-only lane this generalizes)
 
 ## Summary
@@ -97,26 +98,150 @@ qualification set:
   report `renderer.firefox: skipped (unverified — forced fallback, Firefox has no
   software equivalent)` + `suite: skipped (no verified engine)`, lane exit 0.
 
-## FR8 — Firefox-inclusive repeat-run stability evidence (accumulating; completed in plan phase: qualification_evidence_and_docs)
+## FR8 — Firefox-inclusive repeat-run stability evidence (plan phase: qualification_evidence_and_docs)
 
 Host: WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2), NVIDIA GeForce RTX 3080,
 Mesa d3d12 Gallium; Node 22.23.1 / npm 10.9.8; `workers: 1`, `retries: 0` (config
-local defaults, untouched); full 22-test two-engine suite unless noted.
+local defaults, untouched); full 22-test two-engine suite (11 Chromium + 11
+Firefox) unless noted. Every hardware run asserted **both** raw renderer strings,
+identical across all runs:
+- `renderer.chromium: ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)`
+- `renderer.firefox: D3D12 (NVIDIA GeForce RTX 3080)`
 
-| Run | Date | Mode | renderer.chromium / renderer.firefox | Result | Suite | Total |
+Q-1..Q-3 are **three consecutive** full two-engine hardware runs under
+`E2E_GPU_REQUIRE=1` (so an unnoticed mid-qualification fallback was impossible);
+HW-1 is the Phase 2 wiring-confirmation hardware run (same config); FB-1 is the
+forced-fallback baseline.
+
+| Run | Date | Mode | Result | Suite | Total | Lane exit |
 |---|---|---|---|---|---|---|
-| HW-1 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | `ANGLE (… D3D12 (NVIDIA GeForce RTX 3080) …)` / `D3D12 (NVIDIA GeForce RTX 3080)` | 22/22 pass | 196 s | 208 s (build 10 s) |
+| HW-1 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | 22/22 pass | 196 s | 208 s (build 10 s) | 0 |
+| Q-1 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | 22/22 pass | 196 s | 208 s (build 9 s) | 0 |
+| Q-2 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | 22/22 pass | 198 s | 210 s (build 10 s) | 0 |
+| Q-3 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | 22/22 pass | 196 s | 208 s (build 9 s) | 0 |
+| FB-1 | 2026-07-22 | software-fallback (`E2E_GPU_FORCE_FALLBACK=1`) | 11/11 pass (Chromium only; Firefox skipped) | 582 s | 591 s (build 10 s) | 0 |
 
-_FB-1 (forced-fallback baseline) and the ≥3-consecutive two-engine qualification
-set (with per-test durations and the Firefox background-drag flake disposition)
-are completed in plan phase `qualification_evidence_and_docs`._
+Per-test durations for the **Firefox** arm (the new engine) across the three
+consecutive qualification runs (all pass; seconds):
+
+| Firefox test | Q-1 | Q-2 | Q-3 |
+|---|---|---|---|
+| matrix:75 settles an initial force layout | 2.9 | 2.9 | 3.2 |
+| matrix:104 rotates automatically until paused, then resumes | 8.1 | 8.2 | 7.9 |
+| matrix:134 pointer inert until enable delay | 7.5 | 7.5 | 7.4 |
+| matrix:194 zooms out with the wheel | 9.0 | 9.1 | 9.0 |
+| **matrix:224 zooms in + background-drag rotate** (the known flake) | **13.2** | **13.3** | **13.2** |
+| matrix:269 click-to-focus + reset | 18.1 | 17.9 | 18.2 |
+| matrix:433 AxesHelper toggle | 4.8 | 4.6 | 4.7 |
+| matrix:466 canvas consistent across resize | 4.3 | 4.3 | 4.4 |
+| matrix:527 remounts fresh canvas on re-navigation | 2.9 | 2.9 | 2.9 |
+| right-click-release:174 releases fx/fy/fz | 20.7 | 20.5 | 20.6 |
+| smoke:78 renders graph + core controls | 8.9 | 8.8 | 8.6 |
+
+The Chromium arm ran 11/11 in every run with per-test durations consistent with
+Review 44's hardware tables (2–18 s per test).
+
+**Findings**: no instability — the per-test wall-clock spread across the three
+consecutive Firefox runs is ≤ 0.3 s on every test (the widest is matrix:75 at
+2.9→3.2 s); zero flakes at `retries: 0`; both engines' renderer strings asserted
+and identical every run. Including HW-1, the lane is **4-for-4 full two-engine
+hardware passes** (88/88 individual test executions). Combined two-engine
+wall-clock is ≈ 196–198 s of suite time (≈ 208–210 s incl. build), against the
+feasibility report's ~3.2 min combined figure as historical context.
+
+**Baseline comparison (contemporaneous, same host/session)**: FB-1's Chromium-only
+SwiftShader path ran **11 tests in 582 s** (≈ 53 s/test); the two-engine hardware
+lane ran **22 tests in ≈ 196 s** (≈ 9 s/test) — the hardware lane runs **twice the
+tests (both engines) in about a third of the wall-clock**, i.e. the per-test
+software→hardware speedup is ≈ 6× (consistent with Review 44's 6.1× Chromium
+figure). FB-1 also qualifies Scenario 2: loud `SOFTWARE FALLBACK` banner at start
+and before the report, `E2E_ENGINES=chromium` (Firefox excluded, never an
+llvmpipe masquerade), suite exit semantics preserved (exit 0).
+
+**FR8 verdict — branch (a) satisfied**: ≥ 3 consecutive **fully-green** two-engine
+hardware runs (Q-1..Q-3) recorded with asserted renderers, per-test results,
+wall-clocks, and `retries: 0`, plus the contemporaneous forced-fallback baseline
+(FB-1, 582 s Chromium SwiftShader). No green-except-flake exception was needed —
+the runs are fully green.
 
 ## Flaky Tests
 
-_Disposition of the known `[firefox] tests/e2e/matrix.spec.ts:224` background-drag
-synthetic-input flake is recorded in plan phase `qualification_evidence_and_docs`
-(Decision 10: fix/qualify separately or explicitly accept+document; never masked
-with retries, canonical assertion never weakened). No flake observed in HW-1._
+**`[firefox] tests/e2e/matrix.spec.ts:224` "zooms in with the wheel and rotates
+with a background drag" — disposition (Decision 10): explicitly accepted and
+documented as a pre-existing local qualification flake; NOT observed in this
+qualification set.**
+
+- **Recurrence rate in this session: 0 / 4 hardware runs** (HW-1, Q-1, Q-2, Q-3 —
+  the Firefox arm of matrix:224 passed all four, at a rock-steady 13.2–13.3 s).
+  Historically it recurred once in three full Firefox hardware runs in the
+  feasibility investigation (`firefox-native-gpu-e2e-feasibility.md`) and once in
+  PR #50's two local Firefox runs.
+- **Class**: Firefox synthetic-input-delivery nondeterminism, **not** a
+  software-WebGL timing problem — it survives on hardware (hence hardware
+  rendering did not eliminate it), and it passes when repeated alone. This is the
+  documented Firefox local-arm input-race family (issues #11/#33, and Review 44's
+  Flaky Tests note for the same test).
+- **Disposition**: accepted + documented (Decision 10 permits fix/qualify
+  separately **or** explicit accept+document). A code fix to the canonical
+  `tests/e2e/matrix.spec.ts` is **out of scope** here (spec Decision 10 makes it
+  optional; the spec forbids weakening the canonical assertion as part of this
+  lane work). It is **not masked**: the lane runs `retries: 0`, the canonical
+  assertion (camera azimuth delta > 1) is unchanged, and no test is skipped. If it
+  recurs on future local qualification runs, file a dedicated issue in the #33
+  family rather than retuning inside unrelated work.
+
+The FR8 two-branch merge gate is satisfied by branch (a) (fully green); this
+disposition documents the known flake for completeness and future triage, not
+because it blocked the gate.
+
+## Spec compliance (acceptance criteria)
+
+- **FR1–FR5, FR10** — `npm run test:e2e:gpu` verifies hardware renderers
+  independently for Chromium and Firefox, then runs one combined
+  `E2E_ENGINES=chromium,firefox` 22-test suite; engine-aware per-engine report
+  (Scenario 1). ✓ (HW-1, Q-1..Q-3)
+- **FR3** — Firefox raw renderer read through the probe-only sanitize pref; the
+  sanitized `Generic Renderer` is `unverifiable`, never hardware; deny-list rejects
+  swiftshader/llvmpipe/softpipe/lavapipe/swrast/software/microsoft-basic. ✓
+- **FR4 / Decisions 5–6** — non-strict, not-both-verify ⇒ Chromium SwiftShader +
+  Firefox skipped (Scenario 2); `E2E_GPU_REQUIRE=1` ⇒ abort before build/suite if
+  either engine unverified (Scenario 3); `--engine=firefox` non-strict/no-hardware
+  ⇒ empty-set skip, exit 0 (Scenario 7). ✓
+- **FR6 / Scenario 4** — canonical gate untouched (config byte-identical; no
+  validation.yml/package.json/lockfile delta; both projects load by default). ✓
+- **FR7** — `--engine=chromium|firefox|all` (default all); unknown ⇒ usage error
+  (exit 2). ✓
+- **FR8 / Scenario 5** — ≥3 consecutive fully-green two-engine hardware runs +
+  forced-fallback baseline recorded; flake dispositioned (Decision 10). ✓
+- **FR9 / Scenario 6** — README "Opt-in native-GPU e2e lane" section updated in
+  place (two-engine command, Firefox recipe + sanitize-pref rationale, per-engine
+  report, `--engine` selector, honest fallback, known flake). ✓
+- **Reproducibility** — no dependency/lockfile/toolchain movement; unit tests
+  GPU-free/browser-free/lane-env-free. ✓
+
+## Lessons Learned
+
+- **The four-verdict classifier is the crux of honest Firefox verification.**
+  Firefox's sanitized `Generic Renderer` matches no software marker, so a
+  three-way (`none`/`software`/`hardware`) classifier would have *false-passed* it
+  as hardware. The explicit `unverifiable` verdict tied to the probe-only pref is
+  what makes an honest verdict possible — and the load-bearing contrast (pref off
+  ⇒ `Generic Renderer`, pref on ⇒ `D3D12 (…)`) proves the pref is doing real work,
+  not cargo-culted.
+- **Engine dimension as data paid off.** Keeping Chromium's `CANDIDATES` matrix and
+  adding one `FIREFOX_PROBE_RECIPE` with per-engine launcher dispatch (Firefox gets
+  `firefoxUserPrefs`, Chromium gets `args`) kept the diff a superset of #44 with no
+  scattered `if (engine === "firefox")` branches, and let `partitionCandidates` /
+  the watchdog/reap machinery be reused verbatim.
+- **A run-level field beats an engine-specific one for cross-engine decisions.** The
+  iteration-1 Codex catch — `headed` derived from a Chromium-only field silently
+  ran a Firefox-only `--mode=headed` suite headless — is the general lesson: when a
+  decision spans the engine set, carry it at the run level (`plan.effectiveMode` +
+  `isHeadedRun`), not on one engine's slice.
+- **Firefox hardware did not fix the synthetic-input flake, and that's fine.** The
+  background-drag flake is input-delivery nondeterminism, not a rendering-speed
+  problem; the honest move was to qualify it (0/4 here) and document it, not to
+  paper over it with retries.
 
 ## Consultation Feedback
 
@@ -127,6 +252,38 @@ with retries, canonical assertion never weakened). No flake observed in HW-1._
   Mesa hint), the engine-as-data model, probe isolation (the sanitize pref never
   in the committed config), and correct phase scoping (no Phase 2/3 work pulled
   forward).
+- **Plan phase `two_engine_suite_and_inertness`**: iteration 1 — Gemini APPROVE,
+  Claude APPROVE, Codex REQUEST_CHANGES (the Firefox-only headed suite-dispatch
+  bug above). Fixed with a run-level `plan.effectiveMode` + exported
+  `isHeadedRun(plan)` and a dedicated Firefox-only-headed test. Iteration 2 —
+  unanimous APPROVE, KEY_ISSUES: None.
+
+## Canonical gate proof on a clean checkout
+
+The worktree's `npm run lint` is polluted by an untracked builder-harness file
+(`.claude/hooks/worktree-write-guard.cjs` — 21 errors, absent from clean
+checkouts), so per the hot lesson the full `npm run validate` gate is proven on a
+detached clean worktree (`git worktree add --detach <dir> HEAD` at commit
+`54d836d` + real `npm ci`, npm 10.9.8 / Node 22.23.1). The clean worktree contains
+**no** `.claude/hooks/` (confirmed), so the lint pollution is gone.
+
+- **Run 1**: `npm ci` exit 0; **lint ✓, typecheck ✓, build ✓**; local `test:smoke`
+  runs BOTH engines in **software** (Chromium SwiftShader + Firefox llvmpipe — no
+  GPU env in `validate`) → e2e **21/22**, the single failure being
+  `[firefox] tests/e2e/matrix.spec.ts:224` (the known background-drag flake, here
+  under software llvmpipe where the input-race is most likely). `VALIDATE EXIT: 1`.
+- **Run 2** (same clean worktree, no changes): **lint ✓, typecheck ✓, build ✓,
+  e2e 22/22** (both engines green; `[firefox] tests/e2e/matrix.spec.ts:224` passed
+  at 12.9 s). `VALIDATE EXIT: 0`. The flake is intermittent — it passes on re-run,
+  exactly as Review 44 recorded for the same test on its clean-checkout Run 2.
+
+The lint-pollution proof (the reason this clean-checkout run exists) is
+**satisfied by Run 1**: lint is clean (0 errors) once the untracked harness file
+is absent, and typecheck/build pass. The lone e2e failure is the pre-existing,
+documented Firefox software-input flake (see Flaky Tests) — **not** introduced by
+this branch, which contains zero `tests/e2e/**`, `app/**`, or
+`playwright.config.ts` changes (`git diff main..HEAD -- tests/e2e app
+playwright.config.ts` is empty) and never invokes the lane script from `validate`.
 
 ## Follow-up Items
 

--- a/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
@@ -1,0 +1,142 @@
+# Review 52: Add Firefox Hardware WebGL to the Native-GPU Local E2E Lane
+
+## Metadata
+- **Spec**: [codev/specs/52-firefox-hardware-webgl-gpu-lane.md](../specs/52-firefox-hardware-webgl-gpu-lane.md)
+- **Plan**: [codev/plans/52-firefox-hardware-webgl-gpu-lane.md](../plans/52-firefox-hardware-webgl-gpu-lane.md)
+- **Status**: draft (accumulating through the implement phases; FR8 evidence, flake
+  disposition, and lessons completed in plan phase `qualification_evidence_and_docs`)
+- **Follows**: [Review 44](./44-add-an-opt-in-native-gpu-local.md) (the Chromium-only lane this generalizes)
+
+## Summary
+
+Generalizes the opt-in native-GPU local e2e lane (`npm run test:e2e:gpu`,
+`scripts/e2e-gpu-lane.mjs`) from Chromium-only to a two-engine Chromium+Firefox
+lane. The engine dimension is expressed as **data** (the Chromium `CANDIDATES`
+matrix + a single `FIREFOX_PROBE_RECIPE`) with per-engine launcher dispatch, not
+scattered `if (engine === "firefox")` branches. The lane probes and independently
+verifies a hardware renderer for each requested engine, then runs one combined
+`E2E_ENGINES=chromium,firefox` Playwright suite (one build, one invocation,
+`workers: 1`, `retries: 0`) and ends with a per-engine machine-greppable report.
+
+The one genuinely new element is **Firefox renderer verification**: Firefox
+privacy-sanitizes the unmasked renderer to `Generic Renderer`, so the raw
+renderer is read through an ephemeral, probe-only preference
+(`webgl.sanitize-unmasked-renderer: false`) that never touches the
+application-suite Firefox profile. A sanitized string is classified
+`unverifiable` (never hardware).
+
+The lane is additional tooling, **never** the green gate: `npm run validate`,
+`.github/workflows/validation.yml`, `test:smoke`, Playwright browser defaults,
+`workers`, `retries`, and every committed test's timing/assertions are unchanged.
+CI stays `E2E_ENGINES=chromium` SwiftShader-only.
+
+## Firefox renderer sanitization — the load-bearing contrast
+
+Collected 2026-07-21 on the qualification host (WSL2, NVIDIA GeForce RTX 3080,
+Mesa d3d12). Same Firefox binary, same Mesa env, prefs the only difference:
+
+| Firefox probe prefs | Raw `UNMASKED_RENDERER_WEBGL` | classifyRenderer |
+|---|---|---|
+| `webgl.force-enabled: true` only (sanitize left at Firefox default) | `Generic Renderer` | `unverifiable` |
+| `+ webgl.sanitize-unmasked-renderer: false` (probe recipe) | `D3D12 (NVIDIA GeForce RTX 3080)` | `hardware` |
+
+This is exactly why Chromium's deny-list alone is too weak for Firefox:
+`Generic Renderer` matches no software marker, so without the explicit
+`unverifiable` verdict it would **false-pass as hardware**. The probe-only pref
+is what makes an honest Firefox hardware verdict possible.
+
+## FR6 — Canonical gate provably untouched (plan phase: two_engine_suite_and_inertness)
+
+Collected 2026-07-21 against `main`:
+
+1. `git diff main -- playwright.config.ts` — **empty** (byte-identical to `main`;
+   the Firefox arm needs no new config hook — Decision 9). The `firefox` project's
+   committed prefs remain `webgl.force-enabled: true` only; the probe-only
+   sanitize pref lives solely in the wrapper's `FIREFOX_PROBE_RECIPE`.
+2. `.github/workflows/validation.yml`, `package.json`, `package-lock.json`,
+   `.nvmrc` — absent from `git diff main --stat` entirely. No dependency,
+   lockfile, or `validate`/`test:smoke`/`test:e2e:gpu` script delta. The only
+   code files changed are `scripts/e2e-gpu-lane.mjs` and `tests/gpu-lane.test.mjs`.
+3. Config-load with all lane env unset (`E2E_ENGINES`, `PW_CHROMIUM_ARGS`,
+   `E2E_GPU_*` unset), via `npx playwright test --list`:
+   - Projects resolved: `[chromium]` and `[firefox]` (both present).
+   - 22 tests listed (11 per engine) — the default two-engine matrix is intact.
+   - Because `playwright.config.ts` is byte-identical to `main` (item 1), every
+     other default-behavior assertion (chromium SwiftShader args,
+     `workers: 1`, `retries: 0` non-CI, timeout, reporter, webServer) holds by
+     construction — there is no changed line to perturb them.
+4. PR CI green under `E2E_ENGINES=chromium` SwiftShader — pending, recorded at the
+   Review phase.
+
+## Phase 2 verification — two-engine suite wiring, honest fallback, empty-set skip
+
+Behavioral confirmation on the qualification host (2026-07-21), before the FR8
+qualification set:
+
+- **Two-engine hardware run** (`E2E_GPU_REQUIRE=1 npm run test:e2e:gpu`): both
+  engines verified (`renderer.chromium: ANGLE (Microsoft Corporation, D3D12
+  (NVIDIA GeForce RTX 3080), OpenGL 4.6)`, `renderer.firefox: D3D12 (NVIDIA
+  GeForce RTX 3080)`); full 22-test suite in one Playwright invocation;
+  `mode: hardware`, `suite: pass`, `wall-clock: 208s (build 10s, suite 196s)`,
+  lane exit 0. (Recorded as HW-1 in the FR8 table below.)
+- **Forced fallback** (`E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu`): loud
+  SOFTWARE-FALLBACK banner at start and before the report; report shows
+  `mode: software-fallback`, `renderer.chromium: (software-fallback —
+  SwiftShader)`, `renderer.firefox: skipped (unverified — forced fallback,
+  Firefox has no software equivalent)`. The suite ran `[chromium]` tests only
+  (`E2E_ENGINES=chromium`; Firefox excluded, never an llvmpipe masquerade) —
+  confirmed via the per-test `[chromium]` lines. A completed forced-fallback run
+  is recorded as FB-1 below.
+- **REQUIRE abort** (`E2E_GPU_REQUIRE=1`, a requested engine forced to miss via
+  `--engine=chromium --candidate=native-linux-angle-gl`, skipped on WSL2): the
+  lane logged `not every requested engine verified hardware (unverified:
+  chromium); exiting non-zero before build/suite`, lane exit 1, no build/suite —
+  Decision 5.
+- **Empty-set skip / Scenario 7** (`E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu
+  -- --engine=firefox`): no Playwright invoked (no empty `E2E_ENGINES` crash),
+  report `renderer.firefox: skipped (unverified — forced fallback, Firefox has no
+  software equivalent)` + `suite: skipped (no verified engine)`, lane exit 0.
+
+## FR8 — Firefox-inclusive repeat-run stability evidence (accumulating; completed in plan phase: qualification_evidence_and_docs)
+
+Host: WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2), NVIDIA GeForce RTX 3080,
+Mesa d3d12 Gallium; Node 22.23.1 / npm 10.9.8; `workers: 1`, `retries: 0` (config
+local defaults, untouched); full 22-test two-engine suite unless noted.
+
+| Run | Date | Mode | renderer.chromium / renderer.firefox | Result | Suite | Total |
+|---|---|---|---|---|---|---|
+| HW-1 | 2026-07-21 | hardware (`E2E_GPU_REQUIRE=1`) | `ANGLE (… D3D12 (NVIDIA GeForce RTX 3080) …)` / `D3D12 (NVIDIA GeForce RTX 3080)` | 22/22 pass | 196 s | 208 s (build 10 s) |
+
+_FB-1 (forced-fallback baseline) and the ≥3-consecutive two-engine qualification
+set (with per-test durations and the Firefox background-drag flake disposition)
+are completed in plan phase `qualification_evidence_and_docs`._
+
+## Flaky Tests
+
+_Disposition of the known `[firefox] tests/e2e/matrix.spec.ts:224` background-drag
+synthetic-input flake is recorded in plan phase `qualification_evidence_and_docs`
+(Decision 10: fix/qualify separately or explicitly accept+document; never masked
+with retries, canonical assertion never weakened). No flake observed in HW-1._
+
+## Consultation Feedback
+
+- **Plan phase `engine_aware_core`** (impl consult, iteration 1): Gemini APPROVE,
+  Codex APPROVE, Claude APPROVE — unanimous, KEY_ISSUES: None. Reviewers confirmed
+  the four-verdict `classifyRenderer`, the expanded deny-list, the `unverifiable`
+  safety catch, the FR11 sanitized-renderer diagnostic (probe-pref hint, not the
+  Mesa hint), the engine-as-data model, probe isolation (the sanitize pref never
+  in the committed config), and correct phase scoping (no Phase 2/3 work pulled
+  forward).
+
+## Follow-up Items
+
+- **#41 (local e2e parallelization)**: may consume this two-engine lane and its
+  FR8 evidence to qualify `workers > 1`; out of scope here (`workers: 1`
+  everywhere).
+- Recipe drift watch: the evidence is dated 2026-07 (Mesa d3d12, NVIDIA RTX 3080,
+  WSL2); the recipe is documented as evidence-dated, not guaranteed across
+  host/driver changes.
+
+_This review is completed in plan phase `qualification_evidence_and_docs` (FR8
+qualification set, flake disposition, lessons learned, and the clean-checkout
+`npm run validate` proof)._

--- a/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
@@ -284,6 +284,18 @@ Routed to the **cold** `codev/resources/lessons-learned.md` under the existing
   bug above). Fixed with a run-level `plan.effectiveMode` + exported
   `isHeadedRun(plan)` and a dedicated Firefox-only-headed test. Iteration 2 —
   unanimous APPROVE, KEY_ISSUES: None.
+- **Review phase (PR consult)**: iteration 1 — Gemini APPROVE, Claude APPROVE,
+  Codex REQUEST_CHANGES. Codex caught a per-engine reporting-honesty bug: when
+  Chromium fails verification but **Firefox verifies hardware**, the non-strict
+  fallback reported `renderer.firefox: skipped (unverified — unverified)` — Firefox
+  was verified, so labeling it "unverified" is wrong. Fixed with a distinct
+  `not-run` verdict state (`renderer.firefox: not run (Chromium unverified — a
+  two-engine hardware run needs both engines…)`), with a unit test; all other skip
+  outputs (genuinely-unverified, forced-fallback) are unchanged. Also: plan Status
+  `draft → completed`. Codex's third point (`tests/audit-report.test.mjs` failing)
+  is a Codex-sandbox environment artifact — that test shells out to `npm audit`
+  (with a `registry unavailable` case), is untouched by this branch, and passes
+  95/95 on the qualification host and on porch's own `tests` gate.
 
 ## Canonical gate proof on a clean checkout
 

--- a/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
@@ -243,6 +243,33 @@ because it blocked the gate.
   problem; the honest move was to qualify it (0/4 here) and document it, not to
   paper over it with retries.
 
+## Architecture Updates
+
+Routed to the **cold** `codev/resources/arch.md` (reference detail; the hot
+`arch-critical.md` cap and map are untouched — the "`npm run validate` is the
+green gate" invariant already governs this lane, and no new top-level arch.md
+section was added):
+
+- The **Validation Baseline** native-GPU-lane paragraph (added by spec 44) was
+  updated **in place** to the two-engine reality: per-engine probe + the expanded
+  software deny-list, `E2E_ENGINES=chromium,firefox` in one invocation, Firefox's
+  Mesa-env inheritance with no `playwright.config.ts` hook, the probe-only
+  `webgl.sanitize-unmasked-renderer:false` read + the `unverifiable` verdict, the
+  `--engine=chromium|firefox|all` selector, the honest Firefox-skip fallback,
+  CI-stays-Chromium, and a pointer to this review.
+
+## Lessons Learned Updates
+
+Routed to the **cold** `codev/resources/lessons-learned.md` under the existing
+**Validation Evidence** section (no new top-level section, so the hot
+`lessons-critical.md` map stays accurate; hot tier untouched):
+
+- A privacy-sanitized capability string defeats a known-bad deny-list (it passes
+  and false-reads as good) — read the raw value through the un-sanitizing path (a
+  probe-only preference confined to the ephemeral probe browser) and classify the
+  sanitized string as explicitly *unverifiable*, distinct from hardware and
+  known-software.
+
 ## Consultation Feedback
 
 - **Plan phase `engine_aware_core`** (impl consult, iteration 1): Gemini APPROVE,

--- a/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/reviews/52-firefox-hardware-webgl-gpu-lane.md
@@ -296,6 +296,14 @@ Routed to the **cold** `codev/resources/lessons-learned.md` under the existing
   is a Codex-sandbox environment artifact — that test shells out to `npm audit`
   (with a `registry unavailable` case), is untouched by this branch, and passes
   95/95 on the qualification host and on porch's own `tests` gate.
+- **Architect integration review (PR #53)**: one blocking item — `runProbeOnly()`
+  returned non-zero on a `E2E_GPU_REQUIRE=1` abort **without** printing the report,
+  violating the "probe-only always reports" contract (the probe already did its
+  work; the report is the deliverable, most useful when an engine failed). Fixed
+  by extracting a pure `probeOnlyOutcome(...)` that always emits the per-engine
+  report (`mode: abort`) before the non-zero exit, unit-tested. Minor: `--candidate`
+  / `--channel` (Chromium-only) are now rejected with `--engine=firefox` instead of
+  being silently ignored.
 
 ## Canonical gate proof on a clean checkout
 

--- a/codev/specs/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/specs/52-firefox-hardware-webgl-gpu-lane.md
@@ -325,6 +325,28 @@ sanitization preference being applied — a probe that reports the sanitized
   `--engine=firefox` applies the same honesty rules: verify or (strict) fail;
   non-strict with no hardware reports Firefox unverified/skipped rather than
   presenting llvmpipe as a qualified fallback.
+- **Single-engine `--engine=firefox`, non-strict, Firefox fails verification
+  (explicit empty-engine-set rule).** Firefox is skipped (Decision 6, no software
+  masquerade) and — because Chromium was not requested — the resolved suite engine
+  set is **empty**. The lane MUST NOT invoke Playwright with an empty
+  `E2E_ENGINES` value: `playwright.config.ts` throws on an engine list that matches
+  no known engine (the "matched no known engines" guard), so an empty set would
+  crash the suite rather than run nothing. Instead the lane **skips the build and
+  suite entirely**, emits the engine-aware report with
+  `renderer.firefox: skipped (unverified — <reason>)` and
+  `suite: skipped (no verified engine)`, and exits **0** — consistent with the
+  #44 lane's "hardware absence is never a hard failure by default." An operator who
+  needs this to fail uses `E2E_GPU_REQUIRE=1` (next bullet).
+- **`E2E_GPU_REQUIRE=1 --engine=firefox` with no hardware** ⇒ exit non-zero
+  **before** build/suite (Decision 5), same as any strict unverified engine.
+- **`E2E_GPU_FORCE_FALLBACK=1 --engine=firefox` (vacuous combination).**
+  Force-fallback means "skip probing and take the software path"; Firefox has no
+  software path (Decision 6). This is treated as the same non-strict no-op as the
+  empty-engine-set rule above: **Firefox skipped, no build/suite, report
+  `renderer.firefox: skipped (unverified — forced fallback, Firefox has no software
+  equivalent)`, exit 0.** It is deliberately **not** a `LaneUsageError` (unlike
+  `E2E_GPU_FORCE_FALLBACK=1 E2E_GPU_REQUIRE=1`, which stays a usage error): a
+  benign env+flag combination should degrade to an honest skip, not a hard failure.
 Lane-internal errors unrelated to hardware absence (build failure, malformed
 invocation, contradictory controls) remain hard failures in every mode.
 
@@ -364,18 +386,39 @@ Before the two-engine lane is documented as trusted: **at least three consecutiv
 full two-engine hardware runs** (both engines' raw renderer strings asserted) with
 `retries: 0`, each run's per-test pass/fail, wall-clock, and the combined
 two-engine wall-clock recorded in the review artifacts, alongside a contemporaneous
-baseline for comparison. If the Firefox synthetic-input flake recurs, it is
-recorded as a lane finding and handled per Decision 10 (fixed/qualified separately
-or explicitly accepted+documented — never masked). The forced-fallback path is
+baseline for comparison.
+
+**Merge/qualification gate (explicit).** The stability evidence satisfies the gate
+when **either**:
+- (a) **≥3 consecutive fully-green** two-engine hardware runs are recorded (no test
+  fails, `retries: 0`), **or**
+- (b) the runs are green **except** for the single known Firefox background-drag
+  synthetic-input flake (`tests/e2e/matrix.spec.ts:224`), and that flake is
+  dispositioned per Decision 10 — **either** fixed and requalified, **or** explicitly
+  accepted and documented as a local qualification flake (with its recurrence rate
+  from these runs recorded). Under (b) the flake is **never** masked with retries and
+  the canonical assertion is **never** weakened.
+
+Any failure **other** than that one known, documented flake blocks the gate: it must
+be root-caused (and either fixed or, if a genuinely new flake, itself explicitly
+qualified) before the lane is documented as trusted — a green-except-known-flake
+record is acceptable, an unexplained failure is not. The forced-fallback path is
 qualified by at least one `E2E_GPU_FORCE_FALLBACK=1` run showing Chromium
 SwiftShader + Firefox-skipped. Hardware qualification runs use `E2E_GPU_REQUIRE=1`
 so an unnoticed mid-qualification fallback cannot contaminate the evidence.
 
 ### FR9 — Documentation
 
-The lane's documentation (README and/or the codev resource that #44 established;
-discoverable from README) is updated to cover: the two-engine command and what it
-does; the Firefox probe recipe (Mesa env + probe-only prefs) and the
+The concrete documentation target is **`README.md`'s existing "Opt-in native-GPU
+e2e lane" section** (the doc surface #44 established, currently around README
+lines 138–232), updated **in place** to the two-engine reality — including its
+`=== E2E GPU LANE REPORT ===` example block (the per-engine `renderer.chromium` /
+`renderer.firefox` keys of FR10) and its "Env controls and flags" table (the new
+`--engine=chromium|firefox|all` selector of FR7). The contemporaneous run evidence
+(FR8) lives in this feature's review, `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`,
+which the README section links the way it currently links #44's review. No new
+top-level doc file is created. The updated section covers: the two-engine command
+and what it does; the Firefox probe recipe (Mesa env + probe-only prefs) and the
 `webgl.sanitize-unmasked-renderer` rationale (why Chromium's deny-list alone is
 too weak for Firefox); how to read the engine-aware report; the honest-fallback
 semantics (Firefox skipped, never a software masquerade); the known Firefox
@@ -492,6 +535,15 @@ understand the Firefox probe recipe and sanitization-pref rationale, run it, and
 correctly interpret a two-engine hardware vs. Chromium-fallback+Firefox-skipped
 report.
 
+### Scenario 7 — Single-engine Firefox, non-strict, no hardware (empty engine set)
+`npm run test:e2e:gpu -- --engine=firefox` (or with `E2E_GPU_FORCE_FALLBACK=1`) on a
+host where Firefox does not verify hardware: the resolved suite engine set is empty,
+so the lane **does not** invoke Playwright (no `E2E_ENGINES=""` crash), skips
+build/suite, prints `renderer.firefox: skipped (unverified — <reason>)` and
+`suite: skipped (no verified engine)`, and exits 0. The same invocation with
+`E2E_GPU_REQUIRE=1` instead exits non-zero before build/suite with the per-engine
+diagnostic.
+
 ## Known Stability Caveat
 
 Hardware rendering did **not** eliminate Firefox's existing synthetic
@@ -523,6 +575,40 @@ used to weaken the canonical assertion.
 - **Sequencing**: #41 (parallelization) may consume this two-engine lane's
   qualification; this spec should land (or record two-engine hardware evidence)
   first.
+
+## Consultation Log
+
+### Specify — iteration 1 (Gemini, Codex, Claude)
+
+Verdicts: **Gemini APPROVE** (HIGH), **Claude APPROVE** (HIGH), **Codex
+REQUEST_CHANGES** (HIGH). All three independently verified the spec's codebase
+claims (Chromium-only lane structure, current `SOFTWARE_RENDERER_MARKERS`,
+hardcoded `engine: chromium` report, `E2E_ENGINES` handling, feasibility-report
+figures) and found them accurate; the approach was judged fully feasible with no
+architecture or Baked-Decision changes needed. All feedback was clarification of
+under-specified edge behavior. Changes made:
+
+1. **Single-engine `--engine=firefox` non-strict fallback outcome** (raised by all
+   three; Gemini supplied the concrete failure mode). Firefox-only + non-strict +
+   failed verification yields an **empty** suite engine set, and an empty
+   `E2E_ENGINES` throws in `playwright.config.ts`. FR4 now states explicitly: the
+   lane does not invoke Playwright with an empty engine set, skips build/suite,
+   reports Firefox skipped + `suite: skipped (no verified engine)`, and exits 0
+   (non-strict never hard-fails on hardware absence); `E2E_GPU_REQUIRE=1` makes it
+   exit non-zero before build/suite. Added **Scenario 7** to make it testable.
+2. **Vacuous `E2E_GPU_FORCE_FALLBACK=1 --engine=firefox`** (Claude). FR4 now
+   specifies it as the same honest no-op skip (exit 0), deliberately **not** a
+   `LaneUsageError`, distinguishing it from the genuinely contradictory
+   `FORCE_FALLBACK=1 + REQUIRE=1` usage error.
+3. **FR8 merge-gate ambiguity on a recurring known flake** (Codex). FR8 now gives an
+   explicit two-branch gate: (a) ≥3 consecutive fully-green two-engine hardware
+   runs, **or** (b) green-except-the-known-documented Firefox background-drag flake
+   dispositioned per Decision 10 (never masked). Any failure beyond that one known
+   flake blocks the gate.
+4. **FR9 vague doc target** (Codex). FR9 now names the concrete target:
+   `README.md`'s existing "Opt-in native-GPU e2e lane" section, updated in place
+   (report block + env/flags table), with run evidence in
+   `codev/reviews/52-…`. No new top-level doc file.
 
 ## References
 

--- a/codev/specs/52-firefox-hardware-webgl-gpu-lane.md
+++ b/codev/specs/52-firefox-hardware-webgl-gpu-lane.md
@@ -1,0 +1,540 @@
+# Specification 52: Add Firefox Hardware WebGL to the Native-GPU Local E2E Lane
+
+## Summary
+
+Generalize the opt-in native-GPU local e2e lane (`npm run test:e2e:gpu`,
+`scripts/e2e-gpu-lane.mjs`, delivered by spec #44 / PR #50) from **Chromium-only**
+to a **two-engine Chromium + Firefox** lane, so that on a verified WSL2 host the
+full Playwright suite runs under **genuine hardware-accelerated WebGL for both
+engines the project ships**. The lane remains **additional tooling, never the
+green gate**: `npm run validate`, `.github/workflows/validation.yml`,
+`test:smoke`, Playwright browser defaults, `workers: 1`, `retries`, and every
+committed test's timing/assertions stay **byte-for-byte / behavior-identical** to
+today (arch-critical: Validation Baseline).
+
+Spec #44 shipped the lane Chromium-only by explicit decision (spec #44
+Decision 5: "The proven configurations are Chromium+ANGLE. Firefox hardware GL is
+out of scope"), **not** because of a Firefox or Playwright limitation. The
+feasibility investigation `firefox-native-gpu-e2e-feasibility.md` (2026-07-21)
+then qualified Firefox hardware WebGL end-to-end on the same WSL2 / RTX 3080 host
+and returned a **go** verdict. The capabilities needed already exist in the repo:
+
+- `playwright.config.ts` already defines a `firefox` project and already selects
+  engines via `E2E_ENGINES` (e.g. `E2E_ENGINES=chromium,firefox`).
+- The Mesa D3D12 environment the Chromium lane injects
+  (`GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`) is inherited by
+  Firefox launched from the same suite process.
+- Playwright's `firefox.launch()` supports per-launch `env` and
+  `firefoxUserPrefs`, which is all the Firefox probe needs.
+- A combined Chromium+Firefox hardware run passed all 22 tests in ~3.2 minutes on
+  the qualification host.
+
+The single genuinely new technical element is **Firefox renderer verification**:
+Firefox privacy-sanitizes the unmasked renderer string to `Generic Renderer` /
+`Microsoft Corporation`, so the raw renderer must be read through an **ephemeral,
+probe-only** Firefox preference (`webgl.sanitize-unmasked-renderer: false`) that
+is never applied to the application suite profile.
+
+### Why this is worth building
+
+1. **Both shipped engines get hardware-fidelity local evidence**, not just
+   Chromium — Firefox is a first-class project in the suite today.
+2. **Faster local Firefox iteration** — frames stop being CPU-bound llvmpipe
+   software rasterization.
+3. **Completes the #44 lane's original intent** at essentially zero marginal
+   dependency cost — Playwright already bundles Firefox.
+
+## Problem Analysis
+
+### Current state
+
+- `scripts/e2e-gpu-lane.mjs` is structurally Chromium-only:
+  - `CANDIDATES` carry Chromium launch **flags** (ANGLE args) and the recipe
+    env; `probeRenderer` launches **`chromium`** from `@playwright/test` and
+    reads `UNMASKED_RENDERER_WEBGL`.
+  - `suiteEnvFor()` hardcodes `E2E_ENGINES = "chromium"` and injects
+    `PW_CHROMIUM_ARGS`.
+  - `formatReport()` hardcodes `engine: chromium` and a single `renderer:` line.
+  - `parseArgs()` exposes `--probe-only`, `--mode`, `--candidate`, `--channel`
+    but no engine selector.
+  - The software deny-list `SOFTWARE_RENDERER_MARKERS` is
+    `["swiftshader", "llvmpipe", "software", "microsoft basic"]`.
+- `playwright.config.ts` already exposes both `chromium` and `firefox` projects
+  and already honors `E2E_ENGINES`. The `firefox` project sets only
+  `firefoxUserPrefs: { "webgl.force-enabled": true }` (so a GPU-less CI runner
+  gets software WebGL instead of a context-creation failure). CI runs
+  `E2E_ENGINES=chromium` (Firefox has no SwiftShader equivalent and cannot create
+  a WebGL context on GitHub runners); the Firefox arm is a **local** qualification
+  gate, never a CI gate.
+- Firefox hardware WebGL on this WSL2 host is proven only as the feasibility
+  report's evidence; there is no command or code path that runs it.
+
+### Desired state
+
+- `npm run test:e2e:gpu` on a verified WSL2 host probes **and independently
+  verifies** hardware renderers for **both** Chromium and Firefox, then runs the
+  **full two-engine** Playwright suite (`E2E_ENGINES=chromium,firefox`, all specs,
+  `workers: 1`, no test dropped, no committed wait trimmed) once, under one build.
+- Firefox's **raw** renderer is read through a probe-only sanitization preference
+  and asserted against an expanded software deny-list; a Firefox probe that
+  returns software (llvmpipe/…) is a failed verification, never silently trusted.
+- The final report is **engine-aware**: it records mode plus a per-engine
+  renderer verdict (e.g. `renderer.chromium`, `renderer.firefox`).
+- Exhaustion / partial-verification behavior is **honest**: Firefox has no
+  portable bundled software-WebGL equivalent, so an unverified Firefox llvmpipe
+  run is **never** presented as equivalent to Chromium's qualified SwiftShader
+  fallback.
+- The canonical gate is provably untouched; CI stays Chromium-SwiftShader only.
+
+### Stakeholders
+
+- **Primary**: developer(s) running local two-engine e2e iteration on WSL2.
+- **Secondary**: #41 (local parallelization — now has a two-engine hardware lane
+  to qualify against); flake triage for the Firefox synthetic-input class.
+- **Technical**: builder implementing this spec; CI is a stakeholder only in that
+  it must be provably unaffected.
+
+## Confirmed Decisions
+
+1. **Additive generalization, never the gate.** The two-engine lane extends the
+   #44 wrapper. `npm run validate`, `.github/workflows/validation.yml`,
+   `test:smoke`, Playwright browser defaults, `workers: 1`, and `retries` are
+   byte-for-byte / behavior-identical to today. The lane is not wired into
+   `validate`, `test:smoke`, or CI. CI stays `E2E_ENGINES=chromium`.
+2. **Chromium behavior is preserved.** The existing Chromium probe flags, Mesa
+   env, `PW_CHROMIUM_ARGS` injection, SwiftShader fallback, report semantics for
+   Chromium, and a single-engine Chromium path all keep working. This is a
+   superset change, not a Chromium rewrite. Existing `tests/gpu-lane.test.mjs`
+   behavior for Chromium is preserved or consciously migrated (documented).
+3. **Firefox probe recipe.** For the selected host recipe, Firefox is probed with
+   the **same Mesa environment** as Chromium (`GALLIUM_DRIVER=d3d12`,
+   `LD_LIBRARY_PATH=/usr/lib/wsl/lib`), **no Chromium ANGLE flags**, and
+   probe-only preferences:
+   ```js
+   firefoxUserPrefs: {
+       "webgl.force-enabled": true,
+       "webgl.sanitize-unmasked-renderer": false,
+   }
+   ```
+   `webgl.sanitize-unmasked-renderer: false` is applied **only** to the ephemeral
+   renderer-probe browser. It changes renderer-string *disclosure*, not renderer
+   *selection*; the application suite retains its normal Firefox profile/prefs.
+4. **Verify every requested engine before trusting hardware mode.** For the
+   default (`all`) two-engine lane, a host recipe is fully verified only after
+   **both** Chromium and Firefox return hardware renderer verdicts (each raw
+   string logged verbatim and passing the deny-list). Only then does the combined
+   hardware suite run.
+5. **Strict mode fails if either engine is unverified.** Under
+   `E2E_GPU_REQUIRE=1`, failure to verify **either** requested engine exits
+   non-zero (with the per-engine/per-candidate log) **before** the build or suite
+   starts. This preserves hardware-evidence integrity for qualification runs.
+6. **Honest fallback semantics (no Firefox software masquerade).** Firefox has no
+   portable bundled SwiftShader equivalent. In the default (non-strict) lane, when
+   the two-engine hardware verification cannot be satisfied:
+   - preserve PR #50's deterministic **Chromium SwiftShader** fallback;
+   - **skip Firefox** and report, loudly and in the final report, *why* it was
+     skipped/unverified;
+   - never label an unverified Firefox llvmpipe run as equivalent to Chromium's
+     qualified SwiftShader fallback;
+   - under `E2E_GPU_REQUIRE=1`, fail instead of falling back (Decision 5).
+   A portable Firefox software lane would need separate dependencies and
+   qualification and is **out of scope**.
+7. **Expanded, fail-closed software deny-list.** The renderer deny-list rejects at
+   least: SwiftShader, llvmpipe, softpipe, lavapipe, swrast, generic
+   "software" rasterizers, and Microsoft Basic Render Driver. It applies to both
+   engines' raw renderer strings. The Chromium deny-list must not become weaker.
+8. **Engine selector control.** An optional `--engine=chromium|firefox|all`
+   (working name; final name is a plan decision) selects the probe/suite engine
+   set. `all` is the default and means the two-engine behavior. Single-engine
+   values preserve targeted diagnostics and obey the same honesty rules (Decisions
+   6–7).
+9. **One build, one suite invocation.** The lane still builds once and runs the
+   suite once (`playwright test`), mirroring `test:smoke`. Firefox needs **no new
+   `playwright.config.ts` hook** — it inherits the Mesa env from the suite process
+   and its normal project prefs. `workers: 1` and `retries: 0` for the lane run
+   are unchanged.
+10. **Do not mask the known Firefox flake.** The known Firefox background-drag
+    synthetic-input flake (see Known Stability Caveat) is either fixed/qualified
+    separately or **explicitly accepted and documented** as a local qualification
+    flake. It must NOT be hidden with retries, nor may the canonical assertion be
+    weakened as part of this change.
+11. **No new dependencies.** Playwright already bundles Firefox and exposes
+    `firefox.launch()`. The wrapper stays Node built-ins + `@playwright/test`
+    only. `engines`, `dependencies`, `devDependencies`, and the lockfile are
+    untouched (arch-critical: reproducibility contract).
+12. **Sandbox/relaxation flags stay opt-in-only and Chromium-scoped.** No Firefox
+    equivalent of `--disable-gpu-sandbox` is introduced into any default launch
+    path; any relaxation stays confined to the explicitly invoked local lane.
+
+## Scope
+
+### In scope
+
+- Generalizing `scripts/e2e-gpu-lane.mjs` to be **engine-aware**: an engine-aware
+  probe (Chromium via ANGLE flags + Mesa env; Firefox via Mesa env +
+  probe-only prefs, no ANGLE flags), two-engine verification, a two-engine suite
+  run, and an engine-aware report.
+- Expanding the software deny-list (Decision 7) applied to both engines.
+- Adding the `--engine=chromium|firefox|all` control (Decision 8).
+- Updating `tests/gpu-lane.test.mjs` (and any consumer that greps the report keys)
+  for the engine-aware report and the two-engine verification/selection logic.
+- Firefox-inclusive repeat-run stability evidence (see FR8) recorded in the review
+  artifacts, including the combined two-engine wall-clock.
+- Repo documentation update (see FR9) covering the two-engine lane, the Firefox
+  probe recipe and sanitization-preference rationale, and the honest-fallback and
+  known-flake semantics.
+- Proof the canonical gate is untouched (see FR6).
+
+### Out of scope (non-goals)
+
+- Raising `workers` anywhere or qualifying parallel execution (#41).
+- Any CI/GPU-in-CI work; CI stays `E2E_ENGINES=chromium` SwiftShader-only.
+- A portable Firefox **software** lane (no bundled SwiftShader equivalent;
+  separate dependencies + qualification would be required).
+- Changing `npm run validate`, `test:smoke`, `.github/workflows/validation.yml`,
+  Playwright browser defaults, `workers`, or `retries`.
+- Retuning committed test waits/floors for hardware timing.
+- New dependencies, toolchain changes, or app (`app/**`) code changes.
+- Fixing the Firefox synthetic-input flake is **optional** here (Decision 10):
+  either fix/qualify it separately or explicitly accept+document it. This spec
+  does not mandate a code fix for it.
+- Non-WSL2 Firefox hardware paths (native-Linux Firefox) — may be noted as
+  untested; the qualified path is WSL2 Mesa d3d12.
+
+## Constraints and Invariants
+
+- **Reproducibility contract** (arch-critical): Node `22.23.1`, npm `10.9.8`,
+  lockfile v3, `npm ci`; no dependency regeneration. This work adds no packages,
+  so the lockfile must show **no delta**.
+- **Canonical gate** (arch-critical): `npm run validate` is the green gate;
+  `.github/workflows/validation.yml` must **not appear in the PR diff at all**.
+- **Default-inert principle**: with no lane env set and the lane not invoked,
+  every behavior in the repo — Playwright projects, launch args/prefs, workers,
+  retries, timeouts, reporters, webServer, `E2E_ENGINES` handling — is identical
+  to today. The Firefox project's committed prefs are unchanged.
+- **Probe/suite isolation**: the probe-only Firefox preference
+  (`webgl.sanitize-unmasked-renderer: false`) is confined to the ephemeral probe
+  browser; it must never leak into the suite's Firefox profile.
+- **Evidence honesty** (lessons: Validation Evidence): record each engine's exact
+  raw renderer string, mode, and per-run results verbatim; software-fallback /
+  Firefox-skipped runs are always labeled as such; no hardware claim for an
+  engine without its deny-list assertion passing.
+- **Committed-tree proof discipline** (lessons-critical): if a local gate check
+  fails only on untracked harness files, prove the gate on a clean worktree
+  (`git worktree add --detach HEAD` + real `npm ci`) rather than suppressing it in
+  committed config.
+
+## Solution Exploration
+
+### Approach A: Second Firefox-only lane / separate script
+
+**Description**: Ship a parallel `test:e2e:gpu:firefox` wrapper.
+
+**Pros**: Zero risk to the Chromium lane.
+
+**Cons**: Duplicates probe/build/report/fallback logic; diverges over time;
+defeats the feasibility report's "one combined 22-test run" evidence; two
+commands to teach and maintain. Fails the "one command runs the full two-engine
+suite" intent.
+
+**Complexity**: Medium. **Risk**: Medium (drift).
+
+### Approach B: Verify Firefox but always run it software in the suite
+
+**Description**: Probe Firefox for information only; keep the suite Firefox arm on
+llvmpipe.
+
+**Pros**: Simplest suite wiring.
+
+**Cons**: Defeats the purpose — no hardware Firefox evidence; and it invites
+exactly the dishonest "software presented as hardware" outcome Decision 6 forbids.
+
+**Complexity**: Low. **Risk**: High (evidence dishonesty).
+
+### Approach C: Generalize the existing wrapper to be engine-aware (selected)
+
+**Description**: Extend `scripts/e2e-gpu-lane.mjs` so the probe, verification,
+suite-env composition, and report are keyed by engine. For the selected host
+recipe, probe Chromium (ANGLE flags + Mesa env) and Firefox (Mesa env +
+probe-only prefs). Require both to verify for hardware mode; run one combined
+`E2E_ENGINES=chromium,firefox` suite. Report per-engine renderers. Fall back /
+strict-fail per Decisions 5–6.
+
+**Pros**: One command, one build, one suite invocation (matches the feasibility
+report's proven shape); no duplicated logic; the existing default-inert
+`PW_CHROMIUM_ARGS` contract is untouched; Firefox needs no new config hook.
+
+**Cons**: The wrapper's internal candidate/probe model must grow an engine
+dimension; the report-key change ripples into unit tests and any report consumer
+(a deliberate, contained migration).
+
+**Complexity**: Medium. **Risk**: Low.
+
+**Selected** — it is the only approach that delivers a single combined
+two-engine hardware run with honest per-engine verification while preserving the
+Chromium lane and the untouched-gate invariant.
+
+## Functional Requirements
+
+### FR1 — Two-engine one-command lane
+
+`npm run test:e2e:gpu` (no extra args) runs the entire two-engine lane
+end-to-end: host probe → per-engine renderer verification (Chromium **and**
+Firefox) → build + production server (same flow as today) → one full
+`E2E_ENGINES=chromium,firefox` Playwright suite → engine-aware mode/renderer
+report. Invoking nothing ⇒ nothing changes anywhere (default-inert).
+
+### FR2 — Engine-aware probe
+
+For the host recipe the lane selects (WSL2 Mesa d3d12 on the qualification host):
+- **Chromium** probe: the existing ANGLE candidate flags + Mesa env
+  (`GALLIUM_DRIVER=d3d12`, `LD_LIBRARY_PATH=/usr/lib/wsl/lib`), reading
+  `UNMASKED_RENDERER_WEBGL` through the repo's own Playwright Chromium.
+- **Firefox** probe: the **same Mesa env**, **no ANGLE flags**, launched via
+  Playwright's `firefox` with the probe-only prefs from Decision 3, reading the
+  raw `UNMASKED_RENDERER_WEBGL`.
+Each probe records a **renderer and vendor** verbatim, per engine, in the probe
+transcript(s) and drives the FR3 verdict. The engine set to probe is the requested
+set (FR7): `all` ⇒ {chromium, firefox}.
+
+### FR3 — Per-engine renderer verification (expanded deny-list)
+
+Before trusting hardware mode, each requested engine's raw renderer string is
+asserted **not** to match the expanded software deny-list (Decision 7:
+SwiftShader, llvmpipe, softpipe, lavapipe, swrast, "software" rasterizers,
+Microsoft Basic Render Driver). A probe that crashes, times out, or returns a
+software/empty string is a **failed** engine verdict (logged with an actionable
+FR11 diagnostic). Firefox's verdict specifically depends on the probe-only
+sanitization preference being applied — a probe that reports the sanitized
+`Generic Renderer` string must be treated as **unverifiable**, not as hardware.
+
+### FR4 — Two-engine verification gating and honest fallback
+
+- **Default (`all`), both engines verify hardware** ⇒ run the combined
+  `E2E_ENGINES=chromium,firefox` hardware suite.
+- **Default (`all`), not both verify** ⇒ honest fallback (Decision 6):
+  Chromium runs under its deterministic SwiftShader fallback; **Firefox is
+  skipped** with a loud reason at start **and** in the final report; the run is
+  unmistakably labeled as not a two-engine hardware result.
+- **`E2E_GPU_REQUIRE=1` and any requested engine fails verification** ⇒ exit
+  non-zero **before** build/suite, with the per-engine log (Decision 5).
+- **`E2E_GPU_FORCE_FALLBACK=1`** ⇒ skip all hardware probing and take the honest
+  fallback path (Chromium SwiftShader; Firefox skipped) — how the fallback is
+  proven on a GPU-capable host.
+- Single-engine `--engine=chromium` preserves the exact #44 behavior. Single-engine
+  `--engine=firefox` applies the same honesty rules: verify or (strict) fail;
+  non-strict with no hardware reports Firefox unverified/skipped rather than
+  presenting llvmpipe as a qualified fallback.
+Lane-internal errors unrelated to hardware absence (build failure, malformed
+invocation, contradictory controls) remain hard failures in every mode.
+
+### FR5 — Full two-engine suite, nothing dropped
+
+For a verified hardware run the lane runs the **full** suite once with
+`E2E_ENGINES=chromium,firefox` (all specs for both projects), `workers: 1`, no
+committed wait trimmed, no test skipped because of the lane. `PW_CHROMIUM_ARGS`
+continues to carry only Chromium's verified flags; Firefox inherits the Mesa env
+from the suite process and uses its normal project prefs. Lane retries policy
+stays `retries: 0` (Decision 10 forbids masking the Firefox flake with retries).
+
+### FR6 — Canonical gate provably untouched
+
+- `.github/workflows/validation.yml` and the `validate`/`test:smoke` chain do not
+  appear in the PR diff.
+- `playwright.config.ts` default behavior with all lane env unset is unchanged:
+  the `firefox` project's committed prefs, `E2E_ENGINES` handling, launch args,
+  workers/retries/timeouts/reporter/webServer are identical to main (prove by
+  loading the resolved config with env unset and/or zero-diff where no config
+  change is needed). Any config change (if truly required) must be default-inert
+  and proven so.
+- PR CI (all shards + quality + gate) green under `E2E_ENGINES=chromium`
+  SwiftShader.
+
+### FR7 — Engine selector
+
+`--engine=chromium|firefox|all` (working name) selects the engine set for both the
+probe/verification stage and the suite run. `all` is the default and equals the
+two-engine behavior. Unknown values are a hard usage error (like the existing
+`parseArgs` validation). The selector is lane-only (read by the wrapper, not by
+any committed test or by `playwright.config.ts` default behavior).
+
+### FR8 — Firefox-inclusive repeat-run stability evidence
+
+Before the two-engine lane is documented as trusted: **at least three consecutive
+full two-engine hardware runs** (both engines' raw renderer strings asserted) with
+`retries: 0`, each run's per-test pass/fail, wall-clock, and the combined
+two-engine wall-clock recorded in the review artifacts, alongside a contemporaneous
+baseline for comparison. If the Firefox synthetic-input flake recurs, it is
+recorded as a lane finding and handled per Decision 10 (fixed/qualified separately
+or explicitly accepted+documented — never masked). The forced-fallback path is
+qualified by at least one `E2E_GPU_FORCE_FALLBACK=1` run showing Chromium
+SwiftShader + Firefox-skipped. Hardware qualification runs use `E2E_GPU_REQUIRE=1`
+so an unnoticed mid-qualification fallback cannot contaminate the evidence.
+
+### FR9 — Documentation
+
+The lane's documentation (README and/or the codev resource that #44 established;
+discoverable from README) is updated to cover: the two-engine command and what it
+does; the Firefox probe recipe (Mesa env + probe-only prefs) and the
+`webgl.sanitize-unmasked-renderer` rationale (why Chromium's deny-list alone is
+too weak for Firefox); how to read the engine-aware report; the honest-fallback
+semantics (Firefox skipped, never a software masquerade); the known Firefox
+background-drag flake and its disposition (Decision 10); and the unchanged
+non-gate status and #41 sequencing.
+
+### FR10 — Engine-aware honest reporting surface
+
+The lane's terminal output ends with a machine-greppable summary that replaces the
+single hardcoded `engine: chromium` / `renderer:` lines with an explicit
+per-engine contract, e.g.:
+
+```text
+=== E2E GPU LANE REPORT ===
+mode: hardware
+engines: chromium,firefox
+renderer.chromium: ANGLE (... D3D12 (NVIDIA GeForce RTX 3080) ...)
+renderer.firefox: D3D12 (NVIDIA GeForce RTX 3080)
+suite: pass
+wall-clock: ...
+```
+
+Fallback / skipped states are represented explicitly per engine (e.g.
+`renderer.firefox: skipped (unverified — <reason>)`). Report keys must be stable
+and documented; `tests/gpu-lane.test.mjs` and any report-key consumer are updated
+to the new contract.
+
+### FR11 — Actionable per-engine operator diagnostics
+
+Every skipped or failed engine/candidate produces a one-line diagnostic naming the
+cause and a remedy hint, covering at minimum: Mesa d3d12 not selected (probe
+returned llvmpipe — hint the Mesa package / env recipe); Firefox probe returned the
+sanitized `Generic Renderer` (hint the probe-only preference); probe crash/timeout
+(name the engine and where its transcript lives); WSL GPU libs missing. Diagnostics
+must make "no adapter on this host" versus "adapter present but a per-engine recipe
+prerequisite is missing" obvious to an operator who has not read this spec.
+
+## Non-Functional Requirements
+
+### Reproducibility
+No dependency, lockfile, or toolchain movement. The lane runs on the pinned
+Node/npm via the normal repo environment; Firefox is the already-installed
+Playwright bundle.
+
+### Behavior preservation
+Default-path behavior everywhere (config, tests, scripts, CI) is provably
+unchanged; the two-engine lane is pure addition over the #44 lane.
+
+### Evidence honesty
+Per-engine raw renderer strings and per-run results recorded verbatim; Firefox
+runs that are software or sanitized-unverifiable are labeled as such and never
+counted as hardware; the combined run's mode is unambiguous.
+
+### Security
+No new sandbox/blocklist relaxation in default paths; probe-only Firefox prefs are
+confined to the ephemeral probe. No secrets, no third-party services, no network
+egress beyond what the existing suite already does.
+
+### Maintainability
+The engine dimension is expressed as data/config, not scattered `if
+(engine === "firefox")` conditionals duplicated across the file; the wrapper still
+delegates the suite run to the existing config/scripts rather than re-implementing
+it; touched comments updated to reflect the two-engine reality.
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Firefox sanitized renderer (`Generic Renderer`) mistaken for hardware | Medium | High | FR3: verdict depends on the probe-only sanitization pref; a sanitized string is unverifiable, not hardware |
+| Firefox background-drag synthetic-input flake recurs on hardware | Medium | Medium | Decision 10 + FR8: fix/qualify separately or explicitly accept+document; never mask with retries or weaken the assertion |
+| Report-key change breaks a consumer/unit test | Medium | Medium | FR10 contained migration: update `tests/gpu-lane.test.mjs` + documented consumers; stable documented keys |
+| Probe-only Firefox pref leaks into the suite profile | Low | High | Constraint: pref confined to ephemeral probe; suite Firefox prefs unchanged (FR6) |
+| Config drift endangers the canonical gate | Low | High | Firefox needs no new config hook (Decision 9); FR6 byte-identical default proof + CI green |
+| Two-engine wrapper duplicates suite-invocation logic | Low | Medium | NFR Maintainability: delegate over duplicate; engine set is data |
+| Host/driver variance breaks the Firefox recipe | Medium | Low | Adapter-agnostic Mesa recipe + honest fallback (FR4); recipe documented as evidence-dated, not guaranteed |
+
+## Acceptance Scenarios
+
+### Scenario 1 — Two-engine hardware run on the proven WSL2 host
+`npm run test:e2e:gpu` on the WSL2/RTX 3080 host: the lane verifies Chromium
+(ANGLE D3D12 string) and Firefox (raw `D3D12 (NVIDIA GeForce RTX 3080)` via the
+probe-only pref), both ≠ any deny-listed software renderer; the full
+`E2E_ENGINES=chromium,firefox` suite (22 tests) runs in one Playwright invocation;
+the final report says `mode: hardware`, `engines: chromium,firefox`, and both
+`renderer.chromium` / `renderer.firefox` lines with wall-clock.
+
+### Scenario 2 — Honest fallback (Firefox not masqueraded)
+Same command with `E2E_GPU_FORCE_FALLBACK=1` (or on a host where Firefox does not
+verify): a clear warning states why; Chromium runs under SwiftShader; Firefox is
+**skipped** with a stated reason; the final report unmistakably shows Chromium
+software-fallback and Firefox skipped/unverified — never Firefox llvmpipe labeled
+as a qualified fallback. Exit code reflects the suite result.
+
+### Scenario 3 — Strict mode fails on either unverified engine
+`E2E_GPU_REQUIRE=1` with either Chromium or Firefox failing verification exits
+non-zero before the build/suite, printing the per-engine log.
+
+### Scenario 4 — Canonical gate untouched
+`git diff` on the PR shows no change to `.github/workflows/validation.yml` or the
+`validate`/`test:smoke` chain; with lane env unset the resolved Playwright config
+(including the `firefox` project prefs and `E2E_ENGINES` handling) is
+behavior-identical to main; PR CI (quality + SwiftShader Chromium e2e shards +
+gate) is green.
+
+### Scenario 5 — Stability evidence recorded
+The review artifacts contain ≥3 consecutive full two-engine hardware runs (per-run
+results, both engines' renderer strings, wall-clocks, `retries: 0`), a
+forced-fallback run, and the disposition of the Firefox synthetic-input flake
+(fixed/qualified or explicitly accepted).
+
+### Scenario 6 — Documentation
+A developer who has not read this spec can find the two-engine lane in README,
+understand the Firefox probe recipe and sanitization-pref rationale, run it, and
+correctly interpret a two-engine hardware vs. Chromium-fallback+Firefox-skipped
+report.
+
+## Known Stability Caveat
+
+Hardware rendering did **not** eliminate Firefox's existing synthetic
+background-drag flake:
+
+```text
+[firefox] tests/e2e/matrix.spec.ts:224
+zooms in with the wheel and rotates with a background drag
+Expected camera delta: > 1
+Observed camera delta: 0.0006443659645876926
+```
+
+PR #50's review recorded the same test failing once in two local Firefox runs;
+the feasibility investigation reproduced it once in three full hardware Firefox
+runs, though it then passed 5/5 repeated alone and in the combined 22-test run.
+This is best described as **Firefox synthetic-input delivery nondeterminism**, not
+a software-WebGL timing problem. Per Decision 10 it must be fixed/qualified
+separately or explicitly accepted and documented — not hidden with retries and not
+used to weaken the canonical assertion.
+
+## Dependencies
+
+- **Internal**: the #44 lane (`scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`,
+  the `PW_CHROMIUM_ARGS` hook), the existing `firefox` Playwright project and
+  `E2E_ENGINES` handling in `playwright.config.ts`.
+- **External services**: none.
+- **Evidence source**: `firefox-native-gpu-e2e-feasibility.md` (go verdict, runtime
+  evidence, required-change breakdown, upstream Firefox sanitization references).
+- **Sequencing**: #41 (parallelization) may consume this two-engine lane's
+  qualification; this spec should land (or record two-engine hardware evidence)
+  first.
+
+## References
+
+- Issue #52 (this spec); `firefox-native-gpu-e2e-feasibility.md`.
+- Spec / plan / review #44
+  (`codev/{specs,plans,reviews}/44-add-an-opt-in-native-gpu-local.md`), PR #50.
+- `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`, `playwright.config.ts`.
+- Upstream (from the feasibility report): Playwright `BrowserType.launch`
+  (`firefoxUserPrefs`, launch `env`); Firefox `SanitizeRenderer.cpp`,
+  `ClientWebGLContext.cpp`, and `StaticPrefList.yaml`
+  (`webgl.sanitize-unmasked-renderer`).
+- `codev/resources/arch-critical.md` — Validation Baseline (canonical gate; do not
+  raise workers / trim waits).
+- `codev/resources/lessons-critical.md` — Validation Evidence (renderer-string
+  discipline); Toolchain and Worktree Hygiene (clean-checkout proof).

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -170,3 +170,38 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   firefox-only headed decision test. Rebuttal written (ACCEPTED+FIXED both points).
 - iter2: unanimous APPROVE, KEY_ISSUES None. Committing [Phase:
   two_engine_suite_and_inertness].
+
+### Implement — Phase 3 `qualification_evidence_and_docs` (iteration 1)
+- Phase 2 committed 8d79964. Phase 3: FR8 ≥3 consecutive two-engine hardware runs
+  (E2E_GPU_REQUIRE=1) + forced-fallback baseline + flake disposition (Decision 10)
+  + README (FR9) + complete review + clean-worktree validate proof.
+
+### Phase 3 — evidence + docs results
+- FR8: 3 consecutive fully-green two-engine hardware runs Q-1/Q-2/Q-3 (22/22 each,
+  196-198s suite, E2E_GPU_REQUIRE=1, retries:0) + HW-1 = 4-for-4 (88/88 test
+  execs). Firefox per-test spread ≤0.3s. Both renderers asserted identical every
+  run. Branch (a) satisfied — fully green, no known-flake exception needed.
+- Flake disposition (Decision 10): background-drag matrix:224 = 0/4 recurrence
+  this session (13.2-13.3s stable). Accepted+documented as pre-existing Firefox
+  synthetic-input flake; NOT fixed (out of scope), NOT masked (retries:0,
+  assertion unchanged).
+- FB-1 baseline (FORCE_FALLBACK): 11/11 chromium SwiftShader (firefox skipped),
+  582s suite / 591s total, exit 0. Two-engine hardware 22 tests/196s vs chromium
+  SwiftShader 11 tests/582s ⇒ ~6× per-test, matching #44.
+- README (FR9) updated in place: two-engine command, Firefox recipe + sanitize-
+  pref rationale, per-engine report block, --engine selector, honest fallback,
+  known flake. Review completed (spec-compliance checklist, lessons, consult log).
+- Committing Phase 3; launching clean-worktree `npm run validate` proof (worktree
+  lint polluted by untracked .claude/hooks).
+
+### Phase 3 — clean-checkout validate proof (lessons-critical)
+- Clean detached worktree at 54d836d + real `npm ci` (no .claude/hooks present):
+  - Run 1: lint ✓, typecheck ✓, build ✓; test:smoke runs both engines in SOFTWARE
+    (chromium SwiftShader + firefox llvmpipe) → e2e 21/22, VALIDATE EXIT 1. Sole
+    failure = known firefox matrix:224 background-drag flake (software input-race;
+    this is where it lives). Lint-pollution proof SATISFIED (lint 0 errors).
+  - Run 2 (no changes): e2e 22/22, VALIDATE EXIT 0 (firefox:224 passed 12.9s).
+    Intermittent flake passes on re-run — exact #44 pattern.
+- Branch touches only scripts/e2e-gpu-lane.mjs + tests/gpu-lane.test.mjs (+docs);
+  zero tests/e2e / app / playwright.config.ts changes ⇒ flake is pre-existing.
+- Review 52 status → complete. Folding clean-checkout proof into Phase 3 commit.

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -81,3 +81,48 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
 - `porch done 52` (checks pass) → **GATE: plan-approval reached** (no rebuttal — no
   REQUEST_CHANGES). Requested via `porch gate 52`, notified architect. STOPPED, waiting
   for human `porch approve 52 plan-approval`. (Strict mode: builder does NOT approve.)
+
+### Implement — Phase 1 `engine_aware_core` (iteration 1)
+- plan-approval gate APPROVED by architect; `porch next` advanced to implement /
+  plan phase `engine_aware_core`.
+- Scope (Phase 1 only): engine-aware core in `scripts/e2e-gpu-lane.mjs` +
+  `tests/gpu-lane.test.mjs`. NO two-engine suite wiring (that's Phase 2).
+- Design decisions:
+  - Engine dimension as DATA: keep Chromium `CANDIDATES`; add single
+    `FIREFOX_PROBE_RECIPE` (Mesa env, no ANGLE flags, probe-only prefs
+    webgl.force-enabled + webgl.sanitize-unmasked-renderer:false).
+  - `classifyRenderer` now returns none|software|unverifiable|hardware;
+    "Generic Renderer" ⇒ unverifiable (Firefox sanitized). Deny-list expanded
+    with softpipe/lavapipe/swrast.
+  - `probeRenderer` engine-aware (launcher dispatch chromium|firefox; firefox
+    passes firefoxUserPrefs not args); transcripts gain engine prefix
+    (probe-<engine>-<id>-<mode>.log).
+  - `computeRunPlan` = pure two-engine gating fn (hardware / software-fallback /
+    skip-empty / abort) — fully unit-tested, consumed by --probe-only now and by
+    the full lane in Phase 2.
+  - `formatReport` migrated to per-engine keys (engines:, renderer.<engine>:).
+  - `--engine=chromium|firefox|all` added to parseArgs (default all).
+  - Phase 1 transitional: full-lane suite path stays #44 Chromium-only (uses
+    computeRunPlan for ["chromium"]); engine-aware probe exercised via
+    --probe-only. Phase 2 generalizes suiteEnvFor + main to the requested set.
+
+### Phase 1 — build/verify results (on-host, WSL2 RTX 3080)
+- `npm run build` ✓; `npm test` ✓ (90 tests, incl. 51 gpu-lane: 0 fail);
+  `npm run typecheck` clean; `npx eslint scripts/e2e-gpu-lane.mjs
+  tests/gpu-lane.test.mjs` clean (exit 0). The 21 `npm run lint` errors are ALL
+  in untracked `.claude/hooks/worktree-write-guard.cjs` (builder-harness file,
+  absent from clean checkouts) — environment noise per lessons-critical, not a
+  project failure. Full clean-worktree `npm run validate` proof deferred to Phase 3.
+- Manual `--probe-only` on this host (Phase 1 acceptance):
+  - `all`: mode hardware; renderer.chromium=`ANGLE (Microsoft Corporation, D3D12
+    (NVIDIA GeForce RTX 3080), OpenGL 4.6)`; renderer.firefox=`D3D12 (NVIDIA
+    GeForce RTX 3080)`. Both hardware, 3s wall-clock.
+  - `--engine=chromium` / `--engine=firefox`: each probes only its engine ✓.
+  - `--engine=bogus` → usage error, exit 2 ✓.
+  - forced-fallback probe-only (all) → mode software-fallback, chromium
+    software-fallback, firefox skipped ✓; (firefox-only) → skip-empty ✓.
+- Firefox sanitize-pref contrast (load-bearing evidence for the `unverifiable`
+  verdict): probe WITHOUT the pref ⇒ `"Generic Renderer"` (matches no software
+  marker — would false-pass without the explicit unverifiable class); WITH
+  `webgl.sanitize-unmasked-renderer:false` ⇒ `"D3D12 (NVIDIA GeForce RTX 3080)"`.
+- Signalling `porch done 52` (build-complete → 3-way consult).

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -209,3 +209,14 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
 ### Phase 3 — consult result
 - Unanimous APPROVE (Gemini/Codex/Claude), KEY_ISSUES None. All 3 implement phases
   complete + approved. Advancing porch (→ review/PR).
+
+### Review phase
+- Porch → review phase (checks: pr_exists, review_has_arch_updates,
+  review_has_lessons_updates, e2e_tests, done). test:e2e script absent ⇒
+  e2e_tests check is a no-op skip (|| echo).
+- Routed arch/lessons to COLD docs (hot tier untouched — canonical-gate invariant
+  already covers the lane; no new top-level sections):
+  - arch.md Validation Baseline native-GPU-lane paragraph → two-engine reality.
+  - lessons-learned.md Validation Evidence → sanitized-capability-string lesson.
+- Added ## Architecture Updates + ## Lessons Learned Updates to review 52.
+- Opening PR (→ pr gate for architect integration review).

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -77,4 +77,7 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   3. Regression guard: existing Chromium `--mode`/`--candidate`/`--channel` surface + all its
      tests stay green (only report-key assertions updated); any other red = regression (Codex2).
   Updated Expert Review + Change Log sections.
-- Committing "[Spec 52] Plan with multi-agent review", then continue porch.
+- Committed "[Spec 52] Plan with multi-agent review" (665fd9b).
+- `porch done 52` (checks pass) → **GATE: plan-approval reached** (no rebuttal — no
+  REQUEST_CHANGES). Requested via `porch gate 52`, notified architect. STOPPED, waiting
+  for human `porch approve 52 plan-approval`. (Strict mode: builder does NOT approve.)

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -37,4 +37,31 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   4. FR9: named concrete doc target = README "Opt-in native-GPU e2e lane" section,
      updated in place; evidence in review 52 (Codex).
   Added Consultation Log section (SPIR requirement).
-- Committing as "[Spec 52] Specification with multi-agent review", then `porch next 52`.
+- Committed "[Spec 52] Specification with multi-agent review" (3923c2b).
+- Wrote rebuttal (52-specify-iter1-rebuttals.md): all feedback accepted, no disagreements.
+- `porch done 52` → **GATE: spec-approval reached**. Requested via `porch gate 52`,
+  notified architect via `afx send`. STOPPED, waiting for human `porch approve 52 spec-approval`.
+  (Strict mode: builder does NOT call porch approve.)
+
+### Plan phase (iteration 1)
+- Architect APPROVED spec-approval gate (verified empty-engine-set rule against
+  playwright.config.ts projects.length===0 guard; no architecture concerns). Advanced to plan.
+- Read #44 plan for the established decomposition style. Wrote 3-phase plan
+  (`codev/plans/52-firefox-hardware-webgl-gpu-lane.md`):
+  1. `engine_aware_core` — per-engine probe recipes (Chromium CANDIDATES + single
+     Firefox recipe), generalized probe w/ firefox.launch + probe-only sanitize pref,
+     expanded deny-list (softpipe/lavapipe/swrast + sanitized `Generic Renderer` →
+     unverifiable verdict), `--engine` selector, two-engine verification-gating pure fn,
+     per-engine report (renderer.chromium/renderer.firefox), unit tests. Files:
+     scripts/e2e-gpu-lane.mjs + tests/gpu-lane.test.mjs.
+  2. `two_engine_suite_and_inertness` — engine-set-aware suiteEnvFor (Mesa env into
+     suite process, Firefox inherits it; PW_CHROMIUM_ARGS Chromium-only; empty set →
+     skip, never pass empty E2E_ENGINES), honest fallback, REQUIRE abort, empty-set
+     skip, FR6 default-inert proof (config-load, firefox prefs unchanged).
+  3. `qualification_evidence_and_docs` — ≥3 two-engine hardware runs, flake disposition
+     (Decision 10), README section updated in place (FR9).
+- Key design: engine dimension as DATA + per-engine launcher dispatch (not scattered
+  if(firefox) branches). Firefox recipe = same Mesa env, no ANGLE flags. Probe-only
+  sanitize pref stays in wrapper; committed firefox project keeps webgl.force-enabled only.
+- porch checks pass (plan_exists, has_phases_json, min_two_phases=3).
+- Committing "[Spec 52] Initial implementation plan", then `porch done 52` for consult.

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -1,0 +1,40 @@
+# spir-52 thread — Firefox hardware WebGL e2e lane (issue #52)
+
+Builder for spec #52: generalize the opt-in native-GPU local e2e lane
+(`scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`) from Chromium-only to a
+two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 / PR #50.
+
+## Log
+
+### Specify phase (iteration 1)
+- Spawned in strict mode at `specify` phase. A comprehensive spec already exists
+  (committed `f1f9424`): `codev/specs/52-firefox-hardware-webgl-gpu-lane.md`.
+- Reviewed the spec against the actual code — "Current state" claims verified accurate:
+  - `SOFTWARE_RENDERER_MARKERS = ["swiftshader","llvmpipe","software","microsoft basic"]`
+    (spec calls for expanding to also cover softpipe/lavapipe/swrast + MS Basic Render Driver).
+  - `formatReport()` hardcodes `engine: chromium` + single `renderer:` line.
+  - `suiteEnvFor()` pins `E2E_ENGINES = "chromium"`.
+  - `parseArgs()` has `--probe-only/--mode/--candidate/--channel`, no engine selector.
+  - `playwright.config.ts` firefox project sets only `webgl.force-enabled: true`; honors E2E_ENGINES.
+- Spec faithfully carries issue #52 Baked Decisions into "Confirmed Decisions" (12 items).
+- Feasibility report `firefox-native-gpu-e2e-feasibility.md` is tracked (committed with spec).
+- Only untracked files are builder-harness noise (`.builder-*`, `.claude/hooks/`) — env, not project.
+- Assessment: spec is thorough and accurate; no rewrite needed. Signalling `porch done 52`
+  to trigger the 3-way consultation (Gemini/Codex/Claude).
+
+### Specify — consultation iter1 results + spec revision
+- Verdicts: Gemini APPROVE (HIGH), Claude APPROVE (HIGH), Codex REQUEST_CHANGES (HIGH).
+  All three verified codebase claims accurate; approach feasible; no architecture or
+  Baked-Decision changes. All feedback = edge-behavior clarification. Incorporated:
+  1. FR4: single-engine `--engine=firefox` non-strict + no hardware → empty engine set
+     would crash `playwright.config.ts` (Gemini). Now: skip build/suite, report Firefox
+     skipped + `suite: skipped (no verified engine)`, exit 0; REQUIRE=1 → exit non-zero.
+     Added Scenario 7.
+  2. FR4: vacuous `FORCE_FALLBACK=1 --engine=firefox` (Claude) → honest no-op skip, NOT
+     a usage error.
+  3. FR8: explicit two-branch merge gate — 3 green runs OR green-except-known-documented
+     flake per Decision 10 (Codex). Any other failure blocks.
+  4. FR9: named concrete doc target = README "Opt-in native-GPU e2e lane" section,
+     updated in place; evidence in review 52 (Codex).
+  Added Consultation Log section (SPIR requirement).
+- Committing as "[Spec 52] Specification with multi-agent review", then `porch next 52`.

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -205,3 +205,7 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
 - Branch touches only scripts/e2e-gpu-lane.mjs + tests/gpu-lane.test.mjs (+docs);
   zero tests/e2e / app / playwright.config.ts changes ⇒ flake is pre-existing.
 - Review 52 status → complete. Folding clean-checkout proof into Phase 3 commit.
+
+### Phase 3 — consult result
+- Unanimous APPROVE (Gemini/Codex/Claude), KEY_ISSUES None. All 3 implement phases
+  complete + approved. Advancing porch (→ review/PR).

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -220,3 +220,14 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   - lessons-learned.md Validation Evidence → sanitized-capability-string lesson.
 - Added ## Architecture Updates + ## Lessons Learned Updates to review 52.
 - Opening PR (→ pr gate for architect integration review).
+
+### Review phase — PR consult (iter1) + fixes
+- Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES (3 pts):
+  1. REAL honesty bug: chromium-fail + firefox-VERIFIED ⇒ report said
+     `renderer.firefox: skipped (unverified — unverified)`. Fixed via distinct
+     `not-run` state ⇒ `not run (Chromium unverified — …)`. Other skip outputs
+     (unverified, forced-fallback) unchanged. Unit test added.
+  2. audit-report.test.mjs failing in Codex sandbox = env artifact (shells to
+     npm audit; untouched by branch; 95/95 green here + porch tests gate).
+  3. plan Status draft ⇒ completed.
+- npm test 95/95, lint/typecheck clean. Committing fixes + pushing to PR #53.

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -231,3 +231,14 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
      npm audit; untouched by branch; 95/95 green here + porch tests gate).
   3. plan Status draft ⇒ completed.
 - npm test 95/95, lint/typecheck clean. Committing fixes + pushing to PR #53.
+
+### Review phase — architect integration review (PR #53) fixes
+- Blocking: runProbeOnly() returned 1 on E2E_GPU_REQUIRE abort WITHOUT printing
+  formatReport (violates "probe-only always reports" contract). Fixed: extracted
+  pure probeOnlyOutcome() → {report, exitCode}; always emits per-engine report
+  (mode: abort) before non-zero exit. Unit test added.
+- Minor: parseArgs now rejects --candidate/--channel (Chromium-only) with
+  --engine=firefox (usage error, exit 2). Unit test added.
+- E2E verified: E2E_GPU_REQUIRE=1 --probe-only forced-miss prints report + exit 1;
+  --engine=firefox --candidate exit 2. 58 gpu-lane tests + 97 total green, lint/
+  typecheck clean. Pushing to PR #53; re-running porch consult (iter2).

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -64,4 +64,17 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   if(firefox) branches). Firefox recipe = same Mesa env, no ANGLE flags. Probe-only
   sanitize pref stays in wrapper; committed firefox project keeps webgl.force-enabled only.
 - porch checks pass (plan_exists, has_phases_json, min_two_phases=3).
-- Committing "[Spec 52] Initial implementation plan", then `porch done 52` for consult.
+- Committed "[Spec 52] Initial implementation plan" (e2aa5ca); ran `porch done 52` → consult.
+
+### Plan — consultation iter1 results + revision
+- Verdicts: Gemini APPROVE (HIGH), Claude APPROVE (HIGH), Codex COMMENT (HIGH). No blockers,
+  no architecture concerns; all verified codebase claims + complete FR/Decision/Scenario coverage.
+  Incorporated 3 non-blocking refinements into Phase 1:
+  1. Explicit `failureDiagnostic` `unverifiable` branch → Firefox Generic Renderer emits the
+     probe-preference hint, not the software/Mesa hint (Claude + Codex1).
+  2. Required FR11 diagnostic unit coverage (sanitized hint, engine-named crash/timeout,
+     engine-tagged transcripts) (Codex1).
+  3. Regression guard: existing Chromium `--mode`/`--candidate`/`--channel` surface + all its
+     tests stay green (only report-key assertions updated); any other red = regression (Codex2).
+  Updated Expert Review + Change Log sections.
+- Committing "[Spec 52] Plan with multi-agent review", then continue porch.

--- a/codev/state/spir-52_thread.md
+++ b/codev/state/spir-52_thread.md
@@ -126,3 +126,47 @@ two-engine Chromium+Firefox lane. Strict mode (porch-driven). Follow-up to #44 /
   marker — would false-pass without the explicit unverifiable class); WITH
   `webgl.sanitize-unmasked-renderer:false` ⇒ `"D3D12 (NVIDIA GeForce RTX 3080)"`.
 - Signalling `porch done 52` (build-complete → 3-way consult).
+
+### Implement — Phase 2 `two_engine_suite_and_inertness` (iteration 1)
+- Phase 1 3-way consult: unanimous APPROVE, KEY_ISSUES None. Committed
+  f3612e5 [Phase: engine_aware_core]. (Porch commits only status.yaml; builder
+  commits code per-phase.)
+- Phase 2 scope: engine-set-aware suiteEnvFor(plan,baseEnv); runFullLane uses the
+  full requested engine set + skip-empty dispatch + honest fallback + REQUIRE
+  abort; FR6 default-inert proof; playwright.config.ts UNCHANGED (Decision 9).
+
+### Phase 2 — build/verify results (on-host)
+- suiteEnvFor now plan-based (two-engine env: E2E_ENGINES=chromium,firefox +
+  Chromium recipe Mesa env, Firefox inherits it; firefox-only: Firefox Mesa env,
+  no PW_CHROMIUM_ARGS; fallback: SwiftShader chromium-only; skip-empty/abort
+  guarded to never produce a suite env). runFullLane uses the full requested set.
+- Unit tests: 54 pass. lint (my files) clean, typecheck clean.
+- On-host behavioral proofs:
+  - Two-engine HARDWARE full run (E2E_GPU_REQUIRE=1): 22/22 pass, mode hardware,
+    renderer.chromium ANGLE D3D12 + renderer.firefox raw D3D12, 208s (build 10s,
+    suite 196s), exit 0. [HW-1]
+  - Forced-fallback: mode software-fallback, chromium (software-fallback —
+    SwiftShader), firefox skipped; suite ran [chromium] tests only (E2E_ENGINES=
+    chromium; Firefox excluded, no masquerade); two loud banners. (SwiftShader is
+    slow — proven via 5/5 chromium tests before a manual timeout; full FB run =
+    Phase 3.)
+  - REQUIRE abort (chromium forced-miss via native-linux candidate): exit 1
+    before build/suite, per-engine log.
+  - skip-empty (--engine=firefox + FORCE_FALLBACK): no build/suite, "suite:
+    skipped (no verified engine)", exit 0.
+- FR6 default-inert proof: playwright.config.ts EMPTY diff vs main (byte-
+  identical — Firefox needs no config hook, Decision 9); no validation.yml/
+  package.json/lockfile delta; config-load with lane env unset lists both
+  [chromium] and [firefox] (22 tests). Recorded in review draft
+  (codev/reviews/52-...md, new file — staged for consult visibility).
+- Env hygiene note: a `timeout`-killed experiment orphaned a next-server on port
+  3000; killed by PID, port free. No worktree pollution.
+
+### Phase 2 — consult result + commit
+- iter1: Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES (real bug: headed
+  suite dispatch derived from Chromium-only field ⇒ a firefox-only --mode=headed
+  hardware run would wrongly run headless). Fixed: run-level plan.effectiveMode +
+  exported isHeadedRun(plan); removed redundant chromiumEffectiveMode; added
+  firefox-only headed decision test. Rebuttal written (ACCEPTED+FIXED both points).
+- iter2: unanimous APPROVE, KEY_ISSUES None. Committing [Phase:
+  two_engine_suite_and_inertness].

--- a/firefox-native-gpu-e2e-feasibility.md
+++ b/firefox-native-gpu-e2e-feasibility.md
@@ -1,0 +1,240 @@
+# Firefox Native-GPU E2E Feasibility
+
+**Date:** 2026-07-21  
+**Related:** GitHub issue [#44](https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/issues/44), merged PR [#50](https://github.com/mohidmakhdoomi/nextjs-3d-force-graph-impl/pull/50)  
+**Status:** Feasible follow-up; not implemented
+
+## Verdict
+
+Firefox hardware-WebGL support in `npm run test:e2e:gpu` is feasible. PR #50
+deliberately made the lane Chromium-only because its proven configurations were
+Chromium+ANGLE; Firefox hardware GL was explicitly out of scope rather than
+blocked by a browser limitation (see
+[`codev/specs/44-add-an-opt-in-native-gpu-local.md`](codev/specs/44-add-an-opt-in-native-gpu-local.md)).
+
+The existing architecture already contains most of what is needed:
+
+- Playwright has a Firefox project and supports selecting both projects with
+  `E2E_ENGINES=chromium,firefox`.
+- The Mesa D3D12 environment used by the Chromium lane is inherited by Firefox.
+- Playwright supports per-launch environment variables and Firefox preferences.
+- A combined Chromium+Firefox hardware run passed all 22 tests on the
+  qualification host.
+
+This should be delivered as a separate follow-up issue/spec, while leaving the
+canonical validation command and CI workflow unchanged.
+
+## Qualification Host
+
+- WSL2, Linux kernel `6.6.87.2-microsoft-standard-WSL2`
+- NVIDIA GeForce RTX 3080
+- NVIDIA Windows driver `581.29`
+- Mesa `26.0.3`
+- Node.js `22.23.1`
+- Playwright `1.61.1`, bundled Firefox `151.0`
+- `/dev/dxg` and `/usr/lib/wsl/lib` available
+
+`glxinfo -B` reported:
+
+```text
+Device: D3D12 (NVIDIA GeForce RTX 3080)
+Accelerated: yes
+OpenGL core profile version: 4.6
+```
+
+## Runtime Evidence
+
+| Check | Result |
+| --- | --- |
+| Firefox headless with the Mesa D3D12 recipe | Hardware WebGL; raw renderer `D3D12 (NVIDIA GeForce RTX 3080)` |
+| Firefox headed with the Mesa D3D12 recipe | Hardware WebGL works |
+| Firefox without the GPU recipe | `llvmpipe (LLVM 21.1.8, 256 bits)` |
+| Firefox full-suite run 1 | 11/11 passed in approximately 1.7 minutes |
+| Firefox full-suite run 2 | 10/11 passed in approximately 1.8 minutes; known background-drag miss |
+| Firefox full-suite run 3 | 11/11 passed in approximately 1.7 minutes |
+| Background-drag test repeated independently | 5/5 passed |
+| Combined Chromium+Firefox hardware run | 22/22 passed in 3.2 minutes |
+
+The combined execution used the same shape a generalized wrapper would use:
+
+```sh
+E2E_ENGINES=chromium,firefox \
+PW_CHROMIUM_ARGS='--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox' \
+GALLIUM_DRIVER=d3d12 \
+LD_LIBRARY_PATH=/usr/lib/wsl/lib \
+MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA \
+LIBGL_ALWAYS_SOFTWARE=false \
+npx playwright test
+```
+
+## Firefox Renderer Verification
+
+Firefox normally exposed the following values to page JavaScript under the
+hardware recipe:
+
+```text
+renderer: Generic Renderer
+vendor: Microsoft Corporation
+```
+
+This is Firefox privacy sanitization, not a software-renderer result. Reusing
+Chromium's current deny-list against `Generic Renderer` would therefore be too
+weak: it could produce an unverifiable or false hardware classification.
+
+Firefox has a `webgl.sanitize-unmasked-renderer` preference. Setting it to
+`false` only in the short-lived renderer-probe browser exposed the underlying
+renderer:
+
+```text
+D3D12 (NVIDIA GeForce RTX 3080)
+```
+
+The software control exposed:
+
+```text
+llvmpipe (LLVM 21.1.8, 256 bits)
+```
+
+The preference should be disabled only for the ephemeral blank-page probe, not
+for the application suite. It changes renderer-string disclosure, not renderer
+selection. The suite can retain its normal Firefox profile and preferences.
+
+Relevant upstream documentation and source:
+
+- [Playwright `BrowserType.launch`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch)
+  supports launch environments and `firefoxUserPrefs`.
+- [Firefox WebGL parameter handling](https://searchfox.org/firefox-main/source/dom/canvas/ClientWebGLContext.cpp)
+  applies renderer sanitization conditionally.
+- [Firefox renderer sanitization](https://searchfox.org/firefox-main/source/dom/canvas/SanitizeRenderer.cpp)
+  recognizes `llvmpipe` and otherwise buckets or replaces renderer strings.
+- [Firefox static WebGL preferences](https://searchfox.org/firefox-main/source/modules/libpref/init/StaticPrefList.yaml)
+  define `webgl.sanitize-unmasked-renderer`.
+
+## Required Implementation Changes
+
+### 1. Generalize the probe by engine
+
+Replace the Chromium-only launcher in
+[`scripts/e2e-gpu-lane.mjs`](scripts/e2e-gpu-lane.mjs) with an
+engine-aware launcher:
+
+- Chromium: retain the candidate's ANGLE flags and Mesa environment.
+- Firefox: use the same Mesa environment, no Chromium ANGLE flags, and probe
+  with:
+
+  ```js
+  firefoxUserPrefs: {
+      "webgl.force-enabled": true,
+      "webgl.sanitize-unmasked-renderer": false,
+  }
+  ```
+
+The probe should record a renderer and vendor for each requested engine. Expand
+the software deny-list to fail closed for at least SwiftShader, llvmpipe,
+softpipe, lavapipe, swrast, software rasterizers, and Microsoft Basic Render
+Driver.
+
+### 2. Verify every requested engine
+
+For the default two-engine lane, a candidate is fully verified only after both
+Chromium and Firefox return hardware renderer verdicts. Under
+`E2E_GPU_REQUIRE=1`, failure to verify either engine should exit nonzero before
+the build or suite starts.
+
+An optional `--engine=chromium|firefox|all` control would preserve targeted
+diagnostics while allowing `all` to be the intended two-engine behavior.
+
+### 3. Run the existing two-engine Playwright matrix
+
+For a verified candidate, set:
+
+```text
+E2E_ENGINES=chromium,firefox
+```
+
+Continue setting `PW_CHROMIUM_ARGS` for Chromium. Firefox needs no new
+Playwright-config hook because it inherits the Mesa environment from the suite
+process. The build should still run once, followed by one Playwright invocation
+with `workers: 1` and `retries: 0` unchanged.
+
+### 4. Make the report engine-aware
+
+The current report hardcodes `engine: chromium` and one renderer. Replace that
+with an explicit per-engine contract, for example:
+
+```text
+=== E2E GPU LANE REPORT ===
+mode: hardware
+engines: chromium,firefox
+renderer.chromium: ANGLE (... D3D12 ...)
+renderer.firefox: D3D12 (NVIDIA GeForce RTX 3080)
+suite: pass
+wall-clock: ...
+```
+
+Update unit tests and any consumers that grep the existing report keys.
+
+### 5. Preserve honest fallback semantics
+
+Firefox has no portable bundled SwiftShader equivalent. If both hardware
+engines cannot be verified, the safest default behavior is:
+
+- preserve PR #50's deterministic Chromium SwiftShader fallback;
+- skip Firefox and report why it was skipped;
+- under `E2E_GPU_REQUIRE=1`, fail instead of falling back.
+
+Do not label an unverified Firefox llvmpipe run as equivalent to Chromium's
+qualified SwiftShader fallback. A portable Firefox software lane would need
+separate dependencies and qualification.
+
+## Known Stability Caveat
+
+Hardware rendering did not eliminate Firefox's existing synthetic
+background-drag flake:
+
+```text
+[firefox] tests/e2e/matrix.spec.ts:224
+zooms in with the wheel and rotates with a background drag
+
+Expected camera delta: > 1
+Observed camera delta: 0.0006443659645876926
+```
+
+PR #50's review had already recorded the same test failing once in two local
+Firefox validation runs. This investigation reproduced it once in three full
+hardware Firefox runs, although the test then passed 5/5 when repeated alone
+and also passed in the combined 22-test run.
+
+Therefore the issue is better described as Firefox synthetic-input delivery
+nondeterminism, not solely a slow software-WebGL timing problem. A follow-up
+should either fix/qualify that test separately or explicitly accept the known
+local qualification flake. It should not hide it with retries or weaken the
+canonical assertion as part of the GPU-lane change.
+
+## Recommended Acceptance Criteria
+
+- `npm run test:e2e:gpu` verifies hardware renderers independently for Chromium
+  and Firefox before running a two-engine hardware suite.
+- Firefox's raw probe renderer is collected through the probe-only sanitization
+  preference and rejects known software renderers.
+- A verified WSL2 candidate runs all 22 tests in one Playwright invocation.
+- `E2E_GPU_REQUIRE=1` fails if either requested engine is not hardware-backed.
+- Non-strict exhaustion retains a loud Chromium software fallback and clearly
+  reports Firefox as skipped/unverified.
+- At least three consecutive full two-engine hardware runs pass with
+  `retries: 0`, or any Firefox flake is explicitly resolved and requalified.
+- `npm run validate`, `test:smoke`, `.github/workflows/validation.yml`, browser
+  defaults, `workers`, retries, and committed test timings remain unchanged.
+- No new dependency or lockfile change is introduced.
+
+## Conclusion
+
+This is a **go** as a focused follow-up feature. There is no Firefox or
+Playwright blocker, headless Firefox reaches the WSL2 D3D12 adapter, exact
+renderer verification is available through an ephemeral probe preference, and
+the existing Playwright configuration already runs both engines successfully.
+
+The principal remaining risk is test stability, specifically the known Firefox
+background-drag input-delivery flake. That should be handled transparently in
+the follow-up's qualification rather than attributed to software rendering or
+masked with retries.

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -453,6 +453,41 @@ export function reportEntriesFromPlan(plan, requestedEngines) {
         }));
 }
 
+// Pure: the --probe-only report + exit code. A probe-only run already did all its
+// work, so it ALWAYS reports (the report is the deliverable, most useful exactly
+// when an engine failed) — INCLUDING when E2E_GPU_REQUIRE=1 forces a non-zero
+// exit (`mode: abort`). Per-engine lines show each engine's ACTUAL probe result
+// (a probe is a diagnostic, not a run): verified ⇒ verbatim renderer; otherwise
+// its own skip reason. forceFallback ran no probe, so those lines come from the
+// plan's engines map instead.
+export function probeOnlyOutcome({
+    requestedEngines,
+    verdicts = {},
+    plan,
+    controls,
+    wallClock,
+}) {
+    const engines = requestedEngines.map((engine) => {
+        if (controls.forceFallback) {
+            return {engine, renderer: engineReportLine(plan.engines[engine])};
+        }
+        const verdict = verdicts[engine];
+        return {
+            engine,
+            renderer: verdict.verified
+                ? verdict.renderer
+                : `skipped (unverified — ${verdict.reason})`,
+        };
+    });
+    const report = formatReport({
+        mode: plan.mode === "abort" ? "abort" : reportModeLabel(plan.mode),
+        engines,
+        suite: "skipped (--probe-only)",
+        wallClock,
+    });
+    return {report, exitCode: plan.mode === "abort" ? 1 : 0};
+}
+
 // Two-engine verification gating (spec 52 FR4, Decisions 4–6) — a PURE decision
 // function. Given the requested engine set, each engine's probe verdict, and
 // the controls, decide the run shape. Only "hardware" runs the combined suite;
@@ -968,6 +1003,21 @@ export function parseArgs(argv) {
                 "a Playwright channel through PW_CHROMIUM_ARGS",
         );
     }
+    if (
+        args.engines.length === 1 &&
+        args.engines[0] === "firefox" &&
+        (args.candidate !== null || args.channel !== null)
+    ) {
+        // --candidate selects a Chromium ANGLE recipe and --channel a Chromium
+        // Playwright channel; both are Chromium-only and meaningless for a
+        // Firefox-only run (Firefox has a single probe recipe). Reject rather
+        // than silently ignore.
+        throw new LaneUsageError(
+            "--candidate and --channel are Chromium-only and have no effect " +
+                "with --engine=firefox (Firefox has a single probe recipe) — " +
+                "drop them, or use --engine=all",
+        );
+    }
     return args;
 }
 
@@ -1073,34 +1123,22 @@ async function runProbeOnly(args, controls, elapsedSeconds) {
     const plan = computeRunPlan({requestedEngines, verdicts, controls});
 
     if (plan.mode === "abort") {
-        log(
-            "E2E_GPU_REQUIRE=1 — not every requested engine verified hardware; " +
-                "exiting non-zero",
-        );
-        return 1;
+        // E2E_GPU_REQUIRE=1 and some engine did not verify. Unlike the full lane
+        // (which aborts BEFORE doing any build/suite work), a probe-only run has
+        // already produced its verdicts — so it ALWAYS emits the per-engine
+        // report before the non-zero exit (the report is the deliverable, most
+        // useful exactly when an engine failed).
+        log("E2E_GPU_REQUIRE=1 — not every requested engine verified hardware");
     }
-
-    const engines = requestedEngines.map((engine) => {
-        if (controls.forceFallback) {
-            return {engine, renderer: engineReportLine(plan.engines[engine])};
-        }
-        const verdict = verdicts[engine];
-        return {
-            engine,
-            renderer: verdict.verified
-                ? verdict.renderer
-                : `skipped (unverified — ${verdict.reason})`,
-        };
+    const {report, exitCode} = probeOnlyOutcome({
+        requestedEngines,
+        verdicts,
+        plan,
+        controls,
+        wallClock: `${elapsedSeconds()}s`,
     });
-    console.log(
-        formatReport({
-            mode: reportModeLabel(plan.mode),
-            engines,
-            suite: "skipped (--probe-only)",
-            wallClock: `${elapsedSeconds()}s`,
-        }),
-    );
-    return 0;
+    console.log(report);
+    return exitCode;
 }
 
 // Full lane: build + suite, mirroring `test:smoke`. Probes the full requested

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -429,6 +429,14 @@ export function reportModeLabel(planMode) {
     return planMode === "skip-empty" ? "skipped" : planMode;
 }
 
+// Whether the suite runs headed. Only a hardware run can be headed (fallback is
+// always the config's default headless), and only when the run's uniform
+// effective mode is "headed" (the --mode=headed override) — true for BOTH
+// Chromium-inclusive and Firefox-only hardware runs, not just Chromium.
+export function isHeadedRun(plan) {
+    return plan.mode === "hardware" && plan.effectiveMode === "headed";
+}
+
 // Build the ordered per-engine report entries for a run plan.
 export function reportEntriesFromPlan(plan, requestedEngines) {
     return requestedEngines
@@ -501,12 +509,16 @@ export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
             mode: "hardware",
             suiteEngines: [...requestedEngines],
             engines,
+            // The --mode override is applied uniformly across engines, so every
+            // verified engine shares one effective mode; it drives the headed
+            // suite dispatch (isHeadedRun) for Chromium-inclusive AND
+            // Firefox-only hardware runs alike.
+            effectiveMode:
+                verdicts[requestedEngines[0]]?.effectiveMode ?? "headless",
         };
         if (hasChromium) {
             plan.chromiumCandidate = verdicts.chromium.candidate;
             plan.chromiumExtraEnv = verdicts.chromium.extraEnv ?? {};
-            plan.chromiumEffectiveMode =
-                verdicts.chromium.effectiveMode ?? null;
         }
         if (requestsFirefox) {
             plan.firefoxRecipe = verdicts.firefox.candidate;
@@ -551,25 +563,50 @@ export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
     };
 }
 
-// Env for the actual suite run (spec 44 FR4: full Chromium suite, workers/
-// retries/timeouts untouched — those stay the config's own defaults).
-// Hardware mode injects the verified recipe via the merged PW_CHROMIUM_ARGS
-// hook; fallback mode guarantees the config's default SwiftShader args.
-//
-// NOTE (spec 52): this stays Chromium-scoped in plan phase engine_aware_core.
-// Plan phase two_engine_suite_and_inertness generalizes it to the requested
-// engine set (E2E_ENGINES=chromium,firefox with Firefox inheriting the Mesa env
-// from the suite process).
-export function suiteEnvFor(mode, baseEnv, candidate = null, extraEnv = {}) {
-    if (mode === "hardware") {
-        const env = composeEnv(baseEnv, candidate, extraEnv);
-        env.E2E_ENGINES = "chromium";
-        env.PW_CHROMIUM_ARGS = candidate.flags.join(" ");
+// Env for the actual suite run (spec 44 FR4 / spec 52 FR5: the full suite for
+// the resolved engine set, workers/retries/timeouts untouched — those stay the
+// config's own defaults). Consumes the run plan from computeRunPlan:
+//   - Hardware with Chromium in the set (Chromium alone OR Chromium+Firefox):
+//     inject the verified Chromium recipe's Mesa env into the suite process and
+//     set E2E_ENGINES to the resolved set; a two-engine run's Firefox INHERITS
+//     that same Mesa env with no new config hook (Decision 9). PW_CHROMIUM_ARGS
+//     stays Chromium-scoped.
+//   - Hardware, Firefox-only: inject the Firefox recipe's Mesa env directly
+//     (same GALLIUM_DRIVER + LD_LIBRARY_PATH); no PW_CHROMIUM_ARGS.
+//   - Software-fallback: the config's own SwiftShader defaults, Chromium only
+//     (Firefox is skipped, not run — Decision 6), exactly the #44 fallback.
+// skip-empty / abort run no suite, so calling this for them is a lane-internal
+// invariant violation (guarded below), not a reachable path.
+export function suiteEnvFor(plan, baseEnv) {
+    if (plan.mode === "hardware") {
+        const engineList = plan.suiteEngines.join(",");
+        if (plan.suiteEngines.includes("chromium")) {
+            const env = composeEnv(
+                baseEnv,
+                plan.chromiumCandidate,
+                plan.chromiumExtraEnv ?? {},
+            );
+            env.E2E_ENGINES = engineList;
+            env.PW_CHROMIUM_ARGS = plan.chromiumCandidate.flags.join(" ");
+            return env;
+        }
+        const env = composeEnv(
+            baseEnv,
+            plan.firefoxRecipe,
+            plan.firefoxExtraEnv ?? {},
+        );
+        env.E2E_ENGINES = engineList;
         return env;
     }
-    const env = fallbackEnv(baseEnv);
-    env.E2E_ENGINES = "chromium";
-    return env;
+    if (plan.mode === "software-fallback") {
+        const env = fallbackEnv(baseEnv);
+        env.E2E_ENGINES = "chromium";
+        return env;
+    }
+    throw new Error(
+        `suiteEnvFor: no suite runs for plan mode "${plan.mode}" ` +
+            "(skip-empty/abort must return before build/suite)",
+    );
 }
 
 // Headed mode reaches Playwright through the CLI flag — no config change.
@@ -1046,31 +1083,49 @@ async function runProbeOnly(args, controls, elapsedSeconds) {
     return 0;
 }
 
-// Full lane: build + suite, mirroring `test:smoke`.
-//
-// NOTE (spec 52): in plan phase engine_aware_core the suite run stays the
-// qualified #44 Chromium-only lane (the engine-aware probe added in this phase
-// is exercised via --probe-only). Plan phase two_engine_suite_and_inertness
-// generalizes this path to run the full requested engine set as one two-engine
-// suite (E2E_ENGINES=chromium,firefox), with the empty-engine-set skip and the
-// FR6 default-inert proof.
+// Full lane: build + suite, mirroring `test:smoke`. Probes the full requested
+// engine set, gates on computeRunPlan, and runs ONE Playwright invocation for
+// the resolved suite engine set (E2E_ENGINES=chromium,firefox for the default
+// two-engine hardware run; Chromium-only SwiftShader on honest fallback). An
+// empty engine set (Firefox-only, unverified) is never handed to Playwright.
 async function runFullLane(args, controls, elapsedSeconds) {
-    const suiteEngines = ["chromium"];
+    const requestedEngines = args.engines;
     const verdicts = controls.forceFallback
         ? {}
-        : await probeEngines(suiteEngines, args);
-    const plan = computeRunPlan({
-        requestedEngines: suiteEngines,
-        verdicts,
-        controls,
-    });
+        : await probeEngines(requestedEngines, args);
+    const plan = computeRunPlan({requestedEngines, verdicts, controls});
 
     if (plan.mode === "abort") {
+        // E2E_GPU_REQUIRE=1 and some requested engine did not verify hardware:
+        // fail before build/suite (Decision 5). Per-candidate diagnostics were
+        // already logged inline during probing.
         log(
-            "E2E_GPU_REQUIRE=1 — no hardware candidate verified; exiting " +
-                "non-zero instead of falling back",
+            "E2E_GPU_REQUIRE=1 — not every requested engine verified hardware " +
+                `(unverified: ${plan.unverified.join(", ")}); exiting non-zero ` +
+                "before build/suite",
         );
         return 1;
+    }
+
+    if (plan.mode === "skip-empty") {
+        // Empty engine set (Scenario 7): Firefox unverified and Chromium not
+        // requested. The lane MUST NOT invoke Playwright with an empty
+        // E2E_ENGINES (it trips the config's projects.length===0 guard), so it
+        // skips build/suite entirely and exits 0 — hardware absence is never a
+        // hard failure by default.
+        log(
+            "no verified engine to run (Firefox unverified, Chromium not " +
+                "requested) — skipping build and suite",
+        );
+        console.log(
+            formatReport({
+                mode: reportModeLabel(plan.mode),
+                engines: reportEntriesFromPlan(plan, requestedEngines),
+                suite: "skipped (no verified engine)",
+                wallClock: `${elapsedSeconds()}s`,
+            }),
+        );
+        return 0;
     }
 
     if (plan.mode === "software-fallback") {
@@ -1092,7 +1147,7 @@ async function runFullLane(args, controls, elapsedSeconds) {
         console.log(
             formatReport({
                 mode: reportModeLabel(plan.mode),
-                engines: reportEntriesFromPlan(plan, suiteEngines),
+                engines: reportEntriesFromPlan(plan, requestedEngines),
                 suite: `not-run (build failed, exit ${build.code})`,
                 wallClock: `${elapsedSeconds()}s (build ${build.seconds}s)`,
             }),
@@ -1100,22 +1155,11 @@ async function runFullLane(args, controls, elapsedSeconds) {
         return build.code;
     }
 
-    const headed =
-        plan.mode === "hardware" && plan.chromiumEffectiveMode === "headed";
-    const env =
-        plan.mode === "hardware"
-            ? suiteEnvFor(
-                  "hardware",
-                  process.env,
-                  plan.chromiumCandidate,
-                  plan.chromiumExtraEnv,
-              )
-            : suiteEnvFor("software-fallback", process.env);
     const suite = await runStage(
         "suite",
         "npx",
-        playwrightTestArgs(headed),
-        env,
+        playwrightTestArgs(isHeadedRun(plan)),
+        suiteEnvFor(plan, process.env),
     );
 
     if (plan.mode === "software-fallback") {
@@ -1124,7 +1168,7 @@ async function runFullLane(args, controls, elapsedSeconds) {
     console.log(
         formatReport({
             mode: reportModeLabel(plan.mode),
-            engines: reportEntriesFromPlan(plan, suiteEngines),
+            engines: reportEntriesFromPlan(plan, requestedEngines),
             suite: suiteResultLabel(suite.code),
             wallClock: formatWallClock(
                 elapsedSeconds(),

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -1,33 +1,55 @@
 #!/usr/bin/env node
-// Opt-in native-GPU local e2e lane (issue #44, spec/plan 44).
+// Opt-in native-GPU local e2e lane (issue #44 Chromium lane; issue #52 adds the
+// Firefox arm).
 //
 // This wrapper is ADDITIONAL tooling, never the green gate: `npm run validate`
 // and CI stay on the qualified SwiftShader serial path. It probes the host for
-// a usable hardware-WebGL recipe, verifies the effective renderer through the
-// repo's own Playwright Chromium BEFORE trusting anything, and runs the full
-// Chromium e2e suite under the verified flags (build → production server →
-// suite, mirroring `test:smoke`) — falling back loudly to default SwiftShader
-// rendering when no hardware candidate verifies.
+// a usable hardware-WebGL recipe PER ENGINE, verifies the effective renderer
+// through the repo's own Playwright browser BEFORE trusting anything, and runs
+// the full e2e suite under the verified configuration (build → production
+// server → suite, mirroring `test:smoke`) — falling back loudly to default
+// SwiftShader rendering (Chromium) when no hardware candidate verifies.
 //
-// Deterministic candidate lifecycle (spec FR3):
+// Two engines (issue #52):
+//   - Chromium is probed via the ANGLE candidate matrix (launch flags) + the
+//     Mesa d3d12 env. Its deterministic SwiftShader fallback is the CI gate.
+//   - Firefox is probed via the SAME Mesa env with NO ANGLE flags and a single
+//     probe recipe. Firefox privacy-sanitizes the unmasked renderer to
+//     "Generic Renderer", so the raw renderer is read through the ephemeral,
+//     PROBE-ONLY preference `webgl.sanitize-unmasked-renderer: false` (never
+//     applied to the application-suite Firefox profile). A sanitized string is
+//     treated as UNVERIFIABLE, never hardware. Firefox has no portable software
+//     equivalent, so on exhaustion it is SKIPPED (never an llvmpipe masquerade).
+//
+// Deterministic candidate lifecycle (spec 44 FR3, generalized per engine):
 //   1. prereq check   — unusable candidates are SKIPPED with an actionable
 //                       one-line diagnostic; they are never attempted.
 //   2. verification   — the candidate's renderer probe must return a string
 //                       that survives the deny-list (no SwiftShader/llvmpipe/
-//                       software rasterizer); crash/timeout/software ⇒ FAILED,
-//                       next candidate is tried.
-//   3. exhaustion     — all skipped/failed ⇒ loud software fallback. Never a
-//                       hard failure by default; E2E_GPU_REQUIRE=1 converts
-//                       exhaustion into a non-zero exit for qualification
-//                       integrity.
+//                       software rasterizer) and is not the sanitized Firefox
+//                       string; crash/timeout/software/sanitized ⇒ FAILED.
+//   3. exhaustion     — all skipped/failed ⇒ loud software fallback (Chromium)
+//                       and Firefox skipped. Never a hard failure by default;
+//                       E2E_GPU_REQUIRE=1 converts exhaustion of ANY requested
+//                       engine into a non-zero exit for qualification integrity.
 //
 // Env controls (read ONLY by this wrapper; nothing committed elsewhere reads
-// them — spec FR2/FR7):
-//   E2E_GPU_FORCE_FALLBACK=1  skip all hardware candidates; go straight to the
-//                             software-fallback path (how Scenario 2 is proven
-//                             on a GPU-capable host).
-//   E2E_GPU_REQUIRE=1         exit non-zero instead of falling back when no
-//                             candidate verifies (hardware-evidence integrity).
+// them — spec 44 FR2/FR7):
+//   E2E_GPU_FORCE_FALLBACK=1  skip all hardware probing; go straight to the
+//                             software-fallback path (Chromium SwiftShader,
+//                             Firefox skipped — how Scenario 2 is proven on a
+//                             GPU-capable host).
+//   E2E_GPU_REQUIRE=1         exit non-zero instead of falling back when any
+//                             requested engine does not verify hardware.
+//
+// CLI (read ONLY by this wrapper):
+//   --engine=chromium|firefox|all  select the probe/suite engine set (default
+//                                  `all` = both). `all` is the two-engine lane.
+//   --probe-only                   probe the requested engine set and print the
+//                                  per-engine report; run no build/suite.
+//   --mode/--candidate/--channel   Chromium recipe-debugging surface (spec 44
+//                                  FR5 matrix); a plain `npm run test:e2e:gpu`
+//                                  uses none of them.
 //
 // Recipe provenance: WSL2 Mesa d3d12 recipe proven end-to-end on this host
 // class in bugfix-22 / PR #43 (ANGLE→GL and ANGLE→GL-EGL both reached the
@@ -37,7 +59,8 @@
 // headless (headless shell), new-headless (--channel=chromium), and headed
 // WSLg all reach the adapter with identical renderer strings and identical
 // full-suite timing — so the lane defaults to HEADLESS and headed remains one
-// `--mode=headed` away.
+// `--mode=headed` away. Firefox hardware WebGL under the same Mesa d3d12 recipe
+// is proven in firefox-native-gpu-e2e-feasibility.md (2026-07-21, go verdict).
 
 import {spawn} from "node:child_process";
 import {existsSync, mkdirSync, writeFileSync} from "node:fs";
@@ -61,18 +84,32 @@ const PROBE_LOG_DIR = "gpu-lane-logs";
 const PROBE_TOTAL_TIMEOUT_MS = 45_000;
 const PROBE_LAUNCH_TIMEOUT_MS = 30_000;
 
-// Renderer deny-list (spec FR3): any match ⇒ software rendering. Markers from
-// experiment 42's probe plus the proven local strings.
+// The engines the lane can probe/run, in canonical report order.
+export const ENGINES = ["chromium", "firefox"];
+
+// Renderer deny-list (spec 44 FR3, expanded by spec 52 FR3/Decision 7): any
+// match ⇒ software rendering. Markers from experiment 42's probe, the proven
+// local strings, plus the Mesa software rasterizers Firefox can silently land
+// on (softpipe/lavapipe/swrast) when the d3d12 adapter is not selected.
 const SOFTWARE_RENDERER_MARKERS = [
     "swiftshader",
     "llvmpipe",
+    "softpipe",
+    "lavapipe",
+    "swrast",
     "software",
     "microsoft basic",
 ];
 
-// Data-driven candidate list, ordered by evidence strength (spec FR2: adding a
-// future recipe means appending an entry, not restructuring the lane).
-// Shape: {id, summary, hostClass, flags, env, envPrepend, mode}.
+// Firefox privacy-sanitizes the unmasked renderer to this string. It matches no
+// software marker, so without an explicit verdict it would falsely read as
+// hardware — hence a distinct UNVERIFIABLE class tied to the probe-only pref
+// (spec 52 FR3). Seeing it means the probe preference did not take.
+const SANITIZED_RENDERER_MARKERS = ["generic renderer"];
+
+// Data-driven Chromium candidate list, ordered by evidence strength (spec 44
+// FR2: adding a future recipe means appending an entry, not restructuring the
+// lane). Shape: {id, summary, hostClass, flags, env, envPrepend, mode}.
 export const CANDIDATES = [
     {
         id: "wsl2-d3d12-angle-gl",
@@ -132,6 +169,31 @@ export const CANDIDATES = [
     },
 ];
 
+// Single Firefox probe recipe (spec 52 Decision 3): the SAME Mesa d3d12 env as
+// Chromium, NO ANGLE flags (Firefox has prefs, not launch flags), the same WSL2
+// host-prereq gating as the Chromium candidates (reused via partitionCandidates
+// through the shared {hostClass, mode} shape), and probe-only Firefox prefs. The
+// sanitize pref is confined to this ephemeral probe browser; the committed
+// `firefox` Playwright project keeps `webgl.force-enabled: true` only.
+export const FIREFOX_PROBE_RECIPE = {
+    id: "wsl2-d3d12-firefox",
+    summary:
+        "WSL2 Mesa d3d12 via Firefox (no ANGLE flags; probe-only " +
+        "webgl.sanitize-unmasked-renderer=false to read the raw renderer)",
+    hostClass: "wsl2",
+    // No launch flags: Firefox reaches the d3d12 adapter through the Mesa env
+    // alone. `flags` stays an empty array so the shared candidate-shaped code
+    // (partitionCandidates, transcripts) has a uniform field to read.
+    flags: [],
+    env: {GALLIUM_DRIVER: "d3d12"},
+    envPrepend: {LD_LIBRARY_PATH: WSL_LIB_DIR},
+    firefoxUserPrefs: {
+        "webgl.force-enabled": true,
+        "webgl.sanitize-unmasked-renderer": false,
+    },
+    mode: "headless",
+};
+
 // ---------------------------------------------------------------------------
 // Pure logic (unit-tested in tests/gpu-lane.test.mjs; no I/O, no Playwright)
 // ---------------------------------------------------------------------------
@@ -140,11 +202,17 @@ export const CANDIDATES = [
 // every mode, unlike hardware absence which is never one by default.
 export class LaneUsageError extends Error {}
 
+// Classify a raw renderer string into exactly one verdict. Only "hardware" is
+// trusted; "unverifiable" is the Firefox sanitized string (probe pref did not
+// take); "software" is any deny-listed rasterizer; "none" is empty/absent.
 export function classifyRenderer(renderer) {
     if (typeof renderer !== "string" || renderer.trim().length === 0) {
         return "none";
     }
     const lower = renderer.toLowerCase();
+    if (SANITIZED_RENDERER_MARKERS.some((marker) => lower.includes(marker))) {
+        return "unverifiable";
+    }
     return SOFTWARE_RENDERER_MARKERS.some((marker) => lower.includes(marker))
         ? "software"
         : "hardware";
@@ -179,7 +247,8 @@ export function buildHostView({platform, exists, env}) {
 // `extraEnv` (e.g. a defaulted DISPLAY) and the `effectiveMode` (the
 // candidate's own mode unless overridden — the FR5 matrix probes headless
 // variants of headed candidates via the override). Skipped entries carry the
-// FR11 cause + remedy diagnostic.
+// FR11 cause + remedy diagnostic. Reused for both engines: the Firefox recipe
+// is candidate-shaped ({hostClass, mode}), so its host gating is identical.
 export function partitionCandidates(
     hostView,
     candidates = CANDIDATES,
@@ -280,20 +349,34 @@ export function fallbackEnv(baseEnv) {
     return env;
 }
 
-// FR11 diagnostic for a FAILED (attempted) candidate.
+// FR11 diagnostic for a FAILED (attempted) candidate. Names the engine and
+// points at the engine-tagged transcript so a two-engine run's failures are
+// never ambiguous about which browser produced them.
 export function failureDiagnostic(attempt) {
-    const {candidate, renderer, rendererClass, error, logPath} = attempt;
+    const {engine, candidate, renderer, rendererClass, error, logPath} = attempt;
+    const label = `${engine ? `${engine} ` : ""}candidate ${candidate.id}`;
     const where = logPath ? ` — probe transcript: ${logPath}` : "";
     if (error) {
         return (
-            `candidate ${candidate.id} FAILED (${error}) — probe crashed or ` +
+            `${label} FAILED (${error}) — probe crashed or ` +
             `timed out under this flag/env set${where}`
         );
     }
     if (rendererClass === "none") {
         return (
-            `candidate ${candidate.id} produced no usable WebGL context / ` +
+            `${label} produced no usable WebGL context / ` +
             `empty renderer string${where}`
+        );
+    }
+    if (rendererClass === "unverifiable") {
+        // The sanitized-renderer branch (spec 52 FR3/FR11): a Firefox probe that
+        // reports "Generic Renderer" means the probe-only preference did not
+        // take — the REMEDY is the preference, NOT the Mesa/adapter hint below.
+        return (
+            `${label} returned the sanitized renderer "${renderer}" — the ` +
+            "probe-only preference webgl.sanitize-unmasked-renderer=false did " +
+            "not take, so Firefox hid the true renderer (privacy-sanitized to " +
+            `"Generic Renderer"); this is UNVERIFIABLE, not hardware${where}`
         );
     }
     const mesaHint =
@@ -303,28 +386,180 @@ export function failureDiagnostic(attempt) {
               `LD_LIBRARY_PATH=${WSL_LIB_DIR})`
             : "adapter not reachable via this backend";
     return (
-        `candidate ${candidate.id} returned SOFTWARE renderer ` +
+        `${label} returned SOFTWARE renderer ` +
         `"${renderer}" — ${mesaHint}${where}`
     );
 }
 
-// Machine-greppable final report (spec FR10). Stable keys — the FR8 stability
-// evidence and future #41 qualification grep these exact lines.
-export function formatReport({mode, renderer, suite, wallClock}) {
+// Report line for one engine's outcome (spec 52 FR10). Stable phrasing — the
+// FR8 stability evidence and future #41 qualification grep these lines.
+export function engineReportLine(outcome) {
+    if (outcome.state === "hardware") {
+        return outcome.renderer;
+    }
+    if (outcome.state === "software-fallback") {
+        return "(software-fallback — SwiftShader)";
+    }
+    if (outcome.state === "skipped") {
+        return `skipped (unverified — ${outcome.reason})`;
+    }
+    return "(unknown)";
+}
+
+// Machine-greppable final report (spec 52 FR10). Replaces the #44 single
+// `engine: chromium` / `renderer:` lines with a per-engine contract. `engines`
+// is an ordered [{engine, renderer}] list; every requested engine gets exactly
+// one `renderer.<engine>` line (a skipped engine is represented explicitly,
+// never omitted silently).
+export function formatReport({mode, engines, suite, wallClock}) {
     return [
         "=== E2E GPU LANE REPORT ===",
         `mode: ${mode}`,
-        `renderer: ${renderer ?? "(none — suite ran without a probe verdict)"}`,
-        "engine: chromium",
+        `engines: ${engines.map((entry) => entry.engine).join(",")}`,
+        ...engines.map((entry) => `renderer.${entry.engine}: ${entry.renderer}`),
         `suite: ${suite}`,
         `wall-clock: ${wallClock}`,
     ].join("\n");
 }
 
-// Env for the actual suite run (spec FR4: full Chromium suite, workers/
+// The report `mode:` label for a run plan (spec 52 FR10: hardware |
+// software-fallback | skipped). skip-empty (no verified engine) reads as
+// "skipped"; abort never reaches a report.
+export function reportModeLabel(planMode) {
+    return planMode === "skip-empty" ? "skipped" : planMode;
+}
+
+// Build the ordered per-engine report entries for a run plan.
+export function reportEntriesFromPlan(plan, requestedEngines) {
+    return requestedEngines
+        .filter((engine) => plan.engines[engine])
+        .map((engine) => ({
+            engine,
+            renderer: engineReportLine(plan.engines[engine]),
+        }));
+}
+
+// Two-engine verification gating (spec 52 FR4, Decisions 4–6) — a PURE decision
+// function. Given the requested engine set, each engine's probe verdict, and
+// the controls, decide the run shape. Only "hardware" runs the combined suite;
+// non-strict exhaustion keeps Chromium's deterministic SwiftShader fallback and
+// SKIPS Firefox (never an llvmpipe masquerade); a Firefox-only set with no
+// hardware yields an empty engine set that must never reach Playwright
+// (skip-empty, exit 0); E2E_GPU_REQUIRE=1 aborts before build/suite.
+//
+// A verdict is {engine, verified, renderer, reason?, candidate?, extraEnv?,
+// effectiveMode?}. `verified` is true only for a hardware renderer.
+export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
+    const hasChromium = requestedEngines.includes("chromium");
+    const requestsFirefox = requestedEngines.includes("firefox");
+
+    // Forced software fallback: no probe was run. (FORCE_FALLBACK + REQUIRE is a
+    // usage error already rejected by parseControls.)
+    if (controls.forceFallback) {
+        if (hasChromium) {
+            const engines = {
+                chromium: {state: "software-fallback"},
+            };
+            if (requestsFirefox) {
+                engines.firefox = {
+                    state: "skipped",
+                    reason:
+                        "forced fallback, Firefox has no software equivalent",
+                };
+            }
+            return {mode: "software-fallback", suiteEngines: ["chromium"], engines};
+        }
+        // Firefox-only + forced fallback ⇒ vacuous no-op skip (spec 52 FR4):
+        // Firefox has no software path, so there is nothing to run. Exit 0.
+        return {
+            mode: "skip-empty",
+            suiteEngines: [],
+            engines: {
+                firefox: {
+                    state: "skipped",
+                    reason:
+                        "forced fallback, Firefox has no software equivalent",
+                },
+            },
+        };
+    }
+
+    const unverified = requestedEngines.filter(
+        (engine) => !verdicts[engine]?.verified,
+    );
+
+    // Every requested engine verified hardware ⇒ combined hardware run.
+    if (unverified.length === 0) {
+        const engines = {};
+        for (const engine of requestedEngines) {
+            engines[engine] = {
+                state: "hardware",
+                renderer: verdicts[engine].renderer,
+            };
+        }
+        const plan = {
+            mode: "hardware",
+            suiteEngines: [...requestedEngines],
+            engines,
+        };
+        if (hasChromium) {
+            plan.chromiumCandidate = verdicts.chromium.candidate;
+            plan.chromiumExtraEnv = verdicts.chromium.extraEnv ?? {};
+            plan.chromiumEffectiveMode =
+                verdicts.chromium.effectiveMode ?? null;
+        }
+        if (requestsFirefox) {
+            plan.firefoxRecipe = verdicts.firefox.candidate;
+            plan.firefoxExtraEnv = verdicts.firefox.extraEnv ?? {};
+        }
+        return plan;
+    }
+
+    // Not all verified. Strict mode aborts before any build/suite (Decision 5).
+    if (controls.requireHardware) {
+        const engines = {};
+        for (const engine of requestedEngines) {
+            const verdict = verdicts[engine];
+            engines[engine] = verdict?.verified
+                ? {state: "hardware", renderer: verdict.renderer}
+                : {state: "skipped", reason: verdict?.reason ?? "unverified"};
+        }
+        return {mode: "abort", suiteEngines: [], engines, unverified};
+    }
+
+    // Non-strict honest fallback (Decision 6).
+    if (hasChromium) {
+        const engines = {chromium: {state: "software-fallback"}};
+        if (requestsFirefox) {
+            engines.firefox = {
+                state: "skipped",
+                reason: verdicts.firefox?.reason ?? "unverified",
+            };
+        }
+        return {mode: "software-fallback", suiteEngines: ["chromium"], engines};
+    }
+    // Firefox-only, non-strict, unverified ⇒ empty engine set ⇒ skip, exit 0.
+    return {
+        mode: "skip-empty",
+        suiteEngines: [],
+        engines: {
+            firefox: {
+                state: "skipped",
+                reason: verdicts.firefox?.reason ?? "unverified",
+            },
+        },
+    };
+}
+
+// Env for the actual suite run (spec 44 FR4: full Chromium suite, workers/
 // retries/timeouts untouched — those stay the config's own defaults).
 // Hardware mode injects the verified recipe via the merged PW_CHROMIUM_ARGS
 // hook; fallback mode guarantees the config's default SwiftShader args.
+//
+// NOTE (spec 52): this stays Chromium-scoped in plan phase engine_aware_core.
+// Plan phase two_engine_suite_and_inertness generalizes it to the requested
+// engine set (E2E_ENGINES=chromium,firefox with Firefox inheriting the Mesa env
+// from the suite process).
 export function suiteEnvFor(mode, baseEnv, candidate = null, extraEnv = {}) {
     if (mode === "hardware") {
         const env = composeEnv(baseEnv, candidate, extraEnv);
@@ -373,6 +608,30 @@ export async function runSelection({usable, probe, log}) {
     return {status: "exhausted", attempts};
 }
 
+// Short human reason for an engine that did NOT verify hardware — used in the
+// report's `renderer.<engine>: skipped (unverified — <reason>)` line and the
+// start-of-run skip notice. The full per-candidate diagnostics are already
+// logged inline by runSelection; this is the one-line summary.
+export function engineSkipReason(attempts, skipped) {
+    if (attempts.length === 0) {
+        // Every recipe was skipped by the host-prereq check.
+        return skipped.length > 0
+            ? "host prerequisites not met (see per-candidate diagnostics)"
+            : "no usable recipe for this host";
+    }
+    const last = attempts[attempts.length - 1];
+    if (last.error) {
+        return `probe failed (${last.error})`;
+    }
+    if (last.rendererClass === "unverifiable") {
+        return `sanitized renderer "${last.renderer}" — probe preference did not take`;
+    }
+    if (last.rendererClass === "software") {
+        return `software renderer "${last.renderer}"`;
+    }
+    return "no usable WebGL context";
+}
+
 // ---------------------------------------------------------------------------
 // Side-effectful pieces (probe + CLI)
 // ---------------------------------------------------------------------------
@@ -381,7 +640,7 @@ function timestamp() {
     return new Date().toISOString();
 }
 
-// Launch the repo's own Playwright Chromium under the candidate's flags/env
+// Launch the repo's own Playwright browser under the candidate's flags/env/prefs
 // and read the effective UNMASKED_RENDERER_WEBGL. The page-side body is a
 // string because it runs in the browser, not in Node (and the file's lint
 // scope is Node globals only).
@@ -408,21 +667,26 @@ function writeTranscriptFile(logPath, text) {
     writeFileSync(logPath, text);
 }
 
-async function importChromium() {
-    const {chromium} = await import("@playwright/test");
-    return chromium;
+// Resolve the Playwright BrowserType for an engine. Injected in tests.
+async function importBrowserType(engine) {
+    const pw = await import("@playwright/test");
+    return engine === "firefox" ? pw.firefox : pw.chromium;
 }
 
 // Exported for the timed-out-probe cleanup tests: `launcher`, timeouts, and
 // transcript writing are injectable; defaults are the real Playwright path.
+// The launch differs per engine — Chromium takes `args` (+ optional channel),
+// Firefox takes `firefoxUserPrefs` — but the watchdog/late-reap/bounded-close
+// machinery is engine-independent.
 export async function probeRenderer(
     candidate,
     extraEnv,
     {
+        engine = "chromium",
         baseEnv,
         headless,
         channel = null,
-        launcher = importChromium,
+        launcher = importBrowserType,
         totalTimeoutMs = PROBE_TOTAL_TIMEOUT_MS,
         launchTimeoutMs = PROBE_LAUNCH_TIMEOUT_MS,
         closeTimeoutMs = 5_000,
@@ -432,17 +696,22 @@ export async function probeRenderer(
     const startedAt = Date.now();
     const transcript = [];
     const logLine = (line) => transcript.push(`${timestamp()} ${line}`);
-    // One transcript per matrix cell: mode (and channel, when probing the
-    // full-binary new-headless variant) distinguish repeat probes of the same
-    // candidate from each other instead of overwriting.
+    // One transcript per matrix cell: engine + mode (and channel, when probing
+    // the full-binary new-headless Chromium variant) distinguish repeat probes
+    // from each other instead of overwriting.
     const logPath = join(
         PROBE_LOG_DIR,
-        `probe-${candidate.id}-${headless ? "headless" : "headed"}` +
+        `probe-${engine}-${candidate.id}-${headless ? "headless" : "headed"}` +
             `${channel ? `-${channel}` : ""}.log`,
     );
     const env = composeEnv(baseEnv, candidate, extraEnv);
+    logLine(`engine: ${engine}`);
     logLine(`candidate: ${candidate.id} (${candidate.summary})`);
-    logLine(`flags: ${candidate.flags.join(" ")}`);
+    if (engine === "firefox") {
+        logLine(`prefs: ${JSON.stringify(candidate.firefoxUserPrefs)}`);
+    } else {
+        logLine(`flags: ${candidate.flags.join(" ")}`);
+    }
     logLine(
         `env injected: ${JSON.stringify({
             ...candidate.env,
@@ -458,15 +727,18 @@ export async function probeRenderer(
     logLine(`mode: ${headless ? "headless" : "headed"}`);
     logLine(
         `binary: ${
-            channel
-                ? `channel "${channel}" (full Chromium, new headless)`
-                : headless
-                  ? "playwright default headless (chromium headless shell)"
-                  : "playwright chromium (full binary, headed)"
+            engine === "firefox"
+                ? "playwright firefox"
+                : channel
+                  ? `channel "${channel}" (full Chromium, new headless)`
+                  : headless
+                    ? "playwright default headless (chromium headless shell)"
+                    : "playwright chromium (full binary, headed)"
         }`,
     );
 
     const attempt = {
+        engine,
         candidate,
         headless,
         renderer: null,
@@ -479,20 +751,27 @@ export async function probeRenderer(
 
     // The launch promise is captured OUTSIDE the raced work so a watchdog win
     // can still reap a late-resolving browser: without this, a timeout firing
-    // before launch resolves would orphan the Chromium process and keep the
+    // before launch resolves would orphan the browser process and keep the
     // lane alive (Codex impl-review, iteration 1).
     let launchPromise = null;
     let timer = null;
     try {
-        const chromium = await launcher();
+        const browserType = await launcher(engine);
+        const launchOptions = {
+            headless,
+            env,
+            timeout: launchTimeoutMs,
+        };
+        if (engine === "firefox") {
+            launchOptions.firefoxUserPrefs = candidate.firefoxUserPrefs;
+        } else {
+            launchOptions.args = candidate.flags;
+            if (channel) {
+                launchOptions.channel = channel;
+            }
+        }
         const work = (async () => {
-            launchPromise = chromium.launch({
-                headless,
-                ...(channel ? {channel} : {}),
-                args: candidate.flags,
-                env,
-                timeout: launchTimeoutMs,
-            });
+            launchPromise = browserType.launch(launchOptions);
             const browser = await launchPromise;
             const page = await browser.newPage();
             return page.evaluate(PROBE_PAGE_SCRIPT);
@@ -561,14 +840,44 @@ function fallbackWarning(reason) {
     }
 }
 
+// The recipe set to probe for an engine. Chromium iterates the ANGLE candidate
+// matrix (optionally narrowed by --candidate); Firefox has a single recipe.
+function recipesForEngine(engine, args) {
+    if (engine === "firefox") {
+        return [FIREFOX_PROBE_RECIPE];
+    }
+    return args.candidate
+        ? CANDIDATES.filter((candidate) => candidate.id === args.candidate)
+        : CANDIDATES;
+}
+
 // Exported for tests. --mode/--candidate/--channel exist for the FR5
 // headless-vs-headed matrix and recipe debugging; a plain `npm run
-// test:e2e:gpu` uses none of them.
+// test:e2e:gpu` uses none of them. --engine selects the engine set (spec 52
+// FR7): `all` (default) is the two-engine lane.
 export function parseArgs(argv) {
-    const args = {probeOnly: false, mode: null, candidate: null, channel: null};
+    const args = {
+        probeOnly: false,
+        mode: null,
+        candidate: null,
+        channel: null,
+        engines: [...ENGINES],
+    };
     for (const arg of argv) {
         if (arg === "--probe-only") {
             args.probeOnly = true;
+        } else if (arg.startsWith("--engine=")) {
+            const value = arg.slice("--engine=".length);
+            if (value === "all") {
+                args.engines = [...ENGINES];
+            } else if (ENGINES.includes(value)) {
+                args.engines = [value];
+            } else {
+                throw new LaneUsageError(
+                    `--engine must be "chromium", "firefox", or "all", got ` +
+                        `"${value}"`,
+                );
+            }
         } else if (arg.startsWith("--mode=")) {
             const value = arg.slice("--mode=".length);
             if (value !== "headed" && value !== "headless") {
@@ -622,18 +931,58 @@ function runStage(label, command, commandArgs, env) {
     });
 }
 
-// Probe the host and settle on the run mode (FR2/FR3). Returns
-// {mode: "hardware", candidate, extraEnv, effectiveMode, renderer} |
-// {mode: "software-fallback", renderer} | {mode: "abort"} (E2E_GPU_REQUIRE).
-async function resolveMode(controls, args) {
-    if (controls.forceFallback) {
-        fallbackWarning("forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)");
+// Probe a single engine and return its verdict:
+//   {engine, verified, renderer, rendererClass, reason?, candidate?, extraEnv?,
+//    effectiveMode?}
+// `verified` is true only for a hardware renderer; the winning candidate/env is
+// carried for the suite run (Chromium: the ANGLE candidate; Firefox: the recipe).
+async function probeSingleEngine(engine, hostView, args) {
+    const recipes = recipesForEngine(engine, args);
+    const {usable, skipped} = partitionCandidates(hostView, recipes, args.mode);
+    for (const skip of skipped) {
+        log(`[${engine}] candidate ${skip.candidate.id} SKIPPED: ${skip.diagnostic}`);
+    }
+    const selection = await runSelection({
+        usable,
+        probe: (candidate, extraEnv, effectiveMode) =>
+            probeRenderer(candidate, extraEnv, {
+                engine,
+                baseEnv: process.env,
+                headless: effectiveMode !== "headed",
+                channel: engine === "chromium" ? args.channel : null,
+            }),
+        log,
+    });
+
+    if (selection.status === "hardware") {
+        const usableEntry = usable.find(
+            (entry) => entry.candidate === selection.attempt.candidate,
+        );
         return {
-            mode: "software-fallback",
-            renderer: "(not probed — default SwiftShader args used)",
+            engine,
+            verified: true,
+            renderer: selection.attempt.renderer,
+            rendererClass: "hardware",
+            candidate: selection.attempt.candidate,
+            extraEnv: usableEntry?.extraEnv ?? {},
+            effectiveMode:
+                usableEntry?.effectiveMode ??
+                selection.attempt.candidate.mode,
         };
     }
 
+    const last = selection.attempts[selection.attempts.length - 1];
+    return {
+        engine,
+        verified: false,
+        renderer: last?.renderer ?? null,
+        rendererClass: last?.rendererClass ?? "none",
+        reason: engineSkipReason(selection.attempts, skipped),
+    };
+}
+
+// Probe every requested engine and return a {engine: verdict} map.
+async function probeEngines(requestedEngines, args) {
     const hostView = buildHostView({
         platform: process.platform,
         exists: existsSync,
@@ -644,100 +993,106 @@ async function resolveMode(controls, args) {
             `wslLib=${hostView.hasWslLib} wslgSocket=${hostView.hasWslgSocket} ` +
             `DISPLAY=${hostView.display ?? "(unset)"}`,
     );
-    const candidates = args.candidate
-        ? CANDIDATES.filter((candidate) => candidate.id === args.candidate)
-        : CANDIDATES;
-    const {usable, skipped} = partitionCandidates(
-        hostView,
-        candidates,
-        args.mode,
-    );
-    for (const skip of skipped) {
-        log(`candidate ${skip.candidate.id} SKIPPED: ${skip.diagnostic}`);
+    const verdicts = {};
+    for (const engine of requestedEngines) {
+        verdicts[engine] = await probeSingleEngine(engine, hostView, args);
     }
-
-    const selection = await runSelection({
-        usable,
-        probe: (candidate, extraEnv, effectiveMode) =>
-            probeRenderer(candidate, extraEnv, {
-                baseEnv: process.env,
-                headless: effectiveMode !== "headed",
-                channel: args.channel,
-            }),
-        log,
-    });
-
-    if (selection.status === "hardware") {
-        const usableEntry = usable.find(
-            (entry) => entry.candidate === selection.attempt.candidate,
-        );
-        return {
-            mode: "hardware",
-            candidate: selection.attempt.candidate,
-            extraEnv: usableEntry?.extraEnv ?? {},
-            effectiveMode:
-                usableEntry?.effectiveMode ??
-                selection.attempt.candidate.mode,
-            renderer: selection.attempt.renderer,
-        };
-    }
-
-    // Exhausted. Summarize every skip/failure (FR11) before deciding.
-    log("no hardware candidate verified; summary:");
-    for (const skip of skipped) {
-        log(`  SKIPPED ${skip.candidate.id}: ${skip.diagnostic}`);
-    }
-    for (const attempt of selection.attempts) {
-        log(`  FAILED  ${failureDiagnostic(attempt)}`);
-    }
-    if (controls.requireHardware) {
-        log("E2E_GPU_REQUIRE=1 — exiting non-zero instead of falling back");
-        return {mode: "abort"};
-    }
-    fallbackWarning(
-        "no usable hardware candidate (see per-candidate diagnostics above)",
-    );
-    return {
-        mode: "software-fallback",
-        renderer: "(no hardware renderer — default SwiftShader args used)",
-    };
+    return verdicts;
 }
 
-async function main() {
-    const args = parseArgs(process.argv.slice(2));
-    const controls = parseControls(process.env);
-    const startedAt = Date.now();
-    const elapsedSeconds = () => Math.round((Date.now() - startedAt) / 1000);
+// --probe-only: probe the requested engine set and print the per-engine report;
+// run no build/suite. Reports each engine's ACTUAL probe result (a probe is a
+// diagnostic, not a run), while `mode:` reflects what a full run WOULD be.
+async function runProbeOnly(args, controls, elapsedSeconds) {
+    const requestedEngines = args.engines;
+    if (controls.forceFallback) {
+        fallbackWarning(
+            "forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)",
+        );
+    }
+    const verdicts = controls.forceFallback
+        ? {}
+        : await probeEngines(requestedEngines, args);
+    const plan = computeRunPlan({requestedEngines, verdicts, controls});
 
-    const outcome = await resolveMode(controls, args);
-    if (outcome.mode === "abort") {
+    if (plan.mode === "abort") {
+        log(
+            "E2E_GPU_REQUIRE=1 — not every requested engine verified hardware; " +
+                "exiting non-zero",
+        );
         return 1;
     }
 
-    if (args.probeOnly) {
-        console.log(
-            formatReport({
-                mode: outcome.mode,
-                renderer: outcome.renderer,
-                suite: "skipped (--probe-only)",
-                wallClock: `${elapsedSeconds()}s`,
-            }),
+    const engines = requestedEngines.map((engine) => {
+        if (controls.forceFallback) {
+            return {engine, renderer: engineReportLine(plan.engines[engine])};
+        }
+        const verdict = verdicts[engine];
+        return {
+            engine,
+            renderer: verdict.verified
+                ? verdict.renderer
+                : `skipped (unverified — ${verdict.reason})`,
+        };
+    });
+    console.log(
+        formatReport({
+            mode: reportModeLabel(plan.mode),
+            engines,
+            suite: "skipped (--probe-only)",
+            wallClock: `${elapsedSeconds()}s`,
+        }),
+    );
+    return 0;
+}
+
+// Full lane: build + suite, mirroring `test:smoke`.
+//
+// NOTE (spec 52): in plan phase engine_aware_core the suite run stays the
+// qualified #44 Chromium-only lane (the engine-aware probe added in this phase
+// is exercised via --probe-only). Plan phase two_engine_suite_and_inertness
+// generalizes this path to run the full requested engine set as one two-engine
+// suite (E2E_ENGINES=chromium,firefox), with the empty-engine-set skip and the
+// FR6 default-inert proof.
+async function runFullLane(args, controls, elapsedSeconds) {
+    const suiteEngines = ["chromium"];
+    const verdicts = controls.forceFallback
+        ? {}
+        : await probeEngines(suiteEngines, args);
+    const plan = computeRunPlan({
+        requestedEngines: suiteEngines,
+        verdicts,
+        controls,
+    });
+
+    if (plan.mode === "abort") {
+        log(
+            "E2E_GPU_REQUIRE=1 — no hardware candidate verified; exiting " +
+                "non-zero instead of falling back",
         );
-        return 0;
+        return 1;
     }
 
-    // Full lane: build + suite, mirroring `test:smoke` (build && playwright
-    // test; the production server comes from the config's webServer block).
-    // The build never needs recipe env; it runs under the untouched
-    // inherited env in both modes.
+    if (plan.mode === "software-fallback") {
+        // FR3: the fallback notice appears at start AND with the final report,
+        // so fallback output can never read as hardware evidence.
+        fallbackWarning(
+            controls.forceFallback
+                ? "forced by E2E_GPU_FORCE_FALLBACK=1 (no probe was run)"
+                : "no usable hardware candidate (see per-candidate diagnostics above)",
+        );
+    }
+
+    // The build never needs recipe env; it runs under the untouched inherited
+    // env in both modes.
     const build = await runStage("build", "npm", ["run", "build"], process.env);
     if (build.code !== 0) {
         // A failed build is a lane-internal hard failure in every mode (FR3).
         log(`build FAILED (exit ${build.code}) — not running the suite`);
         console.log(
             formatReport({
-                mode: outcome.mode,
-                renderer: outcome.renderer,
+                mode: reportModeLabel(plan.mode),
+                engines: reportEntriesFromPlan(plan, suiteEngines),
                 suite: `not-run (build failed, exit ${build.code})`,
                 wallClock: `${elapsedSeconds()}s (build ${build.seconds}s)`,
             }),
@@ -746,24 +1101,30 @@ async function main() {
     }
 
     const headed =
-        outcome.mode === "hardware" && outcome.effectiveMode === "headed";
+        plan.mode === "hardware" && plan.chromiumEffectiveMode === "headed";
+    const env =
+        plan.mode === "hardware"
+            ? suiteEnvFor(
+                  "hardware",
+                  process.env,
+                  plan.chromiumCandidate,
+                  plan.chromiumExtraEnv,
+              )
+            : suiteEnvFor("software-fallback", process.env);
     const suite = await runStage(
         "suite",
         "npx",
         playwrightTestArgs(headed),
-        suiteEnvFor(outcome.mode, process.env, outcome.candidate,
-            outcome.extraEnv),
+        env,
     );
 
-    if (outcome.mode === "software-fallback") {
-        // FR3: the fallback notice appears at start AND with the final
-        // report, so fallback output can never read as hardware evidence.
+    if (plan.mode === "software-fallback") {
         fallbackWarning("this suite ran under SOFTWARE rendering (see above)");
     }
     console.log(
         formatReport({
-            mode: outcome.mode,
-            renderer: outcome.renderer,
+            mode: reportModeLabel(plan.mode),
+            engines: reportEntriesFromPlan(plan, suiteEngines),
             suite: suiteResultLabel(suite.code),
             wallClock: formatWallClock(
                 elapsedSeconds(),
@@ -774,6 +1135,18 @@ async function main() {
     );
     // The suite's own pass/fail semantics are the lane's exit code (FR3).
     return suite.code;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const controls = parseControls(process.env);
+    const startedAt = Date.now();
+    const elapsedSeconds = () => Math.round((Date.now() - startedAt) / 1000);
+
+    if (args.probeOnly) {
+        return runProbeOnly(args, controls, elapsedSeconds);
+    }
+    return runFullLane(args, controls, elapsedSeconds);
 }
 
 const isMain =

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -403,6 +403,12 @@ export function engineReportLine(outcome) {
     if (outcome.state === "skipped") {
         return `skipped (unverified — ${outcome.reason})`;
     }
+    if (outcome.state === "not-run") {
+        // Verified hardware, but not run — e.g. a two-engine hardware run needs
+        // both engines and the sibling engine failed, so the run fell back to
+        // Chromium-only. This is NOT "unverified" (the engine passed its probe).
+        return `not run (${outcome.reason})`;
+    }
     return "(unknown)";
 }
 
@@ -543,10 +549,24 @@ export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
     if (hasChromium) {
         const engines = {chromium: {state: "software-fallback"}};
         if (requestsFirefox) {
-            engines.firefox = {
-                state: "skipped",
-                reason: verdicts.firefox?.reason ?? "unverified",
-            };
+            // Firefox is dropped from the run either way (Decision 6: the
+            // fallback is Chromium-only). Report WHY honestly: if Firefox itself
+            // failed verification, its own reason; if Firefox VERIFIED hardware
+            // but the combined run couldn't happen because Chromium failed, say
+            // so — never label a verified Firefox "unverified".
+            engines.firefox = verdicts.firefox?.verified
+                ? {
+                      state: "not-run",
+                      reason:
+                          "Chromium unverified — a two-engine hardware run needs " +
+                          "both engines, so the run fell back to Chromium " +
+                          "SwiftShader; Firefox verified hardware but is not run " +
+                          "(no software equivalent to pair with the fallback)",
+                  }
+                : {
+                      state: "skipped",
+                      reason: verdicts.firefox?.reason ?? "unverified",
+                  };
         }
         return {mode: "software-fallback", suiteEngines: ["chromium"], engines};
     }

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -22,6 +22,7 @@ import {
     fallbackEnv,
     formatReport,
     formatWallClock,
+    isHeadedRun,
     parseArgs,
     parseControls,
     partitionCandidates,
@@ -524,13 +525,14 @@ function chromiumHardwareVerdict() {
         effectiveMode: "headless",
     };
 }
-function firefoxHardwareVerdict() {
+function firefoxHardwareVerdict(effectiveMode = "headless", extraEnv = {}) {
     return {
         engine: "firefox",
         verified: true,
         renderer: FIREFOX_HW,
         candidate: FIREFOX_PROBE_RECIPE,
-        extraEnv: {},
+        extraEnv,
+        effectiveMode,
     };
 }
 function firefoxSoftwareVerdict() {
@@ -560,7 +562,7 @@ test("computeRunPlan: both engines hardware ⇒ combined two-engine hardware run
     assert.equal(plan.engines.firefox.renderer, FIREFOX_HW);
     // Suite-env carriers for Phase 2.
     assert.equal(plan.chromiumCandidate.id, "wsl2-d3d12-angle-gl");
-    assert.equal(plan.chromiumEffectiveMode, "headless");
+    assert.equal(plan.effectiveMode, "headless");
     assert.equal(plan.firefoxRecipe.id, "wsl2-d3d12-firefox");
 });
 
@@ -633,6 +635,49 @@ test("computeRunPlan: single-engine Firefox hardware runs Firefox alone", () => 
     assert.equal(plan.engines.firefox.renderer, FIREFOX_HW);
     assert.equal(plan.firefoxRecipe.id, "wsl2-d3d12-firefox");
     assert.equal(Object.hasOwn(plan, "chromiumCandidate"), false);
+    assert.equal(plan.effectiveMode, "headless");
+});
+
+test("isHeadedRun: the headed suite decision covers Firefox-only hardware (not just Chromium)", () => {
+    // Regression guard (Codex phase-2 review): a hardware --engine=firefox
+    // --mode=headed run must dispatch headed. The plan's run-level effectiveMode
+    // (not a Chromium-only field) drives this, so Firefox-only headed works.
+    const chromiumHeaded = computeRunPlan({
+        requestedEngines: ["chromium"],
+        verdicts: {
+            chromium: {
+                ...chromiumHardwareVerdict(),
+                effectiveMode: "headed",
+                extraEnv: {DISPLAY: ":0"},
+            },
+        },
+        controls: nonStrict,
+    });
+    assert.equal(chromiumHeaded.effectiveMode, "headed");
+    assert.equal(isHeadedRun(chromiumHeaded), true);
+
+    const firefoxHeaded = computeRunPlan({
+        requestedEngines: ["firefox"],
+        verdicts: {firefox: firefoxHardwareVerdict("headed", {DISPLAY: ":0"})},
+        controls: nonStrict,
+    });
+    assert.equal(firefoxHeaded.effectiveMode, "headed");
+    // The bug was here: without a run-level effectiveMode this returned false.
+    assert.equal(isHeadedRun(firefoxHeaded), true);
+    // The headed DISPLAY extraEnv reaches the Firefox suite env.
+    assert.equal(suiteEnvFor(firefoxHeaded, {PATH: "/usr/bin"}).DISPLAY, ":0");
+
+    // Default headless hardware and software-fallback are never headed.
+    const headless = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: chromiumHardwareVerdict(),
+            firefox: firefoxHardwareVerdict(),
+        },
+        controls: nonStrict,
+    });
+    assert.equal(isHeadedRun(headless), false);
+    assert.equal(isHeadedRun({mode: "software-fallback"}), false);
 });
 
 test("computeRunPlan: single-engine Firefox unverified, non-strict ⇒ empty-set skip (exit 0), no suite", () => {
@@ -916,15 +961,20 @@ test("partitionCandidates: headless default has no display prereq (FR5 outcome)"
     }
 });
 
-test("suiteEnvFor hardware: recipe env + PW_CHROMIUM_ARGS + chromium-only engine", () => {
+test("suiteEnvFor two-engine hardware: E2E_ENGINES=chromium,firefox; Firefox inherits the Chromium recipe's Mesa env", () => {
     const base = {PATH: "/usr/bin", LD_LIBRARY_PATH: "/opt/lib"};
-    const env = suiteEnvFor(
-        "hardware",
-        base,
-        candidateById("wsl2-d3d12-angle-gl"),
-        {DISPLAY: ":0"},
-    );
-    assert.equal(env.E2E_ENGINES, "chromium");
+    const plan = {
+        mode: "hardware",
+        suiteEngines: ["chromium", "firefox"],
+        chromiumCandidate: candidateById("wsl2-d3d12-angle-gl"),
+        chromiumExtraEnv: {DISPLAY: ":0"},
+        firefoxRecipe: FIREFOX_PROBE_RECIPE,
+        firefoxExtraEnv: {},
+    };
+    const env = suiteEnvFor(plan, base);
+    // The resolved set is passed verbatim; Firefox has no separate wiring — it
+    // inherits GALLIUM_DRIVER + LD_LIBRARY_PATH from the injected Mesa env.
+    assert.equal(env.E2E_ENGINES, "chromium,firefox");
     assert.equal(
         env.PW_CHROMIUM_ARGS,
         "--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox",
@@ -937,6 +987,38 @@ test("suiteEnvFor hardware: recipe env + PW_CHROMIUM_ARGS + chromium-only engine
     assert.equal(base.LD_LIBRARY_PATH, "/opt/lib");
 });
 
+test("suiteEnvFor single-engine Chromium hardware: exact #44 env (E2E_ENGINES=chromium)", () => {
+    const base = {PATH: "/usr/bin", LD_LIBRARY_PATH: "/opt/lib"};
+    const plan = {
+        mode: "hardware",
+        suiteEngines: ["chromium"],
+        chromiumCandidate: candidateById("wsl2-d3d12-angle-gl"),
+        chromiumExtraEnv: {},
+    };
+    const env = suiteEnvFor(plan, base);
+    assert.equal(env.E2E_ENGINES, "chromium");
+    assert.equal(
+        env.PW_CHROMIUM_ARGS,
+        "--use-gl=angle --use-angle=gl --ignore-gpu-blocklist --disable-gpu-sandbox",
+    );
+    assert.equal(env.GALLIUM_DRIVER, "d3d12");
+});
+
+test("suiteEnvFor Firefox-only hardware: Firefox Mesa env, E2E_ENGINES=firefox, NO PW_CHROMIUM_ARGS", () => {
+    const base = {PATH: "/usr/bin", LD_LIBRARY_PATH: "/opt/lib"};
+    const plan = {
+        mode: "hardware",
+        suiteEngines: ["firefox"],
+        firefoxRecipe: FIREFOX_PROBE_RECIPE,
+        firefoxExtraEnv: {},
+    };
+    const env = suiteEnvFor(plan, base);
+    assert.equal(env.E2E_ENGINES, "firefox");
+    assert.equal(Object.hasOwn(env, "PW_CHROMIUM_ARGS"), false);
+    assert.equal(env.GALLIUM_DRIVER, "d3d12");
+    assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib:/opt/lib");
+});
+
 test("suiteEnvFor fallback: default SwiftShader args guaranteed, no recipe leakage", () => {
     // Even a shell-exported PW_CHROMIUM_ARGS must not survive into the
     // fallback suite — fallback means the config's own SwiftShader defaults.
@@ -945,12 +1027,26 @@ test("suiteEnvFor fallback: default SwiftShader args guaranteed, no recipe leaka
         PW_CHROMIUM_ARGS: "--use-gl=angle",
         LD_LIBRARY_PATH: "/opt/lib",
     };
-    const env = suiteEnvFor("software-fallback", base);
+    const env = suiteEnvFor({mode: "software-fallback", suiteEngines: ["chromium"]}, base);
     assert.equal(Object.hasOwn(env, "PW_CHROMIUM_ARGS"), false);
     assert.equal(env.E2E_ENGINES, "chromium");
     assert.equal(Object.hasOwn(env, "GALLIUM_DRIVER"), false);
     // Operator-owned values pass through untouched.
     assert.equal(env.LD_LIBRARY_PATH, "/opt/lib");
+});
+
+test("suiteEnvFor: skip-empty / abort never produce a suite env (no empty E2E_ENGINES)", () => {
+    // Scenario 7 invariant: an empty engine set must never reach Playwright.
+    // runFullLane returns before build/suite for these modes; suiteEnvFor
+    // refuses them outright as a belt-and-suspenders guard.
+    assert.throws(
+        () => suiteEnvFor({mode: "skip-empty", suiteEngines: []}, {}),
+        /no suite runs for plan mode "skip-empty"/,
+    );
+    assert.throws(
+        () => suiteEnvFor({mode: "abort", suiteEngines: []}, {}),
+        /no suite runs for plan mode "abort"/,
+    );
 });
 
 test("playwrightTestArgs: headed reaches Playwright via the CLI flag only", () => {

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -1,6 +1,7 @@
-// Unit coverage for the opt-in native-GPU lane's pure logic (issue #44).
+// Unit coverage for the opt-in native-GPU lane's pure logic (issue #44 Chromium
+// lane; issue #52 Firefox arm).
 //
-// Everything here is GPU-free, browser-free, and lane-env-free (spec FR7):
+// Everything here is GPU-free, browser-free, and lane-env-free (spec 44 FR7):
 // the probe is injected as a plain async function, host facts are injected as
 // a fake view, and importing the wrapper module must never launch anything.
 import assert from "node:assert/strict";
@@ -8,10 +9,15 @@ import test from "node:test";
 
 import {
     CANDIDATES,
+    ENGINES,
+    FIREFOX_PROBE_RECIPE,
     LaneUsageError,
     buildHostView,
     classifyRenderer,
     composeEnv,
+    computeRunPlan,
+    engineReportLine,
+    engineSkipReason,
     failureDiagnostic,
     fallbackEnv,
     formatReport,
@@ -21,6 +27,8 @@ import {
     partitionCandidates,
     playwrightTestArgs,
     probeRenderer,
+    reportEntriesFromPlan,
+    reportModeLabel,
     runSelection,
     suiteEnvFor,
     suiteResultLabel,
@@ -42,6 +50,11 @@ const nativeLinuxHost = {
     display: null,
 };
 
+// The exact renderer strings recorded in the evidence artifacts.
+const CHROMIUM_HW =
+    "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)";
+const FIREFOX_HW = "D3D12 (NVIDIA GeForce RTX 3080)";
+
 function candidateById(id) {
     const candidate = CANDIDATES.find((entry) => entry.id === id);
     assert.ok(candidate, `unknown candidate fixture id: ${id}`);
@@ -49,21 +62,18 @@ function candidateById(id) {
 }
 
 test("classifyRenderer: proven hardware strings survive the deny-list", () => {
-    // The exact strings recorded in bugfix-22 (WSL2 d3d12) and experiment 42
-    // run #5 (Kaggle T4).
-    assert.equal(
-        classifyRenderer(
-            "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
-        ),
-        "hardware",
-    );
+    // The exact strings recorded in bugfix-22 (WSL2 d3d12), experiment 42
+    // run #5 (Kaggle T4), and the Firefox feasibility report (raw renderer read
+    // through the probe-only sanitize pref).
+    assert.equal(classifyRenderer(CHROMIUM_HW), "hardware");
     assert.equal(
         classifyRenderer("ANGLE (NVIDIA Corporation, Tesla T4/PCIe/SSE2, OpenGL ES 3.2)"),
         "hardware",
     );
+    assert.equal(classifyRenderer(FIREFOX_HW), "hardware");
 });
 
-test("classifyRenderer: software rasterizers are denied", () => {
+test("classifyRenderer: software rasterizers are denied (expanded deny-list)", () => {
     assert.equal(
         classifyRenderer(
             "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)",
@@ -71,14 +81,24 @@ test("classifyRenderer: software rasterizers are denied", () => {
         "software",
     );
     assert.equal(
-        classifyRenderer("llvmpipe (LLVM 15.0.7, 256 bits)"),
+        classifyRenderer("llvmpipe (LLVM 21.1.8, 256 bits)"),
         "software",
     );
     assert.equal(classifyRenderer("Microsoft Basic Render Driver"), "software");
-    assert.equal(
-        classifyRenderer("Google SwiftShader"),
-        "software",
-    );
+    assert.equal(classifyRenderer("Google SwiftShader"), "software");
+    // Spec 52 Decision 7 additions: the Mesa software rasterizers Firefox can
+    // land on when the d3d12 adapter is not selected.
+    assert.equal(classifyRenderer("softpipe"), "software");
+    assert.equal(classifyRenderer("llvmpipe (LLVM 21.1.8, 256 bits) lavapipe"), "software");
+    assert.equal(classifyRenderer("Mesa swrast"), "software");
+});
+
+test("classifyRenderer: the sanitized Firefox renderer is 'unverifiable', never hardware", () => {
+    // Firefox privacy-sanitizes the unmasked renderer to "Generic Renderer"
+    // when the probe-only pref did not take (spec 52 FR3). It matches no
+    // software marker, so a distinct verdict keeps it from reading as hardware.
+    assert.equal(classifyRenderer("Generic Renderer"), "unverifiable");
+    assert.equal(classifyRenderer("generic renderer"), "unverifiable");
 });
 
 test("classifyRenderer: empty/absent strings are 'none', never hardware", () => {
@@ -229,6 +249,27 @@ test("partitionCandidates: non-linux platforms skip everything", () => {
     }
 });
 
+test("partitionCandidates: the Firefox recipe reuses the WSL2 host-prereq gating", () => {
+    // Spec 52 Decision 3 / plan: the Firefox recipe is candidate-shaped, so its
+    // host gating is identical to Chromium's — usable on a WSL2 host, skipped
+    // (with the same diagnostics) off it.
+    const usableOnWsl2 = partitionCandidates(wsl2Host, [FIREFOX_PROBE_RECIPE]);
+    assert.equal(usableOnWsl2.usable.length, 1);
+    assert.equal(usableOnWsl2.usable[0].candidate.id, "wsl2-d3d12-firefox");
+    assert.equal(usableOnWsl2.usable[0].effectiveMode, "headless");
+
+    const noDxg = partitionCandidates(nativeLinuxHost, [FIREFOX_PROBE_RECIPE]);
+    assert.equal(noDxg.usable.length, 0);
+    assert.match(noDxg.skipped[0].diagnostic, /\/dev\/dxg absent/);
+
+    const notLinux = partitionCandidates(
+        {...wsl2Host, platform: "win32"},
+        [FIREFOX_PROBE_RECIPE],
+    );
+    assert.equal(notLinux.usable.length, 0);
+    assert.match(notLinux.skipped[0].diagnostic, /untested/);
+});
+
 test("composeEnv injects recipe env and prepends LD_LIBRARY_PATH without mutating the base", () => {
     const base = {
         PATH: "/usr/bin",
@@ -250,6 +291,12 @@ test("composeEnv injects recipe env and prepends LD_LIBRARY_PATH without mutatin
 
 test("composeEnv sets LD_LIBRARY_PATH outright when the base has none", () => {
     const env = composeEnv({PATH: "/usr/bin"}, candidateById("wsl2-d3d12-angle-gl"));
+    assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib");
+});
+
+test("composeEnv: the Firefox recipe composes the same Mesa env (no ANGLE flags involved)", () => {
+    const env = composeEnv({PATH: "/usr/bin"}, FIREFOX_PROBE_RECIPE);
+    assert.equal(env.GALLIUM_DRIVER, "d3d12");
     assert.equal(env.LD_LIBRARY_PATH, "/usr/lib/wsl/lib");
 });
 
@@ -275,9 +322,9 @@ test("runSelection: first hardware verdict wins and stops probing", async () => 
         probe: async (candidate) => {
             calls.push(candidate.id);
             return {
+                engine: "chromium",
                 candidate,
-                renderer:
-                    "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
+                renderer: CHROMIUM_HW,
                 rendererClass: "hardware",
                 error: null,
                 logPath: "gpu-lane-logs/probe-x.log",
@@ -294,7 +341,7 @@ test("runSelection: a failed candidate falls through to the next; exhaustion rep
     const usable = partitionCandidates(wsl2Host).usable;
     const verdicts = {
         "wsl2-d3d12-angle-gl": {
-            renderer: "llvmpipe (LLVM 15.0.7, 256 bits)",
+            renderer: "llvmpipe (LLVM 21.1.8, 256 bits)",
             rendererClass: "software",
             error: null,
         },
@@ -308,6 +355,7 @@ test("runSelection: a failed candidate falls through to the next; exhaustion rep
     const selection = await runSelection({
         usable,
         probe: async (candidate) => ({
+            engine: "chromium",
             candidate,
             logPath: `gpu-lane-logs/probe-${candidate.id}.log`,
             ...verdicts[candidate.id],
@@ -321,55 +369,341 @@ test("runSelection: a failed candidate falls through to the next; exhaustion rep
     assert.ok(logged.some((line) => /probe timeout/.test(line)));
 });
 
-test("failureDiagnostic covers the FR11 cases with cause + remedy + log path", () => {
+test("failureDiagnostic covers the FR11 cases with engine + cause + remedy + log path", () => {
     const d3d12 = candidateById("wsl2-d3d12-angle-gl");
     const softwareLine = failureDiagnostic({
+        engine: "chromium",
         candidate: d3d12,
-        renderer: "llvmpipe (LLVM 15.0.7, 256 bits)",
+        renderer: "llvmpipe (LLVM 21.1.8, 256 bits)",
         rendererClass: "software",
         error: null,
-        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+        logPath: "gpu-lane-logs/probe-chromium-wsl2-d3d12-angle-gl-headless.log",
     });
+    assert.match(softwareLine, /^chromium candidate wsl2-d3d12-angle-gl/);
     assert.match(softwareLine, /SOFTWARE renderer "llvmpipe/);
     assert.match(softwareLine, /Mesa/);
     assert.match(softwareLine, /GALLIUM_DRIVER=d3d12/);
-    assert.match(softwareLine, /gpu-lane-logs\/probe-wsl2-d3d12-angle-gl\.log/);
+    assert.match(softwareLine, /probe-chromium-wsl2-d3d12-angle-gl-headless\.log/);
 
     const crashLine = failureDiagnostic({
-        candidate: d3d12,
+        engine: "firefox",
+        candidate: FIREFOX_PROBE_RECIPE,
         renderer: null,
         rendererClass: "none",
         error: "browser crashed",
-        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+        logPath: "gpu-lane-logs/probe-firefox-wsl2-d3d12-firefox-headless.log",
     });
+    // Crash/timeout wording names the engine and points at the engine-tagged
+    // transcript (spec 52 FR11, Codex plan-review refinement 1).
+    assert.match(crashLine, /^firefox candidate wsl2-d3d12-firefox/);
     assert.match(crashLine, /FAILED \(browser crashed\)/);
-    assert.match(crashLine, /probe transcript: gpu-lane-logs\//);
+    assert.match(crashLine, /probe transcript: gpu-lane-logs\/probe-firefox-/);
 
     const noContextLine = failureDiagnostic({
+        engine: "chromium",
         candidate: d3d12,
         renderer: "",
         rendererClass: "none",
         error: null,
-        logPath: "gpu-lane-logs/probe-wsl2-d3d12-angle-gl.log",
+        logPath: "gpu-lane-logs/probe-chromium-wsl2-d3d12-angle-gl-headless.log",
     });
     assert.match(noContextLine, /no usable WebGL context/);
 });
 
-test("formatReport emits the exact greppable FR10 contract", () => {
+test("failureDiagnostic: the Firefox sanitized renderer hints the probe pref, NOT Mesa", () => {
+    // Spec 52 FR3/FR11 + Claude plan-review refinement: an 'unverifiable' verdict
+    // must produce the probe-only-preference remedy, not the software branch's
+    // Mesa/adapter hint (which would mislead the operator).
+    const line = failureDiagnostic({
+        engine: "firefox",
+        candidate: FIREFOX_PROBE_RECIPE,
+        renderer: "Generic Renderer",
+        rendererClass: "unverifiable",
+        error: null,
+        logPath: "gpu-lane-logs/probe-firefox-wsl2-d3d12-firefox-headless.log",
+    });
+    assert.match(line, /^firefox candidate wsl2-d3d12-firefox/);
+    assert.match(line, /sanitized renderer "Generic Renderer"/);
+    assert.match(line, /webgl\.sanitize-unmasked-renderer=false/);
+    assert.match(line, /UNVERIFIABLE, not hardware/);
+    // It must NOT emit the software branch's Mesa/GALLIUM hint.
+    assert.doesNotMatch(line, /GALLIUM_DRIVER=d3d12/);
+    assert.doesNotMatch(line, /SOFTWARE renderer/);
+});
+
+test("engineSkipReason summarizes the last attempt (or a host-prereq skip)", () => {
+    assert.match(
+        engineSkipReason([], [{candidate: FIREFOX_PROBE_RECIPE, diagnostic: "x"}]),
+        /host prerequisites not met/,
+    );
+    assert.match(
+        engineSkipReason([{rendererClass: "software", renderer: "llvmpipe", error: null}]),
+        /software renderer "llvmpipe"/,
+    );
+    assert.match(
+        engineSkipReason([{rendererClass: "unverifiable", renderer: "Generic Renderer", error: null}]),
+        /sanitized renderer .*probe preference did not take/,
+    );
+    assert.match(
+        engineSkipReason([{rendererClass: "none", renderer: null, error: "probe timeout after 45000ms"}]),
+        /probe failed \(probe timeout after 45000ms\)/,
+    );
+});
+
+test("engineReportLine renders each engine outcome state", () => {
+    assert.equal(
+        engineReportLine({state: "hardware", renderer: FIREFOX_HW}),
+        FIREFOX_HW,
+    );
+    assert.equal(
+        engineReportLine({state: "software-fallback"}),
+        "(software-fallback — SwiftShader)",
+    );
+    assert.equal(
+        engineReportLine({state: "skipped", reason: "software renderer \"llvmpipe\""}),
+        'skipped (unverified — software renderer "llvmpipe")',
+    );
+});
+
+test("reportModeLabel maps skip-empty to 'skipped'; passes others through", () => {
+    assert.equal(reportModeLabel("hardware"), "hardware");
+    assert.equal(reportModeLabel("software-fallback"), "software-fallback");
+    assert.equal(reportModeLabel("skip-empty"), "skipped");
+});
+
+test("formatReport emits the per-engine greppable FR10 contract (two engines)", () => {
     const report = formatReport({
         mode: "hardware",
-        renderer:
-            "ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)",
-        suite: "skipped (--probe-only)",
-        wallClock: "12s",
+        engines: [
+            {engine: "chromium", renderer: CHROMIUM_HW},
+            {engine: "firefox", renderer: FIREFOX_HW},
+        ],
+        suite: "pass",
+        wallClock: "192s (build 45s, suite 147s)",
     });
     const lines = report.split("\n");
     assert.equal(lines[0], "=== E2E GPU LANE REPORT ===");
     assert.equal(lines[1], "mode: hardware");
-    assert.match(lines[2], /^renderer: ANGLE \(Microsoft Corporation/);
-    assert.equal(lines[3], "engine: chromium");
-    assert.equal(lines[4], "suite: skipped (--probe-only)");
-    assert.equal(lines[5], "wall-clock: 12s");
+    assert.equal(lines[2], "engines: chromium,firefox");
+    assert.match(lines[3], /^renderer\.chromium: ANGLE \(Microsoft Corporation/);
+    assert.equal(lines[4], `renderer.firefox: ${FIREFOX_HW}`);
+    assert.equal(lines[5], "suite: pass");
+    assert.equal(lines[6], "wall-clock: 192s (build 45s, suite 147s)");
+});
+
+test("formatReport: a skipped engine is represented explicitly, never omitted", () => {
+    const report = formatReport({
+        mode: "software-fallback",
+        engines: [
+            {engine: "chromium", renderer: "(software-fallback — SwiftShader)"},
+            {engine: "firefox", renderer: "skipped (unverified — software renderer \"llvmpipe\")"},
+        ],
+        suite: "pass",
+        wallClock: "10s",
+    });
+    assert.match(report, /^engines: chromium,firefox$/m);
+    assert.match(report, /^renderer\.chromium: \(software-fallback — SwiftShader\)$/m);
+    assert.match(report, /^renderer\.firefox: skipped \(unverified — /m);
+});
+
+// ---------------------------------------------------------------------------
+// computeRunPlan — the two-engine verification-gating decision function
+// ---------------------------------------------------------------------------
+
+const nonStrict = {forceFallback: false, requireHardware: false};
+const strict = {forceFallback: false, requireHardware: true};
+const forced = {forceFallback: true, requireHardware: false};
+
+function chromiumHardwareVerdict() {
+    return {
+        engine: "chromium",
+        verified: true,
+        renderer: CHROMIUM_HW,
+        candidate: candidateById("wsl2-d3d12-angle-gl"),
+        extraEnv: {},
+        effectiveMode: "headless",
+    };
+}
+function firefoxHardwareVerdict() {
+    return {
+        engine: "firefox",
+        verified: true,
+        renderer: FIREFOX_HW,
+        candidate: FIREFOX_PROBE_RECIPE,
+        extraEnv: {},
+    };
+}
+function firefoxSoftwareVerdict() {
+    return {
+        engine: "firefox",
+        verified: false,
+        renderer: "llvmpipe (LLVM 21.1.8, 256 bits)",
+        rendererClass: "software",
+        reason: 'software renderer "llvmpipe (LLVM 21.1.8, 256 bits)"',
+    };
+}
+
+test("computeRunPlan: both engines hardware ⇒ combined two-engine hardware run", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: chromiumHardwareVerdict(),
+            firefox: firefoxHardwareVerdict(),
+        },
+        controls: nonStrict,
+    });
+    assert.equal(plan.mode, "hardware");
+    assert.deepEqual(plan.suiteEngines, ["chromium", "firefox"]);
+    assert.equal(plan.engines.chromium.state, "hardware");
+    assert.equal(plan.engines.chromium.renderer, CHROMIUM_HW);
+    assert.equal(plan.engines.firefox.state, "hardware");
+    assert.equal(plan.engines.firefox.renderer, FIREFOX_HW);
+    // Suite-env carriers for Phase 2.
+    assert.equal(plan.chromiumCandidate.id, "wsl2-d3d12-angle-gl");
+    assert.equal(plan.chromiumEffectiveMode, "headless");
+    assert.equal(plan.firefoxRecipe.id, "wsl2-d3d12-firefox");
+});
+
+test("computeRunPlan: default 'all', Firefox unverified, non-strict ⇒ Chromium SwiftShader + Firefox skipped", () => {
+    // Decision 6: not both verify ⇒ honest fallback. Chromium runs its
+    // deterministic SwiftShader fallback (even though it verified hardware),
+    // Firefox is skipped with a stated reason — never an llvmpipe masquerade.
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: chromiumHardwareVerdict(),
+            firefox: firefoxSoftwareVerdict(),
+        },
+        controls: nonStrict,
+    });
+    assert.equal(plan.mode, "software-fallback");
+    assert.deepEqual(plan.suiteEngines, ["chromium"]);
+    assert.equal(plan.engines.chromium.state, "software-fallback");
+    assert.equal(plan.engines.firefox.state, "skipped");
+    assert.match(plan.engines.firefox.reason, /llvmpipe/);
+});
+
+test("computeRunPlan: default 'all', either engine unverified, strict ⇒ abort", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: chromiumHardwareVerdict(),
+            firefox: firefoxSoftwareVerdict(),
+        },
+        controls: strict,
+    });
+    assert.equal(plan.mode, "abort");
+    assert.deepEqual(plan.suiteEngines, []);
+    assert.deepEqual(plan.unverified, ["firefox"]);
+    assert.equal(plan.engines.chromium.state, "hardware");
+    assert.equal(plan.engines.firefox.state, "skipped");
+});
+
+test("computeRunPlan: single-engine Chromium preserves the exact #44 behavior", () => {
+    const hw = computeRunPlan({
+        requestedEngines: ["chromium"],
+        verdicts: {chromium: chromiumHardwareVerdict()},
+        controls: nonStrict,
+    });
+    assert.equal(hw.mode, "hardware");
+    assert.deepEqual(hw.suiteEngines, ["chromium"]);
+    assert.equal(hw.chromiumCandidate.id, "wsl2-d3d12-angle-gl");
+
+    const sw = computeRunPlan({
+        requestedEngines: ["chromium"],
+        verdicts: {
+            chromium: {engine: "chromium", verified: false, reason: "software renderer"},
+        },
+        controls: nonStrict,
+    });
+    assert.equal(sw.mode, "software-fallback");
+    assert.deepEqual(sw.suiteEngines, ["chromium"]);
+    assert.equal(sw.engines.chromium.state, "software-fallback");
+    assert.equal(Object.hasOwn(sw.engines, "firefox"), false);
+});
+
+test("computeRunPlan: single-engine Firefox hardware runs Firefox alone", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["firefox"],
+        verdicts: {firefox: firefoxHardwareVerdict()},
+        controls: nonStrict,
+    });
+    assert.equal(plan.mode, "hardware");
+    assert.deepEqual(plan.suiteEngines, ["firefox"]);
+    assert.equal(plan.engines.firefox.renderer, FIREFOX_HW);
+    assert.equal(plan.firefoxRecipe.id, "wsl2-d3d12-firefox");
+    assert.equal(Object.hasOwn(plan, "chromiumCandidate"), false);
+});
+
+test("computeRunPlan: single-engine Firefox unverified, non-strict ⇒ empty-set skip (exit 0), no suite", () => {
+    // Scenario 7: an empty engine set must never reach Playwright (it would
+    // trip the config's "matched no known engines" guard). Skip build/suite,
+    // report Firefox skipped, exit 0.
+    const plan = computeRunPlan({
+        requestedEngines: ["firefox"],
+        verdicts: {firefox: firefoxSoftwareVerdict()},
+        controls: nonStrict,
+    });
+    assert.equal(plan.mode, "skip-empty");
+    assert.deepEqual(plan.suiteEngines, []);
+    assert.equal(plan.engines.firefox.state, "skipped");
+    assert.match(plan.engines.firefox.reason, /llvmpipe/);
+    assert.equal(Object.hasOwn(plan.engines, "chromium"), false);
+});
+
+test("computeRunPlan: single-engine Firefox unverified, strict ⇒ abort", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["firefox"],
+        verdicts: {firefox: firefoxSoftwareVerdict()},
+        controls: strict,
+    });
+    assert.equal(plan.mode, "abort");
+    assert.deepEqual(plan.unverified, ["firefox"]);
+});
+
+test("computeRunPlan: forced fallback with Chromium ⇒ Chromium SwiftShader, Firefox skipped (no probe)", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {},
+        controls: forced,
+    });
+    assert.equal(plan.mode, "software-fallback");
+    assert.deepEqual(plan.suiteEngines, ["chromium"]);
+    assert.equal(plan.engines.chromium.state, "software-fallback");
+    assert.equal(plan.engines.firefox.state, "skipped");
+    assert.match(plan.engines.firefox.reason, /no software equivalent/);
+});
+
+test("computeRunPlan: forced fallback, Firefox-only ⇒ vacuous skip-empty (exit 0), not a usage error", () => {
+    // FR4: E2E_GPU_FORCE_FALLBACK=1 --engine=firefox is a benign no-op, NOT a
+    // LaneUsageError — Firefox has no software path to force.
+    const plan = computeRunPlan({
+        requestedEngines: ["firefox"],
+        verdicts: {},
+        controls: forced,
+    });
+    assert.equal(plan.mode, "skip-empty");
+    assert.deepEqual(plan.suiteEngines, []);
+    assert.equal(plan.engines.firefox.state, "skipped");
+    assert.match(plan.engines.firefox.reason, /forced fallback/);
+});
+
+test("reportEntriesFromPlan renders the requested engines in order", () => {
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: chromiumHardwareVerdict(),
+            firefox: firefoxSoftwareVerdict(),
+        },
+        controls: nonStrict,
+    });
+    const entries = reportEntriesFromPlan(plan, ["chromium", "firefox"]);
+    assert.deepEqual(
+        entries.map((entry) => entry.engine),
+        ["chromium", "firefox"],
+    );
+    assert.equal(entries[0].renderer, "(software-fallback — SwiftShader)");
+    assert.match(entries[1].renderer, /^skipped \(unverified — /);
 });
 
 test("probeRenderer: a watchdog timeout still reaps a late-resolving browser", async () => {
@@ -406,10 +740,14 @@ test("probeRenderer: a watchdog timeout still reaps a late-resolving browser", a
     );
     assert.match(attempt.error, /probe timeout after 10ms/);
     assert.equal(attempt.rendererClass, "none");
+    assert.equal(attempt.engine, "chromium");
     assert.equal(closed, true, "late-resolving browser must be closed");
-    // The transcript was written via the injected writer, with the error.
+    // The transcript was written via the injected writer, engine-tagged.
     assert.equal(transcripts.length, 1);
-    assert.match(transcripts[0].path, /probe-wsl2-d3d12-angle-gl-headless\.log/);
+    assert.match(
+        transcripts[0].path,
+        /probe-chromium-wsl2-d3d12-angle-gl-headless\.log/,
+    );
     assert.match(transcripts[0].text, /ERROR: probe timeout/);
 });
 
@@ -459,12 +797,79 @@ test("probeRenderer: a launch failure is a failed candidate with the error recor
     assert.equal(transcripts.length, 1);
 });
 
-test("parseArgs: matrix flags parse and validate; channel is probe-only", () => {
+test("probeRenderer firefox: launches with firefoxUserPrefs (incl. the probe-only sanitize pref) and NO args", async () => {
+    let received = null;
+    const fakeBrowser = {
+        close: async () => {},
+        newPage: async () => ({
+            evaluate: async () => ({renderer: FIREFOX_HW, vendor: "Mesa"}),
+        }),
+    };
+    const launcher = async (engine) => ({
+        launch: async (options) => {
+            received = {engine, options};
+            return fakeBrowser;
+        },
+    });
+    const transcripts = [];
+    const attempt = await probeRenderer(FIREFOX_PROBE_RECIPE, {}, {
+        engine: "firefox",
+        baseEnv: {},
+        headless: true,
+        launcher,
+        writeTranscript: (path, text) => transcripts.push({path, text}),
+    });
+    assert.equal(attempt.engine, "firefox");
+    assert.equal(attempt.rendererClass, "hardware");
+    assert.equal(attempt.renderer, FIREFOX_HW);
+    // The launcher was asked for the firefox browser type; the launch carried
+    // the probe-only prefs and no Chromium `args`/`channel`.
+    assert.equal(received.engine, "firefox");
+    assert.equal(
+        received.options.firefoxUserPrefs["webgl.sanitize-unmasked-renderer"],
+        false,
+    );
+    assert.equal(received.options.firefoxUserPrefs["webgl.force-enabled"], true);
+    assert.equal(Object.hasOwn(received.options, "args"), false);
+    assert.equal(Object.hasOwn(received.options, "channel"), false);
+    // Mesa env reached the launch; transcript is firefox-tagged and logs prefs.
+    assert.equal(received.options.env.GALLIUM_DRIVER, "d3d12");
+    assert.match(
+        transcripts[0].path,
+        /probe-firefox-wsl2-d3d12-firefox-headless\.log/,
+    );
+    assert.match(transcripts[0].text, /prefs:/);
+});
+
+test("probeRenderer firefox: the sanitized renderer classifies as unverifiable, not hardware", async () => {
+    const fakeBrowser = {
+        close: async () => {},
+        newPage: async () => ({
+            evaluate: async () => ({
+                renderer: "Generic Renderer",
+                vendor: "Microsoft Corporation",
+            }),
+        }),
+    };
+    const launcher = async () => ({launch: async () => fakeBrowser});
+    const attempt = await probeRenderer(FIREFOX_PROBE_RECIPE, {}, {
+        engine: "firefox",
+        baseEnv: {},
+        headless: true,
+        launcher,
+        writeTranscript: () => {},
+    });
+    assert.equal(attempt.rendererClass, "unverifiable");
+    assert.equal(attempt.renderer, "Generic Renderer");
+});
+
+test("parseArgs: engine selector + matrix flags parse and validate; channel is probe-only", () => {
     assert.deepEqual(parseArgs([]), {
         probeOnly: false,
         mode: null,
         candidate: null,
         channel: null,
+        engines: ["chromium", "firefox"],
     });
     assert.deepEqual(
         parseArgs([
@@ -478,8 +883,15 @@ test("parseArgs: matrix flags parse and validate; channel is probe-only", () => 
             mode: "headless",
             candidate: "wsl2-d3d12-angle-gl-egl",
             channel: "chromium",
+            engines: ["chromium", "firefox"],
         },
     );
+    // --engine selector (spec 52 FR7): all (default) / chromium / firefox.
+    assert.deepEqual(parseArgs(["--engine=all"]).engines, ["chromium", "firefox"]);
+    assert.deepEqual(parseArgs(["--engine=chromium"]).engines, ["chromium"]);
+    assert.deepEqual(parseArgs(["--engine=firefox"]).engines, ["firefox"]);
+    assert.throws(() => parseArgs(["--engine=webkit"]), LaneUsageError);
+
     assert.throws(() => parseArgs(["--mode=windowed"]), LaneUsageError);
     assert.throws(() => parseArgs(["--candidate=no-such-id"]), LaneUsageError);
     assert.throws(() => parseArgs(["--bogus"]), LaneUsageError);
@@ -562,7 +974,7 @@ test("formatWallClock breaks out build and suite stages", () => {
 
 test("candidate data invariants: sandbox relaxations stay lane-only and evidence-ordered", () => {
     // The first candidate must remain the proven bugfix-22 recipe — selection
-    // order is evidence strength (spec FR2).
+    // order is evidence strength (spec 44 FR2).
     assert.equal(CANDIDATES[0].id, "wsl2-d3d12-angle-gl");
     for (const candidate of CANDIDATES) {
         // Every candidate must carry the shape the lane's lifecycle relies on.
@@ -575,4 +987,29 @@ test("candidate data invariants: sandbox relaxations stay lane-only and evidence
             assert.ok(!flag.includes("swiftshader"), `${candidate.id}: ${flag}`);
         }
     }
+});
+
+test("Firefox probe recipe invariants: same Mesa env, no ANGLE flags, probe-only sanitize pref", () => {
+    // Spec 52 Decision 3: Firefox reaches the adapter via the Mesa env only.
+    assert.deepEqual(FIREFOX_PROBE_RECIPE.flags, []);
+    assert.equal(FIREFOX_PROBE_RECIPE.hostClass, "wsl2");
+    assert.equal(FIREFOX_PROBE_RECIPE.mode, "headless");
+    assert.equal(FIREFOX_PROBE_RECIPE.env.GALLIUM_DRIVER, "d3d12");
+    assert.equal(FIREFOX_PROBE_RECIPE.envPrepend.LD_LIBRARY_PATH, "/usr/lib/wsl/lib");
+    // The probe-only preference lives here (the ephemeral probe), and it exposes
+    // the raw renderer — it is NEVER in the committed firefox Playwright project.
+    assert.equal(
+        FIREFOX_PROBE_RECIPE.firefoxUserPrefs["webgl.sanitize-unmasked-renderer"],
+        false,
+    );
+    assert.equal(
+        FIREFOX_PROBE_RECIPE.firefoxUserPrefs["webgl.force-enabled"],
+        true,
+    );
+    // No ANGLE launch flags may sneak into the Firefox recipe.
+    assert.equal(FIREFOX_PROBE_RECIPE.flags.length, 0);
+});
+
+test("engine constants: canonical order is chromium then firefox", () => {
+    assert.deepEqual(ENGINES, ["chromium", "firefox"]);
 });

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -585,6 +585,36 @@ test("computeRunPlan: default 'all', Firefox unverified, non-strict ⇒ Chromium
     assert.match(plan.engines.firefox.reason, /llvmpipe/);
 });
 
+test("computeRunPlan: default 'all', Chromium fails but Firefox VERIFIES ⇒ Firefox reported 'not run', never 'unverified'", () => {
+    // Codex PR-review honesty catch: a verified Firefox dropped because Chromium
+    // failed must NOT read as "skipped (unverified — unverified)". It verified
+    // hardware; it is simply not run (the fallback is Chromium-only, Decision 6).
+    const plan = computeRunPlan({
+        requestedEngines: ["chromium", "firefox"],
+        verdicts: {
+            chromium: {
+                engine: "chromium",
+                verified: false,
+                reason: 'unverified — software renderer "llvmpipe"',
+            },
+            firefox: firefoxHardwareVerdict(),
+        },
+        controls: nonStrict,
+    });
+    assert.equal(plan.mode, "software-fallback");
+    assert.deepEqual(plan.suiteEngines, ["chromium"]);
+    assert.equal(plan.engines.chromium.state, "software-fallback");
+    // The verified-but-dropped Firefox is 'not-run', with an honest reason —
+    // never the nonsensical "unverified — unverified".
+    assert.equal(plan.engines.firefox.state, "not-run");
+    assert.match(plan.engines.firefox.reason, /Chromium unverified/);
+    assert.match(plan.engines.firefox.reason, /verified hardware but is not run/);
+    const line = engineReportLine(plan.engines.firefox);
+    assert.match(line, /^not run \(/);
+    assert.doesNotMatch(line, /unverified — unverified/);
+    assert.doesNotMatch(line, /skipped \(unverified/);
+});
+
 test("computeRunPlan: default 'all', either engine unverified, strict ⇒ abort", () => {
     const plan = computeRunPlan({
         requestedEngines: ["chromium", "firefox"],

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -27,6 +27,7 @@ import {
     parseControls,
     partitionCandidates,
     playwrightTestArgs,
+    probeOnlyOutcome,
     probeRenderer,
     reportEntriesFromPlan,
     reportModeLabel,
@@ -781,6 +782,55 @@ test("reportEntriesFromPlan renders the requested engines in order", () => {
     assert.match(entries[1].renderer, /^skipped \(unverified — /);
 });
 
+test("probeOnlyOutcome: probe-only ALWAYS reports, even when E2E_GPU_REQUIRE aborts", () => {
+    // Architect integration-review fix: a probe-only run already produced its
+    // verdicts, so the per-engine report must be emitted BEFORE the non-zero exit
+    // (the report is most useful exactly when an engine failed). Unlike the full
+    // lane, which aborts before doing any build/suite work.
+    const requestedEngines = ["chromium", "firefox"];
+    const verdicts = {
+        chromium: chromiumHardwareVerdict(),
+        firefox: firefoxSoftwareVerdict(),
+    };
+    const plan = computeRunPlan({requestedEngines, verdicts, controls: strict});
+    assert.equal(plan.mode, "abort");
+    const {report, exitCode} = probeOnlyOutcome({
+        requestedEngines,
+        verdicts,
+        plan,
+        controls: strict,
+        wallClock: "3s",
+    });
+    // Non-zero exit AND a full per-engine report were both produced.
+    assert.equal(exitCode, 1);
+    const lines = report.split("\n");
+    assert.equal(lines[0], "=== E2E GPU LANE REPORT ===");
+    assert.equal(lines[1], "mode: abort");
+    assert.equal(lines[2], "engines: chromium,firefox");
+    assert.match(report, /^renderer\.chromium: ANGLE \(Microsoft Corporation/m);
+    assert.match(report, /^renderer\.firefox: skipped \(unverified — .*llvmpipe/m);
+    assert.match(report, /^suite: skipped \(--probe-only\)$/m);
+});
+
+test("probeOnlyOutcome: a fully-verified probe reports and exits 0", () => {
+    const requestedEngines = ["chromium", "firefox"];
+    const verdicts = {
+        chromium: chromiumHardwareVerdict(),
+        firefox: firefoxHardwareVerdict(),
+    };
+    const plan = computeRunPlan({requestedEngines, verdicts, controls: nonStrict});
+    const {report, exitCode} = probeOnlyOutcome({
+        requestedEngines,
+        verdicts,
+        plan,
+        controls: nonStrict,
+        wallClock: "3s",
+    });
+    assert.equal(exitCode, 0);
+    assert.match(report, /^mode: hardware$/m);
+    assert.match(report, /^renderer\.firefox: D3D12 \(NVIDIA GeForce RTX 3080\)$/m);
+});
+
 test("probeRenderer: a watchdog timeout still reaps a late-resolving browser", async () => {
     // The launch resolves AFTER the watchdog has already failed the probe;
     // the lane must close that late browser instead of orphaning a Chromium
@@ -966,6 +1016,25 @@ test("parseArgs: engine selector + matrix flags parse and validate; channel is p
     assert.deepEqual(parseArgs(["--engine=chromium"]).engines, ["chromium"]);
     assert.deepEqual(parseArgs(["--engine=firefox"]).engines, ["firefox"]);
     assert.throws(() => parseArgs(["--engine=webkit"]), LaneUsageError);
+    // --candidate / --channel are Chromium-only: rejected with --engine=firefox,
+    // but fine with the default (all) set (Chromium still probed).
+    assert.throws(
+        () => parseArgs(["--engine=firefox", "--candidate=wsl2-d3d12-angle-gl"]),
+        LaneUsageError,
+    );
+    assert.throws(
+        () =>
+            parseArgs([
+                "--engine=firefox",
+                "--probe-only",
+                "--channel=chromium",
+            ]),
+        LaneUsageError,
+    );
+    assert.equal(
+        parseArgs(["--candidate=wsl2-d3d12-angle-gl"]).candidate,
+        "wsl2-d3d12-angle-gl",
+    );
 
     assert.throws(() => parseArgs(["--mode=windowed"]), LaneUsageError);
     assert.throws(() => parseArgs(["--candidate=no-such-id"]), LaneUsageError);


### PR DESCRIPTION
## Summary

Generalizes the opt-in native-GPU local e2e lane (`npm run test:e2e:gpu`,
`scripts/e2e-gpu-lane.mjs`) from **Chromium-only** (spec #44 / PR #50) to a
**two-engine Chromium + Firefox** lane, so a verified WSL2 host runs the full
Playwright suite under genuine hardware-accelerated WebGL for **both** shipped
engines. Implements spec/plan #52 (Approach C: engine dimension as **data**, not
scattered `if (engine === "firefox")` branches).

The lane stays **additional local tooling, never the green gate**: `npm run
validate`, `.github/workflows/validation.yml`, `test:smoke`, Playwright browser
defaults, `workers: 1`, `retries`, and every committed test are **byte-for-byte /
behavior-identical** to today. CI stays `E2E_ENGINES=chromium` SwiftShader-only.

## What changed

- **Engine-aware probe/verify** — Chromium keeps its ANGLE candidate matrix + Mesa
  env; Firefox uses the *same* Mesa d3d12 env with **no ANGLE flags** and inherits
  it from the suite process (no `playwright.config.ts` change — Decision 9).
- **Firefox renderer verification** — Firefox privacy-sanitizes the unmasked
  renderer to `Generic Renderer`, so the raw renderer is read through an ephemeral
  **probe-only** `webgl.sanitize-unmasked-renderer: false` preference (the
  committed `firefox` project keeps `webgl.force-enabled: true` only). A sanitized
  string classifies as `unverifiable`, **never** hardware. `classifyRenderer` now
  returns `none | software | unverifiable | hardware`; deny-list expanded with
  softpipe/lavapipe/swrast.
- **Two-engine gating + honest fallback** — a candidate is verified only when
  **both** engines return hardware; on exhaustion Chromium keeps its deterministic
  SwiftShader fallback and Firefox is **skipped** (no llvmpipe masquerade);
  `E2E_GPU_REQUIRE=1` fails before build/suite if either engine is unverified;
  Firefox-only + no-hardware skips build/suite entirely (never an empty
  `E2E_ENGINES`), exit 0.
- **Per-engine report** (`renderer.chromium` / `renderer.firefox`) + `--engine=
  chromium|firefox|all` selector (default `all`).

Only `scripts/e2e-gpu-lane.mjs` and `tests/gpu-lane.test.mjs` change as code (plus
README + review + arch/lessons cold-doc updates). **No** dependency, lockfile,
`playwright.config.ts`, `tests/e2e/**`, or `app/**` change.

## Evidence (WSL2 / RTX 3080; see `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`)

- **FR8**: **3 consecutive fully-green two-engine hardware runs** (Q-1/Q-2/Q-3,
  22/22 each, `E2E_GPU_REQUIRE=1`, `retries: 0`) + HW-1 = 4-for-4 (88/88 test
  execs); `renderer.chromium = ANGLE (… D3D12 (NVIDIA GeForce RTX 3080) …)`,
  `renderer.firefox = D3D12 (NVIDIA GeForce RTX 3080)` asserted identical each run.
- **Baseline**: FB-1 Chromium SwiftShader 11 tests/582 s vs two-engine hardware
  22 tests/196 s ⇒ ~6× per-test.
- **Known Firefox flake** (`matrix.spec.ts:224` background-drag): **0/4** recurrence
  here; accepted+documented (Decision 10) — **not** masked (retries 0, canonical
  assertion unchanged), **not** fixed (out of scope).
- **FR6**: `playwright.config.ts` byte-identical to `main`; no validation.yml /
  package.json / lockfile delta; default config still lists both engines (22 tests).
- **Clean-checkout gate proof**: detached worktree + real `npm ci` — lint ✓ /
  typecheck ✓ / build ✓; validate Run 1 e2e 21/22 (the known Firefox software
  flake), Run 2 **22/22** (`VALIDATE EXIT: 0`). The worktree's 21 lint errors were
  entirely the untracked `.claude/hooks/` builder-harness file.

## Consultation

All three implement phases reviewed 3-way (Gemini / Codex / Claude): `engine_aware_core`
unanimous APPROVE; `two_engine_suite_and_inertness` iter1 Codex REQUEST_CHANGES (a
real Firefox-only-headed suite-dispatch bug, fixed via a run-level `effectiveMode`
+ `isHeadedRun`) → iter2 unanimous APPROVE; `qualification_evidence_and_docs`
unanimous APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
