### PR TITLE
[Spec 41] Parallelize local e2e runs — serial gate + opt-in parallel (CI unchanged)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ both Chromium and Firefox; Playwright owns that server's startup and teardown.
 direct `npm run start` serving the root page with HTTP 200 is verified separately
 as a stage-qualification check.
 
+**Local test parallelism (issue #41).** Local e2e runs are **serial by default**
+(`workers: 1`) — the qualified `retries: 0` gate contract. Parallel execution is
+**opt-in** via the `E2E_WORKERS` environment variable: a positive integer
+(`E2E_WORKERS=4`) or a hardware-relative percentage (`E2E_WORKERS=50%`, scaled
+from `os.cpus().length`); an invalid value fails loudly at config load rather than
+silently running serial. Whenever `CI` is set the count is hard-pinned to `1`
+regardless of `E2E_WORKERS`, so the sharded CI contract is untouched, and local
+`retries: 0` is preserved so flakes stay visible. Parallel workers were qualified
+and found to **destabilize** the timing-sensitive Chromium `matrix.spec.ts`
+camera-settle/drag assertions under SwiftShader CPU contention (4–5 of 22 tests
+fail on **every** parallel run there — the problem is destabilization, not speed:
+parallel is actually faster), so parallelism is not the default. It is most useful
+on the [native-GPU lane](#opt-in-native-gpu-e2e-lane), where the full two-engine
+suite runs ~4× faster on real hardware and stays mostly green. Full qualification
+evidence and the trade-off: `codev/reviews/41-parallelize-local-e2e-runs.md`.
+
 ### Audit evidence
 
 Audits are evidence snapshots, not a zero-finding green gate. Either audit
@@ -109,8 +125,10 @@ check:
   audit captures.
 - **`e2e`** — the production build plus the full Playwright suite, split at the
   test level across four Chromium shards (`--shard=1/4 … 4/4`). Each shard runs
-  strictly serially (`workers: 1`); `playwright.config.ts` sets
-  `fullyParallel: true` so `--shard` splits per test rather than per file.
+  strictly serially — the config resolves `workers` to `1` whenever `CI` is set
+  (issue #41's `resolveWorkers` CI guard, which returns before reading
+  `E2E_WORKERS`); `playwright.config.ts` sets `fullyParallel: true` so `--shard`
+  splits per test rather than per file.
 - **`merge-reports`** — stitches the per-shard blob reports into one HTML report.
 - **`gate`** — a single required status that succeeds only when `quality` and
   `e2e` both pass.
@@ -175,7 +193,9 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
    `E2E_ENGINES=chromium,firefox`. Chromium's verified flags are injected through
    the config's `PW_CHROMIUM_ARGS` hook; **Firefox inherits the same Mesa env**
    from the suite process (no new config hook). Same production server, same
-   `workers: 1`, same `retries: 0`, same timeouts as the normal local suite.
+   **serial default** (`workers: 1`; set `E2E_WORKERS` to opt into parallel —
+   ~4× faster here, see below), same `retries: 0`, same timeouts as the normal
+   local suite.
 4. **Reports honestly, per engine.** The run ends with a machine-greppable block:
 
    ```
@@ -199,20 +219,33 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
    either engine is unverified. The suite's own pass/fail is the lane's exit code.
 
 Measured on the qualification host (WSL2, RTX 3080): the full **two-engine**
-hardware suite (22 tests) runs in ≈ 196 s (≈ 208 s total incl. build) at
-`retries: 0`, versus the Chromium-only SwiftShader path measured in
+hardware suite (22 tests) runs **serially** in ≈ 196 s (≈ 208 s total incl.
+build) at `retries: 0`, versus the Chromium-only SwiftShader path measured in
 `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md` — the hardware lane runs
 **twice the tests (both engines)** in a fraction of the software time, with the
 SwiftShader-only hover/timing flake class absent. Full per-run / per-test
 evidence and the software baseline live in that review (as the #44 lane's
 evidence lives in `codev/reviews/44-add-an-opt-in-native-gpu-local.md`).
 
+Issue #41's **opt-in parallel** (`E2E_WORKERS=50%` → 10 workers on this 20-core
+host) cut that same two-engine hardware suite to ≈ 46 s (≈ 57 s incl. build) —
+about **4× faster** — across a three-run qualification set. The known Firefox
+flake #33 (below) recurred once in those three parallel runs (2/3 green), so
+parallel remains opt-in and `retries: 0` keeps the amplification honest; the
+SwiftShader gate stays serial (it fails 4–5/22 under parallel contention). Full
+evidence: `codev/reviews/41-parallelize-local-e2e-runs.md`.
+
 **Known Firefox flake**: `[firefox] tests/e2e/matrix.spec.ts:224` ("zooms in with
 the wheel and rotates with a background drag") is a pre-existing Firefox
 synthetic-input-delivery nondeterminism (not a software-WebGL timing problem — it
 survives on hardware). It is **not masked with retries** and the canonical
-assertion is **not weakened**; it did not recur across the three-run qualification
-set recorded in review 52. If it recurs, it is dispositioned there, never hidden.
+assertion is **not weakened**. It is an **open, pre-existing** flake that surfaces
+even serially at `retries: 0` (it recurred once in issue #41's serial SwiftShader
+baseline), which is why it is tracked and why CI runs `retries: 2`. Parallel CPU
+contention **amplifies** it (once in three hardware parallel runs), which is one
+concrete reason parallel is opt-in, not the default. Issue #41 neither introduces
+nor fixes it; it stays unmasked and the assertion unchanged, dispositioned here and
+in review 41, never hidden.
 
 ### Env controls and flags
 
@@ -222,6 +255,7 @@ set recorded in review 52. If it recurs, it is dispositioned there, never hidden
 | `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware probing; take the honest fallback path (Chromium SwiftShader, Firefox skipped) deterministically. With `--engine=firefox` alone it is a benign no-op skip (Firefox has no software path), exit 0. |
 | `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when **any requested engine** does not verify hardware — use for hardware-evidence runs so a silent fallback can't pollute results. With `--probe-only` the per-engine report is still printed (`mode: abort`) **before** the non-zero exit — the probe already did its work. |
 | `--probe-only` | Probe + verify + report the requested engine set without building or running the suite. Always prints the report, even on a `E2E_GPU_REQUIRE=1` abort. |
+| `E2E_WORKERS=<int\|percent>` | Config-level local worker count (issue #41), **inherited by this lane**. Opt into parallel with `E2E_WORKERS=50%` (hardware-relative) or `E2E_WORKERS=4`; **~4× faster** on this lane but can surface flake #33. Serial (`1`) by default; **pinned to `1` whenever `CI` is set**; an invalid value fails loudly at config load. |
 | `--mode=headed\|headless` | Override the run mode. Default is **headless** (proven equivalent; see below). Headed needs WSLg/X (`DISPLAY`). |
 | `--candidate=<id>` / `--channel=<name>` | Probe a specific Chromium recipe / a specific Playwright channel (`--channel` is probe-only). Chromium-only — rejected with `--engine=firefox`. Used by the FR5 matrix. |
 
@@ -281,6 +315,10 @@ stability results, lives in `codev/reviews/44-add-an-opt-in-native-gpu-local.md`
 - Renderer strings and timings above are **evidence dated 2026-07** on one
   host (Mesa 26.0.3, driver 581.29); driver updates can shift them. The lane
   probes rather than assumes, and falls back loudly.
-- `workers` stays `1` in the lane, matching the qualified suite. Raising
-  parallelism on top of this lane is issue #41's qualification, sequenced
-  after this one — do not raise it ad hoc.
+- `workers` **defaults to `1`** in the lane, matching the qualified serial suite.
+  Issue #41 qualified raising it and adopted a **serial-default + opt-in-parallel**
+  contract: set `E2E_WORKERS=50%` (or an integer) to run this lane's two-engine
+  suite in parallel (~4× faster on hardware). Parallel is not the default because
+  it destabilizes the SwiftShader gate (4–5/22) and amplifies flake #33 (`retries:
+  0` keeps that visible). See the "Local test parallelism" note above and
+  `codev/reviews/41-parallelize-local-e2e-runs.md`.

--- a/codev/plans/41-parallelize-local-e2e-runs.md
+++ b/codev/plans/41-parallelize-local-e2e-runs.md
@@ -206,14 +206,21 @@ inert (no existing behavior touched).
 #### Acceptance Criteria
 - [ ] `npm run typecheck` passes with the `.mjs` import.
 - [ ] `npm test` passes (migrated `automation.test.mjs` + Phase-1 unit suite).
-- [ ] **Config actually loads and resolves** (not just compiles): a real
-  Playwright invocation confirms parallel workers locally — e.g.
-  `E2E_ENGINES=chromium npx playwright test --list` runs without config error and
-  a real run prints "using N workers" (N>1 on this multi-core host); and
-  `CI=1 E2E_ENGINES=chromium npx playwright test --list` resolves to 1 worker.
-  (Lessons-critical: "it compiled" ≠ "it works" — exercise the real config path.)
-- [ ] `E2E_WORKERS=4` → 4 workers; `E2E_WORKERS=50%` → hardware-relative;
-  `E2E_WORKERS=abc` → loud config-resolution failure (no silent serial).
+- [ ] **Config import resolves** (the novel `.mjs`-from-`.ts` path works):
+  `E2E_ENGINES=chromium npx playwright test --list` completes without a config
+  load/import error. NOTE: `--list` proves the config *loads* but does **not**
+  print the worker count — the next item is the actual worker-count proof.
+- [ ] **Resolved worker count proven by the run banner** (the deterministic
+  observable; `--list` does not report workers): a minimal real run — a single
+  fast test via `--grep`, or the full suite — prints Playwright's
+  `Running N tests using M worker(s)` banner, and `M` is asserted per env:
+  default ⇒ `M > 1` on this multi-core host; `CI=1` ⇒ `M = 1`;
+  `E2E_WORKERS=4` ⇒ `M = 4`. This closes the gap between "config loaded" and
+  "config applied the resolved count".
+  (Lessons-critical: "it compiled" ≠ "it works" — exercise the real path.)
+- [ ] `E2E_WORKERS=50%` → hardware-relative worker count in the banner;
+  `E2E_WORKERS=abc` → loud `WorkerConfigError` at config resolution, **no run
+  starts** (no silent serial).
 - [ ] The `workers: 1` comment block is gone; the new contract comment is present.
 - [ ] `.github/workflows/validation.yml` unchanged (verified:
   `git diff --name-only` does not list it).
@@ -221,10 +228,12 @@ inert (no existing behavior touched).
 #### Test Plan
 - **Unit Tests**: migrated `tests/automation.test.mjs` (delegation + unchanged CI
   workflow contract); Phase-1 helper suite still green.
-- **Integration Tests**: real `npx playwright test --list` under three envs
-  (default, `CI=1`, `E2E_WORKERS=…`) confirming the config resolves workers
-  end-to-end and the invalid case fails loudly. (A full suite run is Phase 3's
-  qualification.)
+- **Integration Tests**: (a) `npx playwright test --list` once to confirm the
+  `.mjs` import loads the config; (b) a minimal real run whose worker banner
+  (`using M worker(s)`) is observed under default / `CI=1` / `E2E_WORKERS=4`
+  (the deterministic worker observable — `--list` does not print it); plus the
+  `E2E_WORKERS=abc` loud-failure case (no run starts). The full-suite ≥3× run is
+  Phase 3's qualification.
 - **Manual Testing**: eyeball Playwright's "Running X tests using N workers"
   banner for default vs `CI=1`.
 

--- a/codev/plans/41-parallelize-local-e2e-runs.md
+++ b/codev/plans/41-parallelize-local-e2e-runs.md
@@ -2,7 +2,10 @@
 
 ## Metadata
 - **ID**: plan-2026-07-22-parallelize-local-e2e-runs
-- **Status**: draft
+- **Status**: complete — all three phases implemented and 3-way approved. Final
+  outcome per Decision 4 / Scenario 5: **serial default + opt-in parallel** (the
+  planned parallel `'50%'` default was flipped to serial on adverse qualification
+  evidence; see `codev/reviews/41-parallelize-local-e2e-runs.md`).
 - **Specification**: [codev/specs/41-parallelize-local-e2e-runs.md](../specs/41-parallelize-local-e2e-runs.md)
 - **Created**: 2026-07-22
 

--- a/codev/plans/41-parallelize-local-e2e-runs.md
+++ b/codev/plans/41-parallelize-local-e2e-runs.md
@@ -1,0 +1,435 @@
+# Plan: Parallelize Local E2E Runs Scaled to Hardware (CI Byte-for-Byte Unchanged)
+
+## Metadata
+- **ID**: plan-2026-07-22-parallelize-local-e2e-runs
+- **Status**: draft
+- **Specification**: [codev/specs/41-parallelize-local-e2e-runs.md](../specs/41-parallelize-local-e2e-runs.md)
+- **Created**: 2026-07-22
+
+## Executive Summary
+
+Implements the spec's **Approach B** (selected): `playwright.config.ts` resolves
+`workers` through a small, importable, **pure helper** — `1` whenever `CI` is
+set (absolute guard), otherwise a hardware-relative scaled value governed by an
+`E2E_WORKERS` override (positive integer or `NN%` percentage) with a scaled
+default of `'50%'`; an invalid override fails loudly (fail-closed, mirroring the
+config's existing `E2E_ENGINES` guard). The helper lives in a `.mjs` file so it
+is directly unit-testable by `node --test` (mirroring the proven
+`scripts/e2e-gpu-lane.mjs` ⇐ `tests/gpu-lane.test.mjs` pattern) while the config
+imports it as a thin consumer.
+
+CI is provably untouched by two mechanisms working together: the unconditional
+`CI → 1` guard (so the 4-shard matrix's per-job serial contract holds
+automatically) and a **zero-diff `.github/workflows/validation.yml`** (the file
+must never appear in the PR diff). The native-GPU lane
+(`scripts/e2e-gpu-lane.mjs`) needs **no code change** — it never sets `workers`,
+so it inherits the config's scaled default automatically; it is the primary
+qualification vehicle (FR7/FR9).
+
+The parallel local **default** is evidence-gated per the spec's **Decision 4
+(the canonical rule)**: it ships as the default only if the parallel
+qualification (≥3 consecutive full two-engine green runs, `retries: 0`) is green;
+if SwiftShader parallel contention destabilizes the timing-sensitive
+`matrix.spec.ts` assertions, the default reverts to serial (`workers: 1`) and
+parallelism becomes opt-in via `E2E_WORKERS`, with the trade-off documented.
+That branch is decided in Phase 3 from recorded evidence — never assumed, never
+masked with retries, never by weakening a canonical assertion.
+
+Work is decomposed into three self-contained, independently testable,
+independently committable phases. Per issue #41's **PR Strategy**, all three
+phases ship as git commits on a single branch under one PR (opened after the
+final phase), not one PR per phase.
+
+## Success Metrics
+
+Copied from the spec's Success Criteria (the definition of done):
+
+- [ ] Local e2e runs use multiple workers scaled to the machine's cores; CI runs
+  are unchanged (`validation.yml` untouched in the diff and `workers` resolves to
+  `1` under `CI=1`).
+- [ ] The full two-engine local suite passes repeatedly (≥3 consecutive runs)
+  under parallel execution, **or** the parallel path is clearly separated from
+  the qualified serial gate with the trade-off documented (Decision 4 branch).
+- [ ] `playwright.config.ts` comment block updated to the new contract (the stale
+  "Do NOT raise `workers`" guidance removed, not edited around).
+- [ ] `npm run validate` wall-clock improves measurably on multi-core hardware
+  when the parallel default is qualified green, **or** the documented serial
+  trade-off path is taken.
+- [ ] `E2E_WORKERS` override works (integer + percentage); invalid values fail
+  loudly; `CI` precedence over `E2E_WORKERS` is tested.
+- [ ] No dependency/lockfile/toolchain movement; `app/**` untouched; local
+  `retries: 0` preserved; flakes never masked; no new `package.json` script.
+
+Implementation-specific metrics:
+
+- [ ] Worker-resolution logic is a pure, unit-tested helper (`node --test`), not
+  scattered conditionals in the config.
+- [ ] `npm test` (node unit tests, incl. the new helper suite + migrated
+  `automation.test.mjs`) is green locally and in CI's `quality` job.
+- [ ] `npm run lint` and `npm run typecheck` are green with the `.mjs` import.
+
+## Phases (Machine Readable)
+
+<!-- REQUIRED: porch uses this JSON to track phase progress. -->
+
+```json
+{
+  "phases": [
+    {"id": "phase_1", "title": "Pure worker-resolution helper + unit tests"},
+    {"id": "phase_2", "title": "Wire helper into config, migrate consumer, update comment"},
+    {"id": "phase_3", "title": "Qualify parallel execution, finalize default, document"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: Pure worker-resolution helper + unit tests
+**Dependencies**: None
+
+#### Objectives
+- Establish the tested worker-resolution **contract** as a standalone, pure,
+  importable module before any config wiring — so the contract is proven in
+  isolation and the config becomes a thin consumer (spec FR8, "Maintainability").
+- Deliver the full FR8 resolution matrix as executable `node --test` coverage.
+
+#### Deliverables
+- [ ] New `scripts/e2e-workers.mjs` exporting a pure `resolveWorkers(env)`, a
+  `DEFAULT_LOCAL_WORKERS` constant (`'50%'`), and a `WorkerConfigError` class
+  (mirroring `LaneUsageError` in `scripts/e2e-gpu-lane.mjs`).
+- [ ] New `tests/e2e-workers.test.mjs` asserting the full FR8 matrix.
+- [ ] JSDoc on `resolveWorkers` so the inferred signature stays clean for the
+  config's `tsc` typecheck (Phase 2 depends on this).
+
+#### Implementation Details
+- **File**: `scripts/e2e-workers.mjs` (plain ESM `.mjs` — importable by both
+  `node --test` and, in Phase 2, `playwright.config.ts`; this format is the
+  proven one for `scripts/e2e-gpu-lane.mjs`).
+- **`resolveWorkers(env)` contract** (env is a `Record<string,string|undefined>`,
+  passed explicitly so the function is pure and unit-testable without mutating
+  `process.env`; the config calls `resolveWorkers(process.env)`):
+  1. **CI guard (absolute, first):** if `env.CI` is truthy → return the number
+     `1`. Returning before reading `E2E_WORKERS` makes `CI` precedence
+     structural. (Truthy check matches the config's existing
+     `process.env.CI ? … : …` idiom for `retries`/`timeout`, so CI resolution is
+     consistent with the rest of the config.)
+  2. **`E2E_WORKERS` override:** let `raw = env.E2E_WORKERS`. If `raw` is
+     `undefined` or trims to empty → treat as unset (fall to default; a wrapper
+     exporting `E2E_WORKERS=""` must not hard-fail). Otherwise, on the trimmed
+     value:
+     - matches `/^[1-9][0-9]*$/` → return `Number(raw)` (positive integer).
+     - matches `/^[1-9][0-9]*%$/` → return the string `raw` (percentage; passed
+       through to Playwright, which computes the count from `os.cpus().length`).
+     - anything else (`0`, `0%`, `-1`, `abc`, `12x`, `1.5`, `%`) → `throw new
+       WorkerConfigError(...)` with a loud message naming the offending value and
+       the accepted forms — never a silent fallback (spec FR2; mirrors the
+       `E2E_ENGINES` "matched no known engines" guard).
+  3. **Scaled default:** return `DEFAULT_LOCAL_WORKERS` (`'50%'`). Playwright
+     floors a percentage at ≥1 worker, so a low-core host degrades gracefully.
+- No `process.env` access inside the helper; no I/O; no Playwright import —
+  purity keeps it trivially unit-testable and decoupled from Playwright.
+- **`'50%'` is the working default** (spec Decision 2's recommended value); Phase
+  3 confirms or, on adverse evidence, flips the default to serial (Decision 4).
+
+#### Acceptance Criteria
+- [ ] `node --test tests/e2e-workers.test.mjs` passes; every FR8 row is covered:
+  `{CI:'1'}` ⇒ `1`; `{CI:'1', E2E_WORKERS:'4'}` ⇒ `1` (CI precedence);
+  `{E2E_WORKERS:'4'}` ⇒ `4`; `{E2E_WORKERS:'50%'}` ⇒ `'50%'`;
+  `{E2E_WORKERS:'0'|'abc'|'12x'|'0%'|'-1'|'1.5'}` ⇒ throws `WorkerConfigError`;
+  `{}` (no CI, no override) ⇒ `'50%'`; `{E2E_WORKERS:''}` ⇒ `'50%'` (empty=unset).
+- [ ] `npm test` stays green (new file included via the `tests/*.test.mjs` glob).
+- [ ] `npm run lint` passes on the new files.
+- [ ] `.github/workflows/validation.yml` unchanged (not touched this phase).
+
+#### Test Plan
+- **Unit Tests**: `tests/e2e-workers.test.mjs` — the full matrix above, driving
+  the pure function directly with literal env objects (behavior, not mocks; no
+  Playwright, no `process.env` mutation).
+- **Integration Tests**: none this phase (helper not yet wired — Phase 2).
+- **Manual Testing**: none required; the unit suite is the contract.
+
+#### Rollback Strategy
+Delete the two new files. Nothing else references them yet, so rollback is
+inert (no existing behavior touched).
+
+#### Risks
+- **Risk**: Percentage/integer regex admits an unintended form (e.g. leading
+  zeros, `1e2`).
+  - **Mitigation**: Explicit anchored regexes plus negative test rows for
+    `1.5`, `01`?, `1e2`, `%`, `12x` in the unit suite; decide leading-zero
+    disposition explicitly in a test.
+
+---
+
+### Phase 2: Wire helper into config, migrate consumer, update comment
+**Dependencies**: Phase 1
+
+#### Objectives
+- Make `playwright.config.ts` resolve `workers` via the Phase-1 helper, delivering
+  hardware-scaled local parallelism with the absolute `CI → 1` guard (FR1/FR3).
+- Replace the stale `workers: 1` comment block with the new contract (FR10).
+- Migrate the source-text consumer in `tests/automation.test.mjs` so the suite
+  reflects reality (FR8) without weakening the CI-contract test.
+
+#### Deliverables
+- [ ] `playwright.config.ts`: import `resolveWorkers` from
+  `./scripts/e2e-workers.mjs`; replace `workers: 1` with
+  `workers: resolveWorkers(process.env)`.
+- [ ] `playwright.config.ts`: rewrite the lines ~96–103 comment block to the new
+  contract (local hardware-scaled parallel via `E2E_WORKERS`/`'50%'` default; CI
+  hard-pinned serial via the guard; local `retries: 0` preserved; qualification
+  rationale). Remove the "Do NOT raise `workers`" text (do not edit around it).
+- [ ] `tests/automation.test.mjs`: migrate the `/workers: 1/` assertion (line 90)
+  to assert the config **delegates** to the helper (e.g.
+  `/workers: resolveWorkers\(process\.env\)/`) and update the adjacent comment;
+  keep `fullyParallel: true` (89) and the retries assertion (93) as-is (retries
+  are unchanged).
+
+#### Implementation Details
+- **Import in the `.ts` config**: `import {resolveWorkers} from
+  "./scripts/e2e-workers.mjs";`. `tsconfig` `include` covers `playwright.config.ts`
+  and `checkJs` is off, so the JS import is not error-checked internally; the
+  JSDoc from Phase 1 keeps the inferred return type (`number | string`) clean
+  where it flows into `defineConfig`'s `workers` field.
+- **CI-serial contract now behavioral**: the "CI runs each shard serially"
+  guarantee moves from a literal `workers: 1` source line to
+  `resolveWorkers({CI:…}) === 1`, which is covered by the Phase-1 unit suite. The
+  `automation.test.mjs` migration therefore asserts *delegation* (the config uses
+  the tested resolver) rather than re-testing the matrix there — keeping the CI
+  source-contract test meaningful without duplicating Phase 1.
+- **No `package.json` change** (no new script; `E2E_WORKERS` is an env var), so
+  `automation.test.mjs`'s "documents every direct package command" test is
+  unaffected.
+- **Retries untouched** (FR5): the `retries: process.env.CI ? 2 : 0` line and its
+  assertion stay exactly as-is.
+
+#### Acceptance Criteria
+- [ ] `npm run typecheck` passes with the `.mjs` import.
+- [ ] `npm test` passes (migrated `automation.test.mjs` + Phase-1 unit suite).
+- [ ] **Config actually loads and resolves** (not just compiles): a real
+  Playwright invocation confirms parallel workers locally — e.g.
+  `E2E_ENGINES=chromium npx playwright test --list` runs without config error and
+  a real run prints "using N workers" (N>1 on this multi-core host); and
+  `CI=1 E2E_ENGINES=chromium npx playwright test --list` resolves to 1 worker.
+  (Lessons-critical: "it compiled" ≠ "it works" — exercise the real config path.)
+- [ ] `E2E_WORKERS=4` → 4 workers; `E2E_WORKERS=50%` → hardware-relative;
+  `E2E_WORKERS=abc` → loud config-resolution failure (no silent serial).
+- [ ] The `workers: 1` comment block is gone; the new contract comment is present.
+- [ ] `.github/workflows/validation.yml` unchanged (verified:
+  `git diff --name-only` does not list it).
+
+#### Test Plan
+- **Unit Tests**: migrated `tests/automation.test.mjs` (delegation + unchanged CI
+  workflow contract); Phase-1 helper suite still green.
+- **Integration Tests**: real `npx playwright test --list` under three envs
+  (default, `CI=1`, `E2E_WORKERS=…`) confirming the config resolves workers
+  end-to-end and the invalid case fails loudly. (A full suite run is Phase 3's
+  qualification.)
+- **Manual Testing**: eyeball Playwright's "Running X tests using N workers"
+  banner for default vs `CI=1`.
+
+#### Rollback Strategy
+Revert `playwright.config.ts` to `workers: 1` and restore the original comment;
+revert the `automation.test.mjs` assertion. The Phase-1 helper can remain
+(unreferenced) or be reverted with Phase 1.
+
+#### Risks
+- **Risk**: Playwright's config loader cannot import the sibling `.mjs`.
+  - **Mitigation**: The end-to-end `--list` acceptance run catches this
+    immediately. Fallback if it fails: co-locate the helper as a `.ts` re-export
+    or inline a thin `.ts` shim the config imports while the test keeps importing
+    the `.mjs` — decided only if the real run fails, not preemptively.
+- **Risk**: A stray `E2E_WORKERS` in a CI-like environment parallelizes a shard.
+  - **Mitigation**: FR3 absolute `CI → 1` guard (returns before reading
+    `E2E_WORKERS`), asserted in Phase 1 and re-verified by the `CI=1 --list` run.
+
+---
+
+### Phase 3: Qualify parallel execution, finalize default, document
+**Dependencies**: Phase 2
+
+#### Objectives
+- Qualify parallel execution with recorded, honest evidence (FR9) and, per
+  Decision 4, **finalize the local default** (parallel `'50%'` vs. serial +
+  opt-in) from that evidence.
+- Confirm the native-GPU lane inherits parallel workers (FR7) with no code change.
+- Document the new contract (FR11) and prove CI is untouched (FR4).
+
+#### Deliverables
+- [ ] Qualification evidence gathered (for transcription into the Review):
+  **≥3 consecutive full two-engine runs** with per-test pass/fail, wall-clock,
+  resolved worker count, `retries: 0` — **primary vehicle: the native-GPU lane**
+  (`E2E_GPU_REQUIRE=1` so a silent software fallback cannot pollute evidence),
+  plus a contemporaneous **serial baseline** wall-clock (`E2E_WORKERS=1`) for
+  comparison.
+- [ ] If the parallel `npm run validate` default is adopted:
+  **SwiftShader-parallel** stability evidence (≥3 consecutive
+  `npm run validate` runs at the scaled default), same recording discipline.
+- [ ] **Default finalized in `scripts/e2e-workers.mjs`**: keep
+  `DEFAULT_LOCAL_WORKERS='50%'` if qualified green; **or** flip the default to
+  serial (`1`) with parallel remaining opt-in via `E2E_WORKERS`, if evidence
+  shows instability — with the trade-off recorded (Decision 4 / Scenario 5).
+- [ ] FR7 verified: the GPU lane runs the full suite under the scaled workers by
+  inheritance (no `scripts/e2e-gpu-lane.mjs` change); if — contrary to analysis —
+  it pins workers, apply the minimal fix to let it inherit/honor `E2E_WORKERS`.
+- [ ] `README.md` updated (FR11): local runs are parallel + hardware-scaled by
+  default (or the opt-in + serial-default outcome, whichever qualified); how to
+  tune with `E2E_WORKERS` (integer or `%`); CI unchanged (`workers: 1` whenever
+  `CI` is set); local `retries: 0` preserved; the qualification outcome. Touch
+  points: the script/table lines (~70–72), the lane "same `workers: 1`" line
+  (~178), the "#41 … sequenced after" note (~284–285, now delivered), and the
+  lane env-var table (~222–228, add `E2E_WORKERS`).
+- [ ] CI-untouched proof: `git diff --name-only origin/main` does not list
+  `.github/workflows/validation.yml`.
+
+#### Implementation Details
+- **GPU-hardware contingency (WSL2 builder):** the GPU lane requires a verifiable
+  hardware WebGL adapter; on this builder that may be unavailable, so
+  `E2E_GPU_REQUIRE=1` may abort. Evidence-gated branch (no outcome assumed):
+  1. **GPU lane verifies hardware** → run it ≥3× under scaled parallel workers;
+     this is the primary, contention-free qualification (Decision 3).
+  2. **GPU lane cannot verify hardware here** → record that honestly; qualify the
+     parallel **`validate`** default on the SwiftShader path instead (≥3×), which
+     is the path that actually gates. Note the missing contention-free substrate
+     as a limitation.
+  3. **SwiftShader parallel destabilizes** the timing-qualified `matrix.spec.ts`
+     tests (the exact risk the old comment named; #34/#33 may amplify) → take
+     Decision 4's fallback: default serial, parallel opt-in via `E2E_WORKERS`,
+     trade-off documented; any instability dispositioned per flake discipline
+     (fixed or explicitly accepted+documented) — **never masked with retries,
+     never by weakening a canonical assertion**.
+- All wall-clocks/worker-counts/per-test results recorded **verbatim**; a single
+  host's parallel result is never generalized (Evidence honesty).
+- The `README` CI-decomposition lines that state each shard runs `workers: 1`
+  remain **true** (CI is unchanged) and are kept; only the *local*-run and *lane*
+  descriptions change.
+
+#### Acceptance Criteria
+- [ ] ≥3 consecutive full two-engine parallel runs recorded with the required
+  detail (worker count, per-test, wall-clock, `retries: 0`), on the GPU lane
+  under `E2E_GPU_REQUIRE=1` where hardware is available — else the documented
+  SwiftShader-`validate` path with the limitation noted.
+- [ ] The finalized default matches the evidence (parallel `'50%'` green, or
+  serial + opt-in documented); Success Metric 4 met (measurable `validate`
+  speedup) or the documented trade-off taken.
+- [ ] `README` states the new contract; a reader who hasn't seen the spec can
+  find: parallel + hardware-scaled local runs, `E2E_WORKERS` tuning, CI unchanged,
+  `retries: 0` preserved, the qualification outcome (Scenario 6).
+- [ ] `npm test`, `npm run lint`, `npm run typecheck` green;
+  `automation.test.mjs`'s README assertions (`E2E_ENGINES=chromium`,
+  `playwright install --with-deps chromium`, script list) still pass.
+- [ ] `.github/workflows/validation.yml` absent from the PR diff.
+
+#### Test Plan
+- **Unit Tests**: if the default flips, update/confirm the Phase-1 matrix row for
+  the default; otherwise unchanged.
+- **Integration Tests**: the repeat-run qualification IS the integration test —
+  the real full suite under the real resolved config, ≥3×.
+- **Manual Testing**: read the rendered README section for accuracy; confirm
+  `git diff` cleanliness for `validation.yml`.
+
+#### Rollback Strategy
+README and any default flip are revertible in isolation. If qualification cannot
+be completed on the builder hardware (no GPU + SwiftShader-parallel unstable),
+the safe landing is the serial-default + opt-in-parallel branch, which is a
+strict superset of today's behavior (default identical to current serial) plus a
+new opt-in — so it never regresses the gate.
+
+#### Risks
+- **Risk**: No GPU on the builder blocks the *primary* (contention-free)
+  qualification.
+  - **Mitigation**: Contingency branch above; SwiftShader-`validate`
+    qualification still gates the shippable default; escalate to the architect via
+    `afx send` only if neither branch can produce honest evidence.
+- **Risk**: Parallel contention amplifies #34 (click-to-focus) / #33 (Firefox
+  pointer-nav) flakes.
+  - **Mitigation**: `retries: 0` keeps them visible (FR5); dispositioned per flake
+    discipline, never masked; if they block the parallel default, take the serial
+    fallback and document.
+
+## Dependency Map
+```
+Phase 1 (pure helper + unit tests)
+   └─→ Phase 2 (wire config, migrate consumer, comment)
+          └─→ Phase 3 (qualify, finalize default, document)
+```
+Strictly linear: Phase 2 needs the tested helper to import; Phase 3 needs the
+wired config to run the qualification and finalize the default.
+
+## Risk Analysis
+
+### Technical Risks
+| Risk | Probability | Impact | Mitigation | Owner |
+|------|------------|--------|------------|-------|
+| SwiftShader parallel contention destabilizes timing-qualified `matrix.spec.ts` | M-H | M | FR9 repeat-run at `retries: 0`; Decision-4 evidence-gated default + documented serial fallback; primary qualification on the contention-free GPU lane | builder |
+| No verifiable GPU on the WSL2 builder → primary qualification vehicle unavailable | M | M | Phase-3 contingency: SwiftShader-`validate` qualifies the shippable default; note the limitation; escalate only if no honest evidence is reachable | builder |
+| Playwright config loader can't import the sibling `.mjs` | L | M | Phase-2 end-to-end `--list` run catches it; `.ts` shim fallback decided only if it fails | builder |
+| Open flakes #34 / #33 amplified under parallel contention | M | M | `retries: 0` keeps them visible (FR5); disposition per flake discipline, never masked | builder |
+| Stray `E2E_WORKERS` in a CI-like env parallelizes a shard | L | H | FR3 absolute `CI → 1` guard (returns before reading `E2E_WORKERS`), tested (FR8) + re-verified | builder |
+| Config change drifts the qualified CI contract | L | H | FR4 zero-diff `validation.yml` + CI green; guard is a one-line tested invariant | builder |
+| Invalid `E2E_WORKERS` silently falls back and misleads | L | M | FR2 fail-closed `WorkerConfigError`, tested (FR8) | builder |
+| `automation.test.mjs` source-text assertion left stale, hiding the change | M | L | FR8 migration is in Phase 2 scope | builder |
+
+### Schedule Risks
+Not applicable — no time estimates (AI-driven development; progress measured by
+completed phases).
+
+## Validation Checkpoints
+1. **After Phase 1**: `node --test tests/e2e-workers.test.mjs` green; full FR8
+   matrix covered; `npm test` and `npm run lint` green.
+2. **After Phase 2**: `npm run typecheck` / `npm test` green; real `playwright
+   test --list` resolves workers correctly under default / `CI=1` /
+   `E2E_WORKERS`; invalid override fails loudly; comment block replaced;
+   `validation.yml` untouched.
+3. **After Phase 3 (before PR)**: ≥3-run parallel qualification recorded; default
+   finalized from evidence; README reflects the outcome; full `npm run validate`
+   green; `git diff` shows no `validation.yml` change.
+4. **PR / CI**: PR CI (quality + 4 SwiftShader e2e shards + gate) green,
+   confirming CI behavior is byte-for-byte preserved.
+
+## Integration Points
+### External Systems
+None. No external services, APIs, or infrastructure — this is
+test-harness/config/tooling and documentation work.
+
+### Internal Systems
+- **`playwright.config.ts`** — consumes `resolveWorkers` (Phase 2).
+- **`scripts/e2e-gpu-lane.mjs`** — inherits the scaled default with no code
+  change (verified Phase 3); primary qualification substrate.
+- **`tests/automation.test.mjs`**, **`tests/e2e-workers.test.mjs`** — the config
+  source-contract and helper-matrix test consumers.
+
+## Documentation Updates Required
+- [ ] `README.md` (FR11): local-parallel default / `E2E_WORKERS` tuning / CI
+  unchanged / `retries: 0` preserved / qualification outcome; update the lane
+  "same `workers: 1`" line and the "#41 sequenced after" note; add `E2E_WORKERS`
+  to the lane env-var table.
+- [ ] `playwright.config.ts` comment block (FR10) — done in Phase 2.
+- [ ] N/A: API docs, architecture diagrams, runbooks, deployment/config guides
+  (no such surfaces are affected).
+- Arch/lessons governance-doc updates, if any durable facts emerge, are handled
+  in the Review phase via the `update-arch-docs` skill (not a code phase).
+
+## Resource Requirements
+- **Environment**: the pinned toolchain (Node 22.23.1 / npm 10.9.8, `npm ci`,
+  lockfile v3); a multi-core host to observe the parallel speedup; ideally a
+  verifiable hardware-WebGL adapter for the GPU-lane qualification (contingency if
+  absent — see Phase 3).
+- **Infrastructure**: none (no DB, services, config, or monitoring changes).
+
+## Notes
+- **Module-format decision**: the helper is a `.mjs` (plain ESM) so `node --test`
+  imports it directly (the config's `.ts` is not runnable by `node --test`); the
+  `.ts` config imports the `.mjs`. This mirrors the established
+  `scripts/e2e-gpu-lane.mjs` ⇐ `tests/gpu-lane.test.mjs` pattern.
+- **Default value**: `'50%'` is the spec's recommended working default; Phase 3
+  either confirms it or flips it to serial per recorded evidence (Decision 4).
+- **No new npm script / no dependency movement**: `E2E_WORKERS` is an env var;
+  the lockfile shows no delta; `app/**` is untouched.
+- **PR strategy**: one PR, three phase-commits, opened after Phase 3 (issue #41).
+  CI is a stakeholder only in being provably unaffected.
+
+## Change Log
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-07-22 | Initial implementation plan | Spec 41 approved; decompose into 3 phases | builder (spir-41) |

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-claude.txt
@@ -1,0 +1,89 @@
+Now let me verify the tests actually pass and check lint:Lint is failing. Let me check what files the lint errors are in:Good — all 21 lint errors are in `.claude/hooks/worktree-write-guard.cjs`, a builder-harness file. Per lessons-critical, this is environment noise ("A local gate failure caused only by an untracked builder-harness file… is environment noise, not a project failure"). The new `scripts/e2e-workers.mjs` and `tests/e2e-workers.test.mjs` produce **zero lint errors**.
+
+Let me also verify the git diff doesn't touch `validation.yml`:Good. `validation.yml` is not in the diff, confirming FR4. The test file mirrors the `gpu-lane.test.mjs` pattern (same `node:assert/strict` + `node:test` imports, pure function testing).
+
+Let me now do a final quality check — verify `package.json` to confirm the glob that picks up tests:The `tests/*.test.mjs` glob naturally includes the new `tests/e2e-workers.test.mjs`. Good.
+
+Now let me do a thorough review of the implementation against the plan's Phase 1 acceptance criteria:
+
+---
+
+## Review: Phase 1 — Pure worker-resolution helper + unit tests
+
+### 1. Spec Adherence
+
+**FR8 resolution matrix — fully covered.** The test file exercises every row the plan calls out:
+
+| Row | Covered? |
+|-----|----------|
+| `{CI:'1'}` ⇒ `1` | ✅ test line 22 |
+| `{CI:'1', E2E_WORKERS:'4'}` ⇒ `1` (CI precedence) | ✅ test line 28 |
+| `{CI:'1', E2E_WORKERS:'abc'}` ⇒ `1` (CI short-circuits before invalid read) | ✅ test line 31 |
+| `{E2E_WORKERS:'4'}` ⇒ `4` | ✅ test line 35 |
+| `{E2E_WORKERS:'50%'}` ⇒ `'50%'` | ✅ test line 41 |
+| Invalid values (0, 0%, -1, abc, 12x, 1.5, %, 01, 1e2, 50 %, 4.0, 0x10, `%`) ⇒ throws | ✅ tests lines 71–94 |
+| `{}` ⇒ `'50%'` (default) | ✅ test line 47 |
+| `{E2E_WORKERS:''}` ⇒ `'50%'` (empty=unset) | ✅ test line 52 |
+
+**FR2 fail-closed loud failure**: `WorkerConfigError` thrown with a descriptive message naming the offending value and accepted forms — explicitly tested (lines 96–105).
+
+**FR3 CI guard (absolute, first)**: structurally enforced — the `if (env.CI)` returns before `env.E2E_WORKERS` is read (line 59). CI precedence over `E2E_WORKERS` tested explicitly, including the case where `E2E_WORKERS` would otherwise throw.
+
+**Decision 2 default `'50%'`**: ✅ Named constant `DEFAULT_LOCAL_WORKERS` exported and asserted.
+
+### 2. Code Quality
+
+- **Purity**: The function takes an explicit `env` parameter, performs no I/O, and does not access `process.env` — exactly as specified. This makes it trivially testable.
+- **Pattern mirrors `e2e-gpu-lane.mjs`**: `WorkerConfigError` extends `Error` (matches `LaneUsageError`); same module structure (constants + pure functions, `.mjs` for `node --test` compatibility).
+- **Regexes are anchored**: `^[1-9][0-9]*$` and `^[1-9][0-9]*%$` — prevents partial matches. Leading zeros, exponent notation, decimals all correctly rejected.
+- **Whitespace handling**: `raw.trim()` before matching; empty-after-trim falls through to default (not a hard fail). This is the right call for env vars that shells might export as empty.
+- **JSDoc present**: Return type `number | string` is documented, which Phase 2 needs for the `.ts` config's type inference.
+
+### 3. Test Coverage
+
+**24 tests, all passing.** Coverage is thorough:
+- All happy-path resolution branches (CI, integer, percentage, default)
+- CI precedence over valid and invalid `E2E_WORKERS`
+- 13 distinct invalid values including edge cases the plan's risk section flagged (leading zeros, exponent, hex)
+- Whitespace trimming around valid values
+- Empty/undefined CI semantics (falsy check matches the config's existing idiom)
+- Error class identity and message content
+- The `DEFAULT_LOCAL_WORKERS` constant value
+
+**Negative test thoroughness is excellent** — the plan flagged `1e2`, `01`, `1.5` as risks and all three are explicitly tested.
+
+### 4. Error Handling
+
+- Invalid `E2E_WORKERS`: throws `WorkerConfigError` with a descriptive message — never silently falls back. ✅
+- Empty `E2E_WORKERS`: treated as unset, falls to default. ✅ (correct — a shell exporting `E2E_WORKERS=""` shouldn't fail)
+- `CI=""`: falsy, falls through to the local path. ✅ (mirrors the config's existing `process.env.CI ? … : …` idiom)
+
+### 5. Plan Alignment
+
+All Phase 1 deliverables are present:
+
+| Deliverable | Status |
+|------------|--------|
+| `scripts/e2e-workers.mjs` with `resolveWorkers(env)`, `DEFAULT_LOCAL_WORKERS`, `WorkerConfigError` | ✅ |
+| `tests/e2e-workers.test.mjs` with full FR8 matrix | ✅ |
+| JSDoc on `resolveWorkers` | ✅ |
+| `node --test` passes | ✅ (24/24) |
+| `npm test` stays green | ✅ (121/121) |
+| `npm run lint` passes on the new files | ✅ (lint errors are pre-existing harness noise, not from these files) |
+| `.github/workflows/validation.yml` unchanged | ✅ |
+
+### Minor observations (not blocking)
+
+1. The `CI: undefined` case in the "empty CI" test (line 66) is a nice touch — it proves `undefined` doesn't match the truthy check. This isn't in the plan's explicit matrix but it's a reasonable defensive test.
+
+2. The whitespace-trimming test (line 56–59) with `\t50%\n` covers a real-world scenario (trailing newline from a heredoc-style env assignment). Good defensive coverage.
+
+---
+
+VERDICT: APPROVE
+SUMMARY: Phase 1 delivers a clean, pure, thoroughly-tested worker-resolution helper that covers the full FR8 matrix with 24 passing tests and zero lint errors on the new files.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-codex.txt
@@ -1,0 +1,8 @@
+I’m reviewing phase_1 only and reading the changed files from disk to verify the helper and its tests against the plan/spec.I’ve verified the phase_1 plan and the new helper/tests; now I’m running the phase-relevant test commands to confirm behavior.`node --test` for the new helper passes. `npm test` is currently failing, but on an unrelated existing test file, so I’m checking that failure before deciding whether it’s a phase_1 regression.The repo-wide lint script also fails on an unrelated existing hook file, so I’m checking the new phase_1 files directly to make sure they’re clean.---
+VERDICT: APPROVE
+SUMMARY: Phase 1 is implemented as planned: the pure worker-resolution helper is correct, well-tested, and scoped cleanly for later config wiring.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_1-iter1-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 1 implementation exactly matches the plan with a robust pure helper and comprehensive test coverage.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
@@ -1,0 +1,56 @@
+I'll read the key files for this Phase 2 review. Let me start with the implementation files and their context.Now let me check the original config to understand the diff, and verify the CI workflow wasn't touched.Good. Let me verify the acceptance criteria by checking the actual test results and typecheck status.Both typecheck and all 121 unit tests pass. Let me also verify the config loads correctly in Playwright and check the `tsconfig.json` to confirm the `.mjs` import path is expected to work.Config loads correctly. Let me also verify lint passes and do a quick sanity check on the git diff to make sure `validation.yml` is clean.Lint has errors. Let me see the full output to understand which files are affected.All 21 lint errors are from the untracked builder-harness file `.claude/hooks/worktree-write-guard.cjs` — environment noise per lessons-critical. The committed project code is lint-clean.
+
+Now let me do a final verification — check that the `automation.test.mjs` assertion migration is sound against the actual config content:All assertions match. Here's my review:
+
+---
+
+## Phase 2 Review: Wire helper into config, migrate consumer, update comment
+
+### Spec Adherence
+
+**All Phase 2 deliverables are present and correct:**
+
+1. **FR1/FR3 — Config wiring** ✅: `playwright.config.ts` line 4 imports `resolveWorkers` from `./scripts/e2e-workers.mjs`; line 120 replaces `workers: 1` with `workers: resolveWorkers(process.env)`. The CI guard is structural (the resolver returns `1` before reading `E2E_WORKERS`), satisfying FR3's absolute serial guarantee.
+
+2. **FR10 — Comment block replaced** ✅: The old "Do NOT raise `workers`" block (lines ~96–103) is fully replaced with a 20-line contract comment (lines 98–118) documenting: CI hard-pinned serial via the resolver, local hardware-scaled parallel with `'50%'` default, `E2E_WORKERS` override with fail-closed semantics, preserved `retries: 0`, and the qualification rationale. The stale guidance is gone, not edited around.
+
+3. **FR8 — Consumer migration** ✅: `tests/automation.test.mjs` line 94 now asserts `/workers: resolveWorkers\(process\.env\)/` instead of `/workers: 1/`. The comment (lines 88–92) explains the delegation pattern clearly: CI-serial is covered by the resolver's unit tests, so this test asserts only that the config delegates to the tested resolver. `fullyParallel: true` (line 93) and retries (line 97) assertions are untouched, which is correct.
+
+4. **FR5 — Retries preserved** ✅: `retries: process.env.CI ? 2 : 0` (config line 128) is byte-identical to the original.
+
+5. **FR4 — CI workflow untouched** ✅: `.github/workflows/validation.yml` does not appear in the diff (verified via `git diff --name-only`).
+
+### Code Quality
+
+**Excellent.** The implementation is minimal and precise:
+- The config stays a thin consumer — one import, one function call. No scattered conditionals.
+- The comment block is thorough without being bloated; it documents the "why" (CI serial contract, local hardware scaling, qualification context) not just the "what."
+- The `automation.test.mjs` migration is well-reasoned: it asserts *delegation* to the tested resolver rather than re-testing the resolution matrix, which avoids duplication while keeping the CI-contract assertion meaningful.
+
+### Test Coverage
+
+**Adequate for this phase:**
+- `npm test` passes all 121 tests (includes both the Phase 1 `e2e-workers.test.mjs` suite and the migrated `automation.test.mjs`).
+- The regex assertions in `automation.test.mjs` match the actual config content (verified).
+- The plan explicitly defers the ≥3× full-suite repeat-run qualification to Phase 3.
+
+### Error Handling
+
+**Not directly applicable to this phase** — error handling lives in the Phase 1 helper (`WorkerConfigError` on invalid `E2E_WORKERS`). The config correctly propagates it by calling `resolveWorkers(process.env)` at config-evaluation time, so a `WorkerConfigError` surfaces immediately at Playwright startup.
+
+### Plan Alignment
+
+The implementation follows the Phase 2 plan exactly. Every deliverable is present, no items are skipped, and no out-of-scope work was added. The `tsconfig.json` uses `moduleResolution: "bundler"`, which handles `.mjs` imports from `.ts` files cleanly — the `--list` integration test confirms Playwright loads the config without error.
+
+### Minor Note (not actionable)
+
+The `npm run lint` failure is entirely from the untracked `.claude/hooks/worktree-write-guard.cjs` — a builder-harness file absent from clean checkouts. Per lessons-critical, this is environment noise, not a project failure. The committed project code is lint-clean.
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 delivers all plan deliverables cleanly — config wired to the tested resolver, comment block replaced with the new contract, consumer assertion migrated, CI provably untouched, all 121 tests and typecheck green.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-codex.txt
@@ -1,0 +1,8 @@
+Using direct file reads to verify the phase-2 implementation against the actual repo contents.Reading the plan/spec and package metadata to verify phase scope and project conventions before judging the implementation.Checking the builder’s recorded phase notes for evidence of the phase-2 validation steps.Getting exact line numbers for the config comment before finalizing the review.---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Phase 2 is mostly implemented correctly, but the new Playwright config comment incorrectly states the local parallel default is already qualified before phase 3 records that evidence.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- `playwright.config.ts:115-118` overstates the qualification status: “the parallel local default is qualified by repeated full two-engine runs…” is not true yet in phase 2. Per the spec/plan, qualification evidence and final default disposition belong to phase 3, so this comment should describe the rationale/evidence gate without asserting completion.
+- None otherwise: the helper is wired in correctly (`playwright.config.ts:120`), the stale `workers: 1` source-text assertion was migrated appropriately in `tests/automation.test.mjs`, and the phase-2 scope appears otherwise aligned with the plan.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 deliverables are fully complete, correctly delegating worker resolution to the pure helper and migrating assertions.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-rebuttals.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-rebuttals.md
@@ -1,0 +1,53 @@
+# Phase 2 — Iteration 1 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Gemini and Claude approved with no issues. Codex raised a single, narrow,
+legitimate point, which I **accepted and fixed**. Details below.
+
+## Codex — `playwright.config.ts` comment overstates qualification status (ACCEPTED, FIXED)
+
+> `playwright.config.ts:115-118` overstates the qualification status: "the
+> parallel local default is qualified by repeated full two-engine runs…" is not
+> true yet in phase 2. Per the spec/plan, qualification evidence and final
+> default disposition belong to phase 3, so this comment should describe the
+> rationale/evidence gate without asserting completion.
+
+**Agreed — this is a correct catch.** The Phase-2 scope is *wiring* the resolver
+into the config; the ≥3-run repeat qualification and the final default
+disposition (keep `'50%'` parallel vs. revert to serial) are explicitly **Phase
+3** per the plan and spec Decision 4. My comment used the present-tense "is
+qualified by…", which reads as *completed* qualification and is premature.
+
+**Change made** (comment-only, no behavioral change):
+
+- Before: "…the parallel local default **is qualified by** repeated full
+  two-engine runs on the native-GPU lane (issue #41), while CI keeps that serial
+  contract automatically via the guard above."
+- After: "…this parallel local default **is being qualified by** repeated full
+  two-engine runs on the native-GPU lane (issue #41) — **that evidence, not this
+  wiring, decides whether it remains the default or reverts to serial.** CI keeps
+  its serial contract automatically via the guard above regardless of that
+  outcome."
+
+This now frames the parallel default as an in-progress, evidence-gated decision
+owned by Phase 3, rather than asserting the qualification is done.
+
+## Codex — non-blocking confirmations (no action needed)
+
+> the helper is wired in correctly (`playwright.config.ts:120`), the stale
+> `workers: 1` source-text assertion was migrated appropriately in
+> `tests/automation.test.mjs`, and the phase-2 scope appears otherwise aligned
+> with the plan.
+
+No change required — noted as positive confirmation of the wiring and the
+`automation.test.mjs` migration.
+
+## Verification after the fix
+
+The change is comment-only; the `workers: resolveWorkers(process.env)` line is
+untouched, so the migrated `automation.test.mjs` assertion still matches. Re-ran:
+
+- `npm test` → 121/121 pass
+- `npm run typecheck` → clean (`.mjs`-from-`.ts` import resolves)
+- `.github/workflows/validation.yml` remains absent from `git diff` (CI unchanged)

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-claude.txt
@@ -1,0 +1,63 @@
+I'll read the key Phase 2 files to review the implementation.Now let me verify the iteration-1 fix (the Codex concern about the comment) and check any remaining context files.I've read all the relevant files. Let me now systematically evaluate the Phase 2 deliverables.
+
+## Phase 2 Review: Wire helper into config, migrate consumer, update comment
+
+### Deliverable 1: Import and wire `resolveWorkers`
+
+**`playwright.config.ts`:**
+- Line 4: `import {resolveWorkers} from "./scripts/e2e-workers.mjs";` — correct import path, named import. ✅
+- Line 122: `workers: resolveWorkers(process.env),` — replaces the old `workers: 1`, passes `process.env` as the pure function expects. ✅
+
+### Deliverable 2: Comment block rewrite (FR10)
+
+Lines 98–120 replace the old `workers: 1` / "Do NOT raise workers" block with the new contract:
+- Explains `fullyParallel` serves two consumers (CI `--shard` and local parallel). ✅
+- Documents CI guard: hard-pinned to 1, returns BEFORE reading `E2E_WORKERS`. ✅
+- Documents local scaling: `'50%'` default, `E2E_WORKERS` override, invalid → loud `WorkerConfigError`. ✅
+- Documents `retries: 0` preserved locally. ✅
+- **Iteration-1 fix verified**: line 117 says "is **being** qualified by" (not "is qualified by"), and lines 118–119 add "that evidence, not this wiring, decides whether it remains the default or reverts to serial." This correctly frames qualification as Phase 3 work. ✅
+- Old "Do NOT raise `workers`" guidance is fully removed, not edited around. ✅
+
+### Deliverable 3: `tests/automation.test.mjs` migration (FR8)
+
+- Line 94: `/workers: resolveWorkers\(process\.env\)/` replaces the old `/workers: 1/` — asserts delegation, not a literal value. ✅
+- Lines 87–92: Comment updated to explain the delegation model ("CI is hard-pinned to 1 so execution within a shard stays strictly serial… while local runs scale to hardware. The CI-serial matrix in that resolver is covered by `tests/e2e-workers.test.mjs`; here we assert only that the config delegates to it."). Correctly avoids duplicating Phase 1 coverage. ✅
+- `fullyParallel: true` assertion unchanged (line 93). ✅
+- `retries: process.env.CI ? 2 : 0` assertion unchanged (line 97). ✅
+- No other test assertions touched — the CI workflow contract tests, README assertions, and package.json script assertions are all untouched. ✅
+
+### Plan Acceptance Criteria
+
+| Criterion | Status |
+|-----------|--------|
+| `npm run typecheck` passes with `.mjs` import | ✅ (builder verified) |
+| `npm test` passes (migrated `automation.test.mjs` + Phase 1 suite) | ✅ (121/121) |
+| Comment block replaced with new contract | ✅ |
+| `.github/workflows/validation.yml` unchanged | ✅ (not in changed files) |
+| No `package.json` change | ✅ |
+| `retries` line untouched | ✅ (line 130) |
+| No lockfile / dependency / `app/**` changes | ✅ |
+
+### Spec Adherence
+
+- **FR1 (hardware-scaled local workers)**: Config now resolves `workers` through the tested helper, delivering `'50%'` scaled-to-cores locally. ✅
+- **FR3 (CI serial guard)**: The guard is structural in the helper (returns `1` before reading `E2E_WORKERS`) and the config consumes it via `resolveWorkers(process.env)`. ✅
+- **FR5 (retries: 0 preserved)**: Line 130 is byte-for-byte unchanged. ✅
+- **FR10 (updated config rationale)**: Fully replaced, not edited around. ✅
+- **FR8 (consumer migration)**: `automation.test.mjs` asserts delegation. ✅
+
+### Code Quality
+
+The implementation is clean and minimal. The config is now a thin consumer of the tested resolver — exactly as the plan prescribed. The comment block is well-structured, accurately describes the contract, and properly frames the qualification as in-progress (Phase 3). The `automation.test.mjs` migration correctly asserts *delegation* rather than re-testing the resolution matrix, which keeps test responsibilities clear (Phase 1 tests own the matrix; this test owns "config uses the resolver").
+
+### Iteration-1 Concerns
+
+The single concern from iteration 1 (Codex: comment overstated qualification status) is confirmed fixed in the actual file. No concerns to re-raise.
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 deliverables are fully complete — config wired to the tested resolver, stale comment block replaced with the accurate new contract (with the iteration-1 tense fix applied), consumer assertion migrated to delegation, CI provably untouched.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-codex.txt
@@ -1,0 +1,8 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 is implemented as planned: the helper is wired into Playwright config, the stale worker comment is replaced with the new contract, and the automation consumer was migrated correctly.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-context.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-context.md
@@ -1,0 +1,68 @@
+### Iteration 1 Reviews
+- gemini: APPROVE — Phase 2 deliverables are fully complete, correctly delegating worker resolution to the pure helper and migrating assertions.
+- codex: REQUEST_CHANGES — Phase 2 is mostly implemented correctly, but the new Playwright config comment incorrectly states the local parallel default is already qualified before phase 3 records that evidence.
+- claude: APPROVE — Phase 2 delivers all plan deliverables cleanly — config wired to the tested resolver, comment block replaced with the new contract, consumer assertion migrated, CI provably untouched, all 121 tests and typecheck green.
+
+### Builder Response to Iteration 1
+# Phase 2 — Iteration 1 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Gemini and Claude approved with no issues. Codex raised a single, narrow,
+legitimate point, which I **accepted and fixed**. Details below.
+
+## Codex — `playwright.config.ts` comment overstates qualification status (ACCEPTED, FIXED)
+
+> `playwright.config.ts:115-118` overstates the qualification status: "the
+> parallel local default is qualified by repeated full two-engine runs…" is not
+> true yet in phase 2. Per the spec/plan, qualification evidence and final
+> default disposition belong to phase 3, so this comment should describe the
+> rationale/evidence gate without asserting completion.
+
+**Agreed — this is a correct catch.** The Phase-2 scope is *wiring* the resolver
+into the config; the ≥3-run repeat qualification and the final default
+disposition (keep `'50%'` parallel vs. revert to serial) are explicitly **Phase
+3** per the plan and spec Decision 4. My comment used the present-tense "is
+qualified by…", which reads as *completed* qualification and is premature.
+
+**Change made** (comment-only, no behavioral change):
+
+- Before: "…the parallel local default **is qualified by** repeated full
+  two-engine runs on the native-GPU lane (issue #41), while CI keeps that serial
+  contract automatically via the guard above."
+- After: "…this parallel local default **is being qualified by** repeated full
+  two-engine runs on the native-GPU lane (issue #41) — **that evidence, not this
+  wiring, decides whether it remains the default or reverts to serial.** CI keeps
+  its serial contract automatically via the guard above regardless of that
+  outcome."
+
+This now frames the parallel default as an in-progress, evidence-gated decision
+owned by Phase 3, rather than asserting the qualification is done.
+
+## Codex — non-blocking confirmations (no action needed)
+
+> the helper is wired in correctly (`playwright.config.ts:120`), the stale
+> `workers: 1` source-text assertion was migrated appropriately in
+> `tests/automation.test.mjs`, and the phase-2 scope appears otherwise aligned
+> with the plan.
+
+No change required — noted as positive confirmation of the wiring and the
+`automation.test.mjs` migration.
+
+## Verification after the fix
+
+The change is comment-only; the `workers: resolveWorkers(process.env)` line is
+untouched, so the migrated `automation.test.mjs` assertion still matches. Re-ran:
+
+- `npm test` → 121/121 pass
+- `npm run typecheck` → clean (`.mjs`-from-`.ts` import resolves)
+- `.github/workflows/validation.yml` remains absent from `git diff` (CI unchanged)
+
+
+### IMPORTANT: Stateful Review Context
+This is NOT the first review iteration. Previous reviewers raised concerns and the builder has responded.
+Before re-raising a previous concern:
+1. Check if the builder has already addressed it in code
+2. If the builder disputes a concern with evidence, verify the claim against actual project files before insisting
+3. Do not re-raise concerns that have been explained as false positives with valid justification
+4. Check package.json and config files for version numbers before flagging missing configuration

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter2-gemini.txt
@@ -1,0 +1,12 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 deliverables are fully complete, correctly wiring the config to the helper and addressing Codex's feedback.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None
+
+All Phase 2 deliverables match the plan perfectly. The config wiring delegates worker resolution to the tested helper, the `automation.test.mjs` consumer assertions have been correctly migrated to assert that delegation, and the `playwright.config.ts` comment block accurately reflects the new contract. 
+
+I verified that the feedback from the previous iteration was correctly applied: the `playwright.config.ts` comment now properly states that the default "is being qualified" and that "that evidence, not this wiring, decides whether it remains the default or reverts to serial", correctly deferring the qualification and final default decision to Phase 3. The builder is clear to proceed.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
@@ -1,0 +1,73 @@
+I'll read the key files for Phase 3 review. Let me start with the main deliverables.Now let me verify the CI workflow file wasn't touched and check the state thread for Phase 3 context:Let me verify the GPU lane script was NOT modified and check what changed in the spec:Now I have a complete picture. Let me assess Phase 3 against its plan and the spec.
+
+---
+
+## Phase 3 Review: Qualify parallel execution, finalize default, document
+
+### 1. Spec Adherence
+
+**FR9 — Qualification evidence**: ✅ Met. The review records ≥3 consecutive full two-engine parallel runs on both paths:
+- **GPU lane** (primary, `E2E_GPU_REQUIRE=1`): 3 runs at 10 workers — 2/3 green, 1/3 hit the known open flake #33. Per-test results, wall-clocks (46s/45s/48s), worker counts (10), `retries: 0` — all verbatim.
+- **SwiftShader** (the actual `validate` gate path): 3 runs — 0/3 green (4–5/22 fail every run), wall-clocks (~3.3m each). Correct serial baseline included (11.7m SwiftShader, 196s hardware).
+
+**FR7 — GPU lane inherits parallel**: ✅ Confirmed. `scripts/e2e-gpu-lane.mjs` has zero diff. Thread records the banner `Running 22 tests using 10 workers` — the lane inherits workers from the config's `resolveWorkers` with no code change.
+
+**FR4 — CI untouched**: ✅ `git diff` shows `.github/workflows/validation.yml` absent from the diff.
+
+**FR10 — Config comment**: ✅ The `playwright.config.ts` comment block (lines 98–120) accurately states the finalized contract: CI hard-pinned `1` via guard-returns-first; local serial default; `E2E_WORKERS` opt-in; `retries: 0` preserved; destabilization rationale.
+
+**FR11 — Documentation**: ✅ README lines 84–98 ("Local test parallelism") cover all six Scenario-6 requirements: serial by default, `E2E_WORKERS` tuning (integer + percentage), CI unchanged, `retries: 0` preserved, qualification outcome (destabilization, not slowness), ~4× speedup on GPU lane opt-in. The lane env-var table (line 258) adds `E2E_WORKERS`. The status/sequencing section (lines 318–324) updates the "#41 sequenced after" note to delivered status.
+
+**Decision 4 (canonical default rule)**: ✅ Correctly applied. Evidence showed parallel destabilizes both paths (SwiftShader: 4–5/22 every run; hardware: flake #33 amplified to 1/3). Default finalized to serial (`DEFAULT_LOCAL_WORKERS = 1`), parallelism opt-in via `E2E_WORKERS`. The FR8 deviation (FR8 said "not 1") is explicitly documented with the Decision-4 authorization in the review. Architect endorsement recorded.
+
+**FR5 — `retries: 0` preserved**: ✅ All qualification runs at `retries: 0`. No masking.
+
+### 2. Code Quality
+
+**`scripts/e2e-workers.mjs`**: The constant flip from `'50%'` to `1` is clean — one-line change with thorough rationale in the header comment and JSDoc. The return-type contract (`number | string`) is unchanged; Playwright handles `1` identically to the prior hard-coded `workers: 1`.
+
+**`tests/e2e-workers.test.mjs`**: Default assertion correctly updated (lines 17–19: `strictEqual(DEFAULT_LOCAL_WORKERS, 1)`; lines 46–49: `resolveWorkers({}) === 1`). All 24 tests aligned with the finalized contract.
+
+**`tests/automation.test.mjs`**: The Phase-2 delegation assertion (`/workers: resolveWorkers\(process\.env\)/`) is correctly agnostic to the resolved value — works for both `'50%'` and `1`. No Phase-3 migration needed; the comment update (lines 87–91) accurately describes the tested resolver delegation.
+
+**`playwright.config.ts`**: Comment is accurate, detailed, and honest about the destabilization finding. No stale text remains.
+
+**README.md**: Well-written, discoverable documentation. The "Local test parallelism" note is placed correctly after the validation-commands table (where a developer looks for how to run things). The known-Firefox-flake note (lines 239–248) gives context for #33 without burying the reader. Cross-references to the review for full evidence.
+
+### 3. Test Coverage
+
+- Unit tests: 24/24 in `e2e-workers.test.mjs`, default row updated to `1`.
+- Integration: The qualification runs themselves ARE the integration test — real full suite under real resolved config, ≥3× on both paths.
+- `automation.test.mjs`: 121/121 per thread. README assertions still pass.
+
+### 4. Error Handling
+
+No new error paths in Phase 3 (the `WorkerConfigError` was Phase 1). The default flip is purely a constant change — no new failure modes.
+
+### 5. Plan Alignment
+
+All Phase-3 deliverables completed:
+- [x] Qualification evidence gathered and recorded in review
+- [x] SwiftShader-parallel stability evidence (the gate-path qualifier)
+- [x] Default finalized from evidence (serial, Decision 4 fallback branch)
+- [x] FR7 verified (GPU lane inherits, no lane code change)
+- [x] README updated (FR11, all touch points)
+- [x] CI-untouched proof (`validation.yml` zero-diff)
+- [x] Review authored with verbatim evidence + deviation documentation
+
+The Phase-3 contingency plan was also correctly navigated: GPU hardware WAS available (best case), but the qualification still didn't produce ≥3 consecutive green parallel runs (flake #33 amplified), so the serial-default fallback was correctly taken rather than shipping a flaky gate.
+
+### 6. Honesty & Evidence Integrity
+
+Particularly commendable: the thread records a self-correction where the builder initially compared parallel-SwiftShader wall-clock (3.3m) to serial-*hardware* (196s) and claimed "no speedup." The builder caught this, corrected it (parallel-SwiftShader is ~3.5× faster than serial-SwiftShader), and reframed the disqualifier as "destabilization, not slowness" — exactly the kind of evidence honesty the spec and lessons-critical demand.
+
+---
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 delivers honest qualification evidence, correctly finalizes the serial default per Decision 4, and documents the contract comprehensively — all deliverables complete with no issues.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-codex.txt
@@ -1,0 +1,9 @@
+---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Phase 3 mostly lands the intended serial-default/opt-in-parallel outcome, but two evidence/documentation inaccuracies should be fixed before approval.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- `codev/reviews/41-parallelize-local-e2e-runs.md:162-165` says parallel “gives no SwiftShader speedup,” but the same review records ~`3.3m` parallel vs `11.7m` serial at `codev/reviews/41-parallelize-local-e2e-runs.md:105-106`. Since evidence honesty is a phase requirement, this contradiction should be corrected.
+- `scripts/e2e-workers.mjs:93` still says “Scaled default” even though Phase 3 flipped the default to serial `1` (`scripts/e2e-workers.mjs:39`). The finalized default contract should be documented consistently in the shipped helper comments.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-gemini.txt
@@ -1,0 +1,9 @@
+```
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 successfully executed the qualification plan, accurately finalized the default to serial based on recorded evidence, and updated documentation accordingly.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None
+```

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-rebuttals.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-rebuttals.md
@@ -1,0 +1,49 @@
+# Phase 3 — Iteration 1 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Gemini and Claude approved with no issues. Codex raised two narrow consistency
+points — both **accepted and fixed**. They were residue from a mid-phase honesty
+correction (after the serial-default confirmation run revealed my original
+"no speedup" framing compared parallel-SwiftShader against the wrong baseline). I
+had swept most occurrences but missed these two.
+
+## Codex #1 — review still said parallel "gives no SwiftShader speedup" (ACCEPTED, FIXED)
+
+> `codev/reviews/41-parallelize-local-e2e-runs.md:162-165` says parallel "gives no
+> SwiftShader speedup," but the same review records ~`3.3m` parallel vs `11.7m`
+> serial at lines 105-106. Since evidence honesty is a phase requirement, this
+> contradiction should be corrected.
+
+**Agreed — a real internal contradiction.** Parallel SwiftShader IS faster (~3.3m
+vs 11.7m serial ≈ 3.5×); the reason to reject it as the default is
+**destabilization** (4–5/22 timing failures every run), not slowness. The
+acceptance-criteria bullet now reads: "SwiftShader parallel is faster (~3.3m vs
+11.7m serial) but **breaks the gate** (4–5/22 timing failures every run), so serial
+is retained; the ~4× speedup is available opt-in on the GPU lane." This aligns with
+the evidence table (§B) and the summary, both of which already state the
+destabilization-not-slowness framing. (My grep for the fix missed this line because
+it was phrased "no SwiftShader speedup", not "no speedup".)
+
+## Codex #2 — helper inline comment still said "Scaled default" (ACCEPTED, FIXED)
+
+> `scripts/e2e-workers.mjs:93` still says "Scaled default" even though Phase 3
+> flipped the default to serial `1`. The finalized default contract should be
+> documented consistently in the shipped helper comments.
+
+**Agreed.** When I flipped `DEFAULT_LOCAL_WORKERS` to `1` I updated the module
+header, the constant's own comment, and the JSDoc, but left the function-body
+inline comment as `// 3. Scaled default.` — now inconsistent with the shipped
+serial default. Fixed to: `// 3. Serial default (see DEFAULT_LOCAL_WORKERS).
+Parallel is opt-in only, via the E2E_WORKERS branch above.`
+
+## Verification after fixes
+
+Both changes are comment/prose-only (no behavior change). Re-ran and swept:
+
+- `node --test tests/e2e-workers.test.mjs` → 24/24; `npm test` → 121/121;
+  `npm run typecheck` → clean; `eslint` on the helper files → clean.
+- Broad audit of every `speedup|faster|slower` mention across README,
+  `playwright.config.ts`, `scripts/e2e-workers.mjs`, and the review — all now
+  consistently state "parallel is faster but destabilizes (SwiftShader) / mostly
+  green (~4× on the GPU lane)". No "Scaled default" text remains.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
@@ -1,0 +1,67 @@
+I'll read the key Phase 3 deliverables in parallel to understand the implementation.Now let me read the remaining Phase 3-specific files to complete the review.Let me verify a few more things — the CI workflow untouched claim and the specs update.Let me verify the GPU lane script wasn't modified (FR7: no code change needed) and check the package.json for no dependency changes.I've now read all the key Phase 3 deliverables. Let me do a final consistency sweep across the critical surfaces.I've completed a thorough review of the Phase 3 deliverables. Here's my assessment:
+
+---
+
+## Phase 3 Review: Qualify parallel execution, finalize default, document
+
+### Spec Adherence
+
+**FR9 (Qualification evidence):** ✅ Exemplary. The review records ≥3 consecutive full two-engine parallel runs on **both** qualification paths:
+- **GPU hardware** (primary, `E2E_GPU_REQUIRE=1`): 3 runs at 10 workers — 2/3 green, 1/3 hit the known open flake #33. Wall-clocks verbatim (44-47s suite vs 196s serial ≈ 4.3× speedup).
+- **SwiftShader** (the actual `validate` gate path): 3 runs at 10 workers — **0/3 green** (4-5/22 timing failures every run at ~3.3m vs 11.7m serial). The destabilization is conclusive.
+
+Serial baselines included, `retries: 0` throughout, worker counts and per-test results verbatim. Evidence honesty is impeccable — the builder even caught and corrected a "no SwiftShader speedup" misframing mid-phase (parallel SwiftShader *is* ~3.5× faster; the disqualifier is destabilization, not slowness).
+
+**Decision 4 (default finalization):** ✅ `DEFAULT_LOCAL_WORKERS` correctly flipped from `'50%'` to `1`. The evidence clearly mandates the serial-default + opt-in-parallel branch (Scenario 5): a gate that fails 4-5/22 every run is not a gate, however fast.
+
+**FR7 (GPU lane inherits parallel):** ✅ Confirmed — zero changes to `scripts/e2e-gpu-lane.mjs` (verified via diff); banner showed `Running 22 tests using 10 workers` when the `'50%'` default was active, proving inheritance.
+
+**FR4 (CI untouched):** ✅ `.github/workflows/validation.yml` does not appear in the diff (verified).
+
+**FR11 (Documentation):** ✅ Comprehensive README update:
+- Lines 84-98: New "Local test parallelism" section — serial default, `E2E_WORKERS` tuning (integer + percentage), CI unchanged, `retries: 0` preserved, trade-off documented with qualification reference.
+- Lane section: `E2E_WORKERS` added to env controls table (line 258), timing paragraph updated (lines 230-236), status/sequencing note updated (lines 319-324), serial-default language throughout.
+- CI decomposition section (lines 128-130): accurately documents the `resolveWorkers` CI guard.
+
+**FR10 (Config comment):** ✅ `playwright.config.ts` lines 99-120 carry the finalized contract in past tense — CI hard-pinned, local serial default, opt-in parallel, qualification outcome — replacing the stale "Do NOT raise workers" text.
+
+**FR8 deviation (documented):** ✅ The review (lines 129-138) explicitly calls out that FR8 literally says "not `1`" for the default, but Decision 4 (the canonical rule) governs and the evidence drove the serial fallback. This is honest and correctly authorized.
+
+### Code Quality
+
+All shipped files are internally consistent after the iteration-1 fixes:
+- `scripts/e2e-workers.mjs`: `DEFAULT_LOCAL_WORKERS = 1`, header/JSDoc/inline comments all say "serial" — no residual "Scaled default" or "50%" language in the function body.
+- `playwright.config.ts`: Comment block matches the finalized contract.
+- `tests/e2e-workers.test.mjs`: Default test row asserts `1`, all 24 tests aligned.
+- No "no speedup" text remains in any shipped file (only in historical rebuttals/thread docs).
+
+### Test Coverage
+
+- `tests/e2e-workers.test.mjs` line 17: `DEFAULT_LOCAL_WORKERS === 1` ✅
+- Lines 46-49: `resolveWorkers({}) === 1` (no CI, no override → serial) ✅
+- Lines 51-54: empty/whitespace `E2E_WORKERS` → serial ✅
+- Full 24-test FR8 matrix intact, correctly reflecting the finalized default.
+
+### Invariants Preserved
+
+- ✅ No dependency/lockfile/toolchain movement (verified via diff)
+- ✅ `app/**` untouched (verified via diff)
+- ✅ Local `retries: 0` preserved (line 130 of config unchanged)
+- ✅ No flake masking — #33 disposition is "accept + document", assertion not weakened, retries not added
+- ✅ No new npm script (FR11 says `E2E_WORKERS` is an env var, not a command)
+
+### Previous Iteration Issues
+
+Both Codex iteration-1 points were correctly addressed:
+1. Review acceptance bullet: "no SwiftShader speedup" → "faster but breaks the gate" ✅
+2. Helper inline comment: "Scaled default" → "Serial default" ✅
+
+---
+
+VERDICT: APPROVE
+SUMMARY: Phase 3 qualification is thorough, honest, and evidence-driven — the serial-default + opt-in-parallel landing is correctly mandated by Decision 4 and the recorded destabilization evidence, with all deliverables (default flip, review, README, config comment, CI untouched proof) complete and internally consistent.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-codex.txt
@@ -1,0 +1,9 @@
+Using filesystem reads to verify the phase_3 implementation against the spec/plan.Reading the phase_3-specific files more closely for evidence, finalized default, and docs consistency.Checking exact line numbers for the phase_3 issues I may cite.---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Phase 3 lands the serial-default/opt-in-parallel decision correctly, but the recorded qualification evidence is not yet detailed enough to satisfy the phase’s per-test evidence requirement.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- `codev/reviews/41-parallelize-local-e2e-runs.md:48-125` records worker counts, wall clocks, aggregate pass/fail counts, and some failing-test detail, but it does **not** provide the full per-run / per-test results the spec and phase_3 plan call for. Phase 3’s core deliverable explicitly requires the ≥3 qualification runs to be recorded with per-test pass/fail detail, and the review currently summarizes those runs instead of preserving that evidence verbatim.
+- `tests/automation.test.mjs:87-92` has a now-stale explanatory comment: it says “local runs scale to hardware,” but Phase 3 finalized the shipped contract as **serial by default** with `E2E_WORKERS` opt-in parallelism. This is minor, but it should be corrected for consistency with the finalized Phase 3 outcome.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-gemini.txt
@@ -1,0 +1,11 @@
+I have reviewed the files changed in this PR for Phase 3. The implementation closely follows the plan and specification. 
+
+You correctly executed the contingency defined in Decision 4 by gating the default on actual qualification evidence. Since the SwiftShader fallback proved unstable under parallel contention, keeping the serial default while offering an opt-in parallel path via `E2E_WORKERS` is exactly the right move. The documentation, tests, and configuration correctly align with this finalized fallback contract. Furthermore, `.github/workflows/validation.yml` was completely avoided, ensuring that the CI baseline remains provably unmodified.
+
+---
+VERDICT: APPROVE
+SUMMARY: The qualification evidence was properly recorded and the serial-fallback default was correctly implemented and documented per Decision 4.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-rebuttals.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-rebuttals.md
@@ -1,0 +1,43 @@
+# Phase 3 — Iteration 2 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Both Codex points **accepted and fixed**.
+
+## Codex #1 — review lacked full per-run / per-test results (FR9) (ACCEPTED, FIXED)
+
+> `codev/reviews/…:48-125` records worker counts, wall clocks, aggregate pass/fail
+> counts, and some failing-test detail, but does **not** provide the full per-run /
+> per-test results the spec and phase_3 plan call for … the review currently
+> summarizes those runs instead of preserving that evidence verbatim.
+
+**Agreed — FR9 explicitly requires "per-test pass/fail" for the ≥3 qualification
+runs, and the architect's landing guardrail asked for verbatim evidence.** I had
+preserved the banners, wall-clocks, aggregate counts, and the *failing* tests
+verbatim, but not the full per-test list for each run.
+
+**Fix:** added an **"Appendix — Per-test results (verbatim, FR9)"** to the review
+containing the complete per-test `✓`/`✘` output (worker-index-prefixed, straight
+from Playwright's `list` reporter) for **all eight** qualification runs: the 3 GPU
+parallel runs, the GPU serial baseline, the 3 SwiftShader parallel runs, and the
+SwiftShader serial baseline / finalized-default confirmation. Every one of the 22
+tests per run is now recorded with its pass/fail verdict — no summarization.
+
+## Codex #2 — stale `automation.test.mjs` comment (ACCEPTED, FIXED)
+
+> `tests/automation.test.mjs:87-92` … says "local runs scale to hardware," but
+> Phase 3 finalized the shipped contract as **serial by default** with
+> `E2E_WORKERS` opt-in parallelism.
+
+**Agreed** — that comment was written in Phase 2 (when `'50%'` was still the
+proposed default) and went stale when Phase 3 flipped the default to serial. The
+assertion itself (delegation to `resolveWorkers`) was and remains correct; only the
+explanatory comment drifted. Fixed to: "locally the default is also serial (1),
+with parallelism opt-in via E2E_WORKERS (Phase-3 qualification kept the gate
+serial)."
+
+## Verification after fixes
+
+Both changes are prose/evidence-only (no behavior change; the migrated assertion is
+untouched). Re-ran: `npm test` → 121/121; `eslint tests/automation.test.mjs` →
+clean. The review appendix preserves all 8×22 per-test verdicts verbatim.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-claude.txt
@@ -1,0 +1,57 @@
+I'll read the key Phase 3 deliverable files to review against the spec and plan requirements.Now let me verify the CI workflow was untouched and check the spec for Phase 3 updates:I've now read all the key Phase 3 deliverable files. Let me do my systematic review.
+
+## Phase 3 Review: Qualify Parallel Execution, Finalize Default, Document
+
+### 1. Spec Adherence
+
+**FR9 — Qualification evidence**: Complete and exemplary. Eight qualification runs recorded with full verbatim per-test output (22 tests × 8 runs = 176 individual test verdicts in the appendix). Each run shows worker count, wall-clock, per-test pass/fail, and `retries: 0`. The GPU lane ran under `E2E_GPU_REQUIRE=1` with verified hardware renderers. SwiftShader parallel runs recorded separately. Serial baselines provided for both paths.
+
+**FR7 — GPU lane inherits parallel**: Verified — no changes to `scripts/e2e-gpu-lane.mjs` in the diff. The lane inherits the config's `resolveWorkers` output and the README documents `E2E_WORKERS` as the opt-in mechanism on this lane.
+
+**FR4 — CI untouched**: Confirmed — `validation.yml` absent from the diff (verified via `git diff --name-only`).
+
+**FR11 — Documentation**: README lines 84-98 add a complete "Local test parallelism" section covering: serial default, `E2E_WORKERS` opt-in (integer and %), CI hard-pinned to `1`, `retries: 0` preserved, qualification outcome with cross-reference to the review. The GPU lane section (lines 196, 230-236, 258, 318-324) is updated with `E2E_WORKERS` in the env table and serial-default + opt-in-parallel contract language. A developer who hasn't seen the spec can find everything Scenario 6 requires.
+
+**FR10 — Config comment**: `playwright.config.ts` lines 98-120 replace the stale "Do NOT raise workers" block with the actual contract: CI hard-pinned serial, local serial default, opt-in parallel via `E2E_WORKERS`, destabilization rationale, `retries: 0` preserved.
+
+**Decision 4 — Evidence-gated default**: The canonical rule was executed exactly as designed. SwiftShader parallel showed 4-5/22 timing failures on every run (0/3 green) — a clear disqualification. The default was correctly flipped to serial (`DEFAULT_LOCAL_WORKERS = 1`), and the deviation from FR8's literal "not `1`" assertion is documented with the architect's endorsement. This is the Scenario 5 / acceptance criterion 2 (second branch) landing.
+
+**FR5 — `retries: 0` preserved**: Confirmed at `playwright.config.ts:130` — `retries: process.env.CI ? 2 : 0` unchanged.
+
+### 2. Code Quality
+
+**`scripts/e2e-workers.mjs`**: The module-level comment (lines 22-30) and the constant's own comment (lines 32-38) are now internally consistent — both explain the Phase 3 qualification outcome (destabilization, not slowness), the serial default, and opt-in parallel. The inline comment at line 93-94 was fixed per iteration 1 feedback: "Serial default (see DEFAULT_LOCAL_WORKERS). Parallel is opt-in only." No stale language remains.
+
+**`playwright.config.ts`**: The new comment block is thorough and accurate. The `resolveWorkers(process.env)` delegation is clean.
+
+**`tests/automation.test.mjs`**: Lines 87-94 correctly explain the delegation pattern, noting CI hard-pinning, serial default, and `E2E_WORKERS` opt-in. The assertion at line 96 (`/workers: resolveWorkers\(process\.env\)/`) validates delegation rather than duplicating the resolver's matrix.
+
+### 3. Test Coverage
+
+**`tests/e2e-workers.test.mjs`**: The default test row at line 46-49 correctly asserts `resolveWorkers({}) === 1` (flipped from the original `'50%'`). The `DEFAULT_LOCAL_WORKERS` direct assertion at line 17-19 confirms `1`. All 24 tests cover the full FR8 matrix plus the serial default outcome.
+
+### 4. Evidence Quality & Honesty
+
+The review is a model of evidence honesty:
+- GPU parallel: 2/3 green, 1/3 hit flake #33 — honestly reported, not hidden
+- SwiftShader parallel: 0/3 green (4-5 timing failures per run) — correctly identified as destabilization, not slowness
+- The "parallel is actually faster" framing is consistent throughout (review lines 105-106, 162-165, helper comment lines 26-29)
+- Serial SwiftShader baseline honestly records its own flake #33 hit (pre-existing, not introduced)
+- Per-test appendix satisfies the Codex iteration 2 request for verbatim FR9 evidence
+
+### 5. Previous Iteration Fixes
+
+All four fixes from iterations 1 and 2 verified in the actual files:
+- **Iter 1 Codex #1** (review "no SwiftShader speedup"): Review line 162-165 now reads "SwiftShader parallel is faster (~3.3m vs 11.7m serial) but **breaks the gate**" ✅
+- **Iter 1 Codex #2** (helper "Scaled default" comment): Line 93 now reads "Serial default" ✅  
+- **Iter 2 Codex #1** (per-test appendix): Lines 181-413 contain all 8×22 verbatim per-test results ✅
+- **Iter 2 Codex #2** (`automation.test.mjs` stale comment): Lines 88-94 accurately describe the serial default + opt-in parallel contract ✅
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 delivers honest, thorough qualification evidence, correctly finalizes the serial default per Decision 4, comprehensively documents the contract (README, config, helper, tests), and proves CI untouched — all deliverables complete, all previous iteration feedback addressed.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-codex.txt
@@ -1,0 +1,8 @@
+Using direct file reads to verify the phase_3 implementation and evidence before judging prior review concerns.Checking the phase_3 docs/evidence details that finalize the default and document the contract.---
+VERDICT: APPROVE
+SUMMARY: Phase 3 is complete: the serial-default/opt-in-parallel decision is correctly finalized from recorded evidence, documented consistently, and backed by detailed per-run/per-test qualification data.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-context.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-context.md
@@ -1,0 +1,115 @@
+### Iteration 1 Reviews
+- gemini: APPROVE — Phase 3 successfully executed the qualification plan, accurately finalized the default to serial based on recorded evidence, and updated documentation accordingly.
+- codex: REQUEST_CHANGES — Phase 3 mostly lands the intended serial-default/opt-in-parallel outcome, but two evidence/documentation inaccuracies should be fixed before approval.
+- claude: APPROVE — Phase 3 delivers honest qualification evidence, correctly finalizes the serial default per Decision 4, and documents the contract comprehensively — all deliverables complete with no issues.
+
+### Builder Response to Iteration 1
+# Phase 3 — Iteration 1 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Gemini and Claude approved with no issues. Codex raised two narrow consistency
+points — both **accepted and fixed**. They were residue from a mid-phase honesty
+correction (after the serial-default confirmation run revealed my original
+"no speedup" framing compared parallel-SwiftShader against the wrong baseline). I
+had swept most occurrences but missed these two.
+
+## Codex #1 — review still said parallel "gives no SwiftShader speedup" (ACCEPTED, FIXED)
+
+> `codev/reviews/41-parallelize-local-e2e-runs.md:162-165` says parallel "gives no
+> SwiftShader speedup," but the same review records ~`3.3m` parallel vs `11.7m`
+> serial at lines 105-106. Since evidence honesty is a phase requirement, this
+> contradiction should be corrected.
+
+**Agreed — a real internal contradiction.** Parallel SwiftShader IS faster (~3.3m
+vs 11.7m serial ≈ 3.5×); the reason to reject it as the default is
+**destabilization** (4–5/22 timing failures every run), not slowness. The
+acceptance-criteria bullet now reads: "SwiftShader parallel is faster (~3.3m vs
+11.7m serial) but **breaks the gate** (4–5/22 timing failures every run), so serial
+is retained; the ~4× speedup is available opt-in on the GPU lane." This aligns with
+the evidence table (§B) and the summary, both of which already state the
+destabilization-not-slowness framing. (My grep for the fix missed this line because
+it was phrased "no SwiftShader speedup", not "no speedup".)
+
+## Codex #2 — helper inline comment still said "Scaled default" (ACCEPTED, FIXED)
+
+> `scripts/e2e-workers.mjs:93` still says "Scaled default" even though Phase 3
+> flipped the default to serial `1`. The finalized default contract should be
+> documented consistently in the shipped helper comments.
+
+**Agreed.** When I flipped `DEFAULT_LOCAL_WORKERS` to `1` I updated the module
+header, the constant's own comment, and the JSDoc, but left the function-body
+inline comment as `// 3. Scaled default.` — now inconsistent with the shipped
+serial default. Fixed to: `// 3. Serial default (see DEFAULT_LOCAL_WORKERS).
+Parallel is opt-in only, via the E2E_WORKERS branch above.`
+
+## Verification after fixes
+
+Both changes are comment/prose-only (no behavior change). Re-ran and swept:
+
+- `node --test tests/e2e-workers.test.mjs` → 24/24; `npm test` → 121/121;
+  `npm run typecheck` → clean; `eslint` on the helper files → clean.
+- Broad audit of every `speedup|faster|slower` mention across README,
+  `playwright.config.ts`, `scripts/e2e-workers.mjs`, and the review — all now
+  consistently state "parallel is faster but destabilizes (SwiftShader) / mostly
+  green (~4× on the GPU lane)". No "Scaled default" text remains.
+
+
+### Iteration 2 Reviews
+- gemini: APPROVE — The qualification evidence was properly recorded and the serial-fallback default was correctly implemented and documented per Decision 4.
+- codex: REQUEST_CHANGES — Phase 3 lands the serial-default/opt-in-parallel decision correctly, but the recorded qualification evidence is not yet detailed enough to satisfy the phase’s per-test evidence requirement.
+- claude: APPROVE — Phase 3 qualification is thorough, honest, and evidence-driven — the serial-default + opt-in-parallel landing is correctly mandated by Decision 4 and the recorded destabilization evidence, with all deliverables (default flip, review, README, config comment, CI untouched proof) complete and internally consistent.
+
+### Builder Response to Iteration 2
+# Phase 3 — Iteration 2 Review Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+Both Codex points **accepted and fixed**.
+
+## Codex #1 — review lacked full per-run / per-test results (FR9) (ACCEPTED, FIXED)
+
+> `codev/reviews/…:48-125` records worker counts, wall clocks, aggregate pass/fail
+> counts, and some failing-test detail, but does **not** provide the full per-run /
+> per-test results the spec and phase_3 plan call for … the review currently
+> summarizes those runs instead of preserving that evidence verbatim.
+
+**Agreed — FR9 explicitly requires "per-test pass/fail" for the ≥3 qualification
+runs, and the architect's landing guardrail asked for verbatim evidence.** I had
+preserved the banners, wall-clocks, aggregate counts, and the *failing* tests
+verbatim, but not the full per-test list for each run.
+
+**Fix:** added an **"Appendix — Per-test results (verbatim, FR9)"** to the review
+containing the complete per-test `✓`/`✘` output (worker-index-prefixed, straight
+from Playwright's `list` reporter) for **all eight** qualification runs: the 3 GPU
+parallel runs, the GPU serial baseline, the 3 SwiftShader parallel runs, and the
+SwiftShader serial baseline / finalized-default confirmation. Every one of the 22
+tests per run is now recorded with its pass/fail verdict — no summarization.
+
+## Codex #2 — stale `automation.test.mjs` comment (ACCEPTED, FIXED)
+
+> `tests/automation.test.mjs:87-92` … says "local runs scale to hardware," but
+> Phase 3 finalized the shipped contract as **serial by default** with
+> `E2E_WORKERS` opt-in parallelism.
+
+**Agreed** — that comment was written in Phase 2 (when `'50%'` was still the
+proposed default) and went stale when Phase 3 flipped the default to serial. The
+assertion itself (delegation to `resolveWorkers`) was and remains correct; only the
+explanatory comment drifted. Fixed to: "locally the default is also serial (1),
+with parallelism opt-in via E2E_WORKERS (Phase-3 qualification kept the gate
+serial)."
+
+## Verification after fixes
+
+Both changes are prose/evidence-only (no behavior change; the migrated assertion is
+untouched). Re-ran: `npm test` → 121/121; `eslint tests/automation.test.mjs` →
+clean. The review appendix preserves all 8×22 per-test verdicts verbatim.
+
+
+### IMPORTANT: Stateful Review Context
+This is NOT the first review iteration. Previous reviewers raised concerns and the builder has responded.
+Before re-raising a previous concern:
+1. Check if the builder has already addressed it in code
+2. If the builder disputes a concern with evidence, verify the claim against actual project files before insisting
+3. Do not re-raise concerns that have been explained as false positives with valid justification
+4. Check package.json and config files for version numbers before flagging missing configuration

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter3-gemini.txt
@@ -1,0 +1,9 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 successfully records qualification evidence, correctly finalizes the serial default with opt-in parallel based on that evidence, updates documentation, and comprehensively addresses all feedback from previous iterations.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None
+
+All Phase 3 deliverables are complete and aligned with the specification and plan. The verbatim evidence appendix accurately captures per-test pass/fail results for the qualification runs, the `automation.test.mjs` comments are up-to-date with the serial fallback decision, and the `README.md` correctly communicates the new opt-in parallel contract. The CI configuration remains provably untouched.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-claude.txt
@@ -1,0 +1,89 @@
+I'll review this plan by first verifying the key files it references to ensure the approach is grounded in reality.Now let me check the tsconfig and the existing test pattern being mirrored:I've read the key files. Let me verify one more thing about the import pattern by checking if there are any existing `.mjs` imports from `.ts` files:Good — confirmed there's no existing `.mjs`-from-`.ts` import precedent in this codebase. That's the one novel pattern this plan introduces, and I want to ensure the plan handles it well.
+
+Now I have a thorough picture. Here's my review:
+
+---
+
+## Plan Review: 41 — Parallelize Local E2E Runs
+
+### 1. Spec Coverage
+
+**All 11 FRs are covered by at least one phase:**
+
+| FR | Phase(s) | Verified |
+|---|---|---|
+| FR1 (hardware-scaled local workers) | 1 (helper), 2 (wire), 3 (qualify default) | ✓ |
+| FR2 (`E2E_WORKERS` override) | 1 (parse+validate), 2 (wire) | ✓ |
+| FR3 (absolute CI guard) | 1 (implement+test) | ✓ |
+| FR4 (CI workflow untouched) | All phases verify | ✓ |
+| FR5 (preserved `retries: 0`) | Not touched — stays as-is | ✓ |
+| FR6 (shared web server) | Not touched — stays as-is | ✓ |
+| FR7 (GPU lane inherits parallel) | 3 (verify by inspection + run) | ✓ |
+| FR8 (worker-resolution coverage) | 1 (unit tests), 2 (migrate `automation.test.mjs`) | ✓ |
+| FR9 (repeat-run qualification) | 3 | ✓ |
+| FR10 (updated config comment) | 2 | ✓ |
+| FR11 (documentation) | 3 | ✓ |
+
+No scope creep — nothing goes beyond the spec.
+
+### 2. Phase Breakdown
+
+Three phases, strictly linear. Sizing is appropriate:
+- **Phase 1** is small and self-contained (two new files, no existing code touched).
+- **Phase 2** is the core wiring (3 files touched: config, automation test, comment block).
+- **Phase 3** is the qualification + documentation pass.
+
+Each phase is independently committable: Phase 1 adds unreferenced files, Phase 2 wires them, Phase 3 finalizes. The linear dependency chain (helper → config → qualify) is logically correct.
+
+### 3. Technical Approach
+
+**Verified against the actual codebase:**
+
+- **Line references are accurate**: `workers: 1` at config line 105; comment block at lines 96–113; `automation.test.mjs` assertions at lines 89–93; README lines 178, 222–228, 284–286 all confirmed.
+
+- **The pure-helper-in-`.mjs` pattern** genuinely mirrors the established `scripts/e2e-gpu-lane.mjs` ⇐ `tests/gpu-lane.test.mjs` pattern. The `WorkerConfigError` class parallels `LaneUsageError`. The `test` script glob (`node --test tests/*.test.mjs` per `package.json` line 14) will pick up the new test file automatically. No `package.json` change needed.
+
+- **`resolveWorkers(env)` design** is clean: pure function, no `process.env` mutation, explicit env injection — exactly the pattern `parseControls(env)` / `buildHostView({...})` use in the GPU lane.
+
+- **The `E2E_ENGINES` fail-closed guard** (config lines 78–85) is the exact precedent the plan cites for `WorkerConfigError`. Consistent error philosophy.
+
+- **GPU lane `workers` inheritance**: Confirmed by reading `e2e-gpu-lane.mjs` — it never sets `workers` (it sets `E2E_ENGINES`, `PW_CHROMIUM_ARGS`, `GALLIUM_DRIVER`, `LD_LIBRARY_PATH`). The plan's claim that it "inherits the config's scaled default automatically" with "no code change" is correct.
+
+- **The `.mjs`-from-`.ts` import** is the one genuinely novel pattern. The tsconfig has `allowJs: true`, `checkJs` defaults to `false`, and `moduleResolution: "bundler"` — so TypeScript itself should handle it. The runtime question is Playwright's config loader (which typically uses esbuild or a similar transpiler). The plan correctly identifies this as a risk, gates it on a real `npx playwright test --list` acceptance run, and has a concrete fallback (`.ts` re-export or inline shim) — to be decided only if the real run fails.
+
+### 4. Testability
+
+- **Phase 1**: The FR8 test matrix is comprehensive — CI guard, CI precedence over `E2E_WORKERS`, integer/percentage parsing, invalid values (with good negative cases: `0`, `0%`, `-1`, `abc`, `12x`, `1.5`), empty-string handling, default resolution. The pure-function design makes all of this trivially testable with no mocking.
+
+- **Phase 2**: The `automation.test.mjs` migration from `/workers: 1/` to `/workers: resolveWorkers\(process\.env\)/` maintains the source-text assertion pattern. The real `--list` integration run under three envs (default, `CI=1`, `E2E_WORKERS=…`) is the right verification.
+
+- **Phase 3**: The ≥3 consecutive full-suite qualification IS the integration test. The `E2E_GPU_REQUIRE=1` gating prevents silent fallback pollution. Evidence-first, not assumption-first.
+
+### 5. Risk Assessment
+
+Risks are honestly identified and well-mitigated:
+
+- **SwiftShader contention** (the core risk): Decision 4's evidence-gated default with a documented serial fallback is the right approach. The plan never assumes the parallel default will work — it proves it or takes the fallback.
+- **GPU availability contingency**: Phase 3's three-branch contingency (GPU lane qualifies → SwiftShader qualifies → serial default + opt-in) is thorough.
+- **`.mjs` import from `.ts`**: Low probability, caught immediately by the `--list` acceptance run, concrete fallback available.
+- **Stray `E2E_WORKERS` in CI**: The `CI → 1` guard returns *before* reading `E2E_WORKERS`, making CI precedence structural, not conditional. Tested in Phase 1.
+
+### 6. Minor Observations (non-blocking)
+
+1. **Phase 1 regex for leading zeros**: The plan's regex `/^[1-9][0-9]*$/` would reject `01`, `001`, etc. The risk section mentions deciding "leading-zero disposition explicitly in a test" — good, this is covered.
+
+2. **Phase 2's `automation.test.mjs` assertion**: The new assertion `/workers: resolveWorkers\(process\.env\)/` is tightly coupled to exact source syntax. This is consistent with the existing pattern (line 90 already does exact source-text matching), but worth noting that any future refactoring of how the config calls the helper would need to update this test.
+
+3. **The plan's claim about `checkJs`**: Verified — `tsconfig.json` has `allowJs: true` but no explicit `checkJs`, which defaults to `false`. The plan is accurate.
+
+---
+
+```
+---
+VERDICT: APPROVE
+SUMMARY: Thorough, spec-complete plan with verified file references, sound technical approach mirroring proven codebase patterns, honest risk handling, and an evidence-gated default that never assumes success.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None
+```

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-codex.txt
@@ -1,0 +1,8 @@
+Using filesystem reads to verify the cited files and plan assumptions before reviewing.Checking the remaining project files the plan depends on (`package.json`, `tsconfig`, and the approved spec on disk).---
+VERDICT: COMMENT
+SUMMARY: Strong, spec-aligned plan with clear phaseing; only minor tightening needed around how worker resolution is proven end-to-end in Phase 2.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- Phase 2's acceptance language leans on `npx playwright test --list` to prove resolved worker counts, but `--list` may not give a reliable observable for `workers=1` vs `workers>1`; the plan should name a concrete proof method for both default and `CI=1` cases (for example a minimal real run that prints the worker banner, or another deterministic config-resolution check).
+- The rest of the plan is well aligned with the spec: it covers the helper extraction, `automation.test.mjs` migration, CI invariants, README/comment updates, qualification evidence, and the evidence-gated serial fallback without re-litigating baked decisions.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-plan-iter1-gemini.txt
@@ -1,0 +1,18 @@
+This is a high-quality implementation plan that translates the spec's requirements safely and thoroughly into a testable progression. 
+
+The decomposition into three phases correctly isolates the pure configuration logic (Phase 1) from the Playwright integration (Phase 2), before gating the final default on real evidence (Phase 3). 
+
+A few things that stand out as particularly well-handled:
+- **Consistency**: Utilizing the truthiness of `process.env.CI` matches the existing idiom in `playwright.config.ts`, maintaining behavioral consistency across all environments.
+- **Contract Migration**: Anticipating that `tests/automation.test.mjs` uses source-text regex assertions for `workers: 1` and ensuring those assertions are migrated to test the delegation rather than becoming stale.
+- **Fail-safe Contingency**: Acknowledging that the builder (a WSL2 headless runner or similar) may lack access to a hardware WebGL adapter, and providing a clear fallback plan for qualifying the shippable default on SwiftShader.
+
+The integration approach is sound, and I have verified on-disk that `scripts/e2e-gpu-lane.mjs` doesn't currently inject or override `workers`, which confirms your analysis in Phase 3 that the lane will inherit the new scaling behavior natively without further code changes. 
+
+---
+VERDICT: APPROVE
+SUMMARY: The plan thoroughly and correctly translates the spec into an actionable, well-sequenced, and highly testable progression.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-review-iter1-rebuttals.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-review-iter1-rebuttals.md
@@ -1,0 +1,54 @@
+# PR Review (Review phase) — Iteration 1 Rebuttals
+
+**Verdicts:** Gemini APPROVE (HIGH) · Claude APPROVE (HIGH) · Codex REQUEST_CHANGES (HIGH)
+
+## Codex #2 — plan still marked `Status: draft` (ACCEPTED, FIXED)
+
+> `codev/plans/41-parallelize-local-e2e-runs.md` still has `## Metadata` →
+> `- **Status**: draft`, even though `status.yaml` marks all three plan phases
+> complete and the review is complete. That should be reconciled before hand-off.
+
+**Agreed** — the SPIR Review phase calls for updating the plan document with final
+status. Updated the plan's `**Status**` from `draft` to:
+
+> **complete** — all three phases implemented and 3-way approved. Final outcome per
+> Decision 4 / Scenario 5: **serial default + opt-in parallel** … see the review.
+
+(The plan has no per-phase status markers to reconcile — only this top-level field.)
+
+## Codex #1 — commit-message format (REBUTTED — false positive + not actionable)
+
+> `git log main..HEAD` shows many branch commits like `chore(porch): 41 ...`, plus
+> user commits such as `[Spec 41] Review, qualification evidence, and
+> governance-doc updates`, which do not match the required `[Spec 1][Phase: ...]`
+> format from `AGENTS.md`.
+
+Two reasons this is not a valid change request:
+
+1. **`[Spec 41] Description` IS a documented, compliant format.** `AGENTS.md`
+   (and `CLAUDE.md`) list **two** commit forms, not one:
+   ```
+   [Spec 1] Description of change
+   [Spec 1][Phase: implement] feat: Add feature
+   ```
+   The `[Phase: ...]` variant is specifically for *implementation-phase* commits.
+   The Review-phase commit `[Spec 41] Review, qualification evidence, and
+   governance-doc updates` matches the first form exactly. So my builder commit is
+   compliant, not a violation.
+
+2. **The `chore(porch): …` commits are porch-generated state commits, not builder
+   commits** — porch creates them to record its own state-machine transitions
+   (phase advances, build-complete, gate approvals). They are not subject to the
+   `[Spec ####]` builder convention, and in **strict mode** the builder must not
+   rewrite porch state or history. Reformatting them would require an
+   `git rebase`/history rewrite of an already-pushed branch — destructive, and a
+   direct violation of "only porch modifies state / never bypass porch." The
+   commit *content* is correct and the history is a faithful, auditable record of
+   the porch-driven SPIR run.
+
+No history rewrite performed; only the legitimately-flagged plan status was fixed.
+
+## Verification
+
+- Plan `Status` reconciled to complete; `npm test` 121/121 and typecheck remain
+  green (docs-only change). CI workflow still zero-diff vs `main`.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-claude.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-claude.txt
@@ -1,0 +1,71 @@
+I'll review this spec by first reading the key project files it references to verify claims and assess feasibility.Now let me check a few more files referenced in the spec:Let me check the README's e2e/GPU sections and the `suiteEnvFor` function's comment about workers being untouched:Good. Let me check one more thing — the README section around line 284 that explicitly mentions issue #41 sequencing:I've now read every key file the spec references. Here is my review.
+
+---
+
+## Specification 41 Review: Parallelize Local E2E Runs
+
+### Completeness
+
+**Excellent.** The spec correctly identifies and references every file that must change:
+
+- `playwright.config.ts` — `workers: 1` at line 105, `fullyParallel: true` at line 104, the comment block at lines 96–113, `retries` at line 113. All verified against the actual file.
+- `tests/automation.test.mjs` — the source-text assertions at lines 90 (`/workers: 1/`) and 93 (`/retries: process\.env\.CI \? 2 : 0/`). Verified: these are literal regex matches against the config source text and will break when the `workers` line changes. FR8 mandates migrating them.
+- `.github/workflows/validation.yml` — the 4-shard matrix, `E2E_ENGINES: chromium`, blob merge. Verified: all present and the zero-diff constraint is sound.
+- `scripts/e2e-gpu-lane.mjs` — line 622 explicitly says `"workers/retries/timeouts untouched — those stay the config's own defaults"`, confirming the lane inherits whatever `playwright.config.ts` resolves. FR7's claim that the lane will "run the full suite under scaled parallel workers" is correct by construction — no lane code change needed, it inherits the config's new workers value automatically.
+- README lines 284–285 explicitly reference this issue as the sequenced next step: `"workers stays 1 in the lane, matching the qualified suite. Raising parallelism on top of this lane is issue #41's qualification, sequenced after this one."`
+
+All cross-references check out. The success criteria are testable. The scope boundary is clear.
+
+### Correctness
+
+**No contradictions found.** Key verifications:
+
+1. **Playwright `workers` accepts `'50%'`** — this is a documented Playwright-native feature. The config can use `workers: '50%'` directly and Playwright computes the count from `os.cpus().length`. The spec's claim about hardware-relative scaling is technically sound.
+
+2. **`webServer` with multiple workers** — the spec's FR6 claim is correct. Playwright starts the webServer once per `playwright test` invocation before spawning workers. All workers share the same server. No port parameterization needed. Verified: the config's `webServer` block (lines 134–142) uses `reuseExistingServer: false`, which is fine — it prevents reusing a stale server, but Playwright itself only starts it once.
+
+3. **CI guard correctness** — the config currently reads `process.env.CI` for `retries` (line 113) and `timeout` (line 95). Adding a `CI → workers: 1` guard is consistent with the existing pattern and is a one-line, testable invariant.
+
+4. **GPU lane inheritance** — the lane's `suiteEnvFor()` (line 635) composes the env for the Playwright invocation but does NOT set workers — it explicitly leaves "workers/retries/timeouts" to the config. When the config resolves to scaled workers locally, the GPU lane automatically gets parallel execution. This is the correct inheritance model.
+
+5. **`E2E_ENGINES` fail-closed pattern** — the spec correctly mirrors the existing guard (lines 78–85 of `playwright.config.ts`) where an invalid value throws rather than falling back silently. Consistent design.
+
+### Feasibility
+
+**High feasibility, medium risk (honestly acknowledged).** The core change is small: one expression in `playwright.config.ts` for workers, a small pure helper, and migrated assertions. The risk is in the *qualification* — whether `matrix.spec.ts`'s timing-sensitive assertions survive parallel contention — and the spec handles this with Decision 4's evidence-gated branching strategy.
+
+One observation on the `E2E_WORKERS` type conversion: env vars are always strings. The resolution helper must distinguish `'4'` (parse to integer `4`) from `'50%'` (pass as string `'50%'` to Playwright). The spec mentions this in FR2 ("positive integer or a percentage string") and FR8 (test both forms), which is sufficient — the plan will handle the parse implementation.
+
+### Edge Cases
+
+The spec covers the major edge cases well:
+- Invalid `E2E_WORKERS` → fail-closed (FR2)
+- `CI` + `E2E_WORKERS` set simultaneously → `CI` wins (FR3)
+- SwiftShader contention breaks tests → serial fallback with documented trade-off (Decision 4)
+- Open flakes amplified → surface, don't mask (FR5, Decision 5)
+
+**Minor edge case the plan should note** (not spec-blocking): `workers: '50%'` on a 1-core machine resolves to 1 worker (Playwright floors at 1). This is correct — it degrades gracefully — but the plan should verify the helper produces sensible values at the boundary.
+
+### Testing Strategy
+
+**Strong.** FR8 specifies the exact worker-resolution matrix to test (CI→1, integer, percentage, invalid→throws, CI precedence, default scaled). FR9 specifies repeat-run qualification evidence with specific methodology (≥3 consecutive, `retries: 0`, `E2E_GPU_REQUIRE=1`, per-test results). The recommendation to extract a pure helper mirrors the proven `gpu-lane.test.mjs` pattern — a good architectural decision.
+
+The migration of `automation.test.mjs` source-text assertions is correctly scoped: lines 90 and 93 must change. The spec wisely does not prescribe *how* to assert the new contract (source text vs. behavioral), leaving that to the plan.
+
+### Security Considerations
+
+N/A — this is test-harness/config work, no app code touched, no new dependencies, no secrets.
+
+### Ambiguities
+
+None material. The spec even handles the uncertain outcome (parallel default vs. serial fallback) as a first-class branching strategy rather than assuming success. This is unusually honest for a spec.
+
+---
+
+---
+VERDICT: APPROVE
+SUMMARY: Exceptionally thorough spec with every claim verified against the actual codebase; technically sound, well-scoped, and honestly risk-managed with an evidence-gated branching strategy for the uncertain parallel qualification outcome.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES: None

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-codex.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-codex.txt
@@ -1,0 +1,17 @@
+Using the repo files directly to verify the spec against current project context.I’m also checking the hot governance docs the spec cites, to verify whether the proposed contract matches project guidance.---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Strong, feasible spec with solid testing/evidence discipline, but it contains a material contradiction about whether local default behavior must become parallel or may remain serial if qualification fails.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- **Contradictory default-behavior contract.** Decision 4 and several success criteria allow a documented serial local default fallback if SwiftShader parallelism is not stable, but FR1, FR11, Scenario 1, and parts of the Summary require the no-`CI`/no-`E2E_WORKERS` local default to be parallel. The spec needs one canonical rule: either (a) default-local-parallel is mandatory, or (b) default-local-parallel is target behavior but serial default remains acceptable if qualification fails.
+- **Acceptance criteria inherit the same contradiction.** Scenario 1 says a plain local run executes concurrently; Scenario 5 says the outcome may instead be a separated opt-in parallel path with a serial gate. As written, a builder could satisfy one scenario set while violating another.
+- **The “default scaled” requirement is slightly underspecified for implementation/testing.** FR8 requires asserting the default scaled value, but the spec should explicitly say whether tests should assert the configured token (e.g. `'50%'`) or the resolved runtime worker count, and whether the default must floor to at least 1 by Playwright semantics or by helper logic.
+
+Everything else looks good:
+- Requirements are detailed and mostly testable.
+- The approach is technically feasible in the current repo shape (`playwright.config.ts`, `tests/automation.test.mjs`, README, GPU lane).
+- Error handling is appropriately fail-closed.
+- Security impact is minimal; no notable missing security requirement beyond preserving CI isolation/precedence, which the spec already covers.
+- Testing strategy is strong, especially the explicit CI guard, invalid-env coverage, and repeat-run evidence discipline.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-gemini.txt
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: The specification is exceptionally thorough, correctly protecting the CI contract while introducing safe, evidence-gated local parallelism.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None. The specification elegantly handles the risks of SwiftShader CPU contention via a phased, evidence-based approach (using the native-GPU lane as the primary qualification substrate) and maintains the byte-for-byte CI invariance constraint perfectly. The plan to extract worker resolution into a pure, unit-testable helper is an excellent architectural choice.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-rebuttals.md
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/41-specify-iter1-rebuttals.md
@@ -1,0 +1,104 @@
+# Spec 41 — Specify iteration 1 rebuttal
+
+## Verdict summary
+
+| Reviewer | Verdict | Confidence |
+|---|---|---|
+| Gemini | APPROVE | HIGH |
+| Codex | REQUEST_CHANGES | HIGH |
+| Claude | APPROVE | HIGH |
+
+Both APPROVE reviewers verified the spec's claims against the codebase and
+specifically praised the evidence-gated branching strategy (Decision 4) and the
+pure-helper testing approach. Codex agreed the spec is "strong, feasible" with
+"solid testing/evidence discipline" but raised one material clarity defect and
+two minor ones. All three Codex points are accepted; the spec is edited to
+resolve them. Details below.
+
+---
+
+## Codex Issue 1 (material) — Contradictory default-behavior contract
+
+> Decision 4 and several success criteria allow a documented serial local
+> default fallback if SwiftShader parallelism is not stable, but FR1, FR11,
+> Scenario 1, and parts of the Summary require the no-`CI`/no-`E2E_WORKERS`
+> local default to be parallel. The spec needs one canonical rule.
+
+**Accepted — this is a real contradiction and it is now fixed.** The spec's
+*intent* was always Codex's option (b): default-local-parallel is the **target**,
+but a serial default remains acceptable if qualification (FR9) fails, with the
+trade-off documented. That intent lived clearly in Decision 4 and Scenario 5, but
+FR1, Scenario 1, and the Summary were phrased as unconditional guarantees, so a
+builder reading only those could believe parallel-default is mandatory. Fixed by
+making Decision 4 the single canonical rule and pointing every other mention at
+it:
+
+- **Decision 4** now opens with an explicit canonical-rule statement: it governs
+  the no-`CI`/no-`E2E_WORKERS` local default, and wherever the Summary, FR1,
+  FR11, or Scenario 1 call the default "parallel," they mean this
+  qualification-gated target and defer to Decision 4 on any apparent conflict.
+- **FR1** now states the parallel count is the default *only if* FR9
+  qualification is green; otherwise the default is serial (`workers: 1`) and the
+  parallel path is opt-in via `E2E_WORKERS` / the GPU lane's scaled default.
+- **Scenario 1** is reframed as qualification-gated ("once the parallel local
+  default is qualified green (Decision 4)…"), with the serial-fallback branch
+  routing to the opt-in path (Scenario 5's alternative).
+- **Summary** gains a clause pinning the ship-as-default question to Decision 4.
+- **FR11** already documented both branches ("…or opt-in with the documented
+  serial trade-off") and is now explicitly governed by Decision 4's canonical
+  sentence, so it needed no separate text change.
+
+Chosen resolution = Codex option (b): **default-local-parallel is target
+behavior; serial default remains acceptable if qualification fails.** This
+matches the architect's baked framing (issue constraint 1 offered exactly these
+two branches) and both APPROVE reviewers' praise of the evidence-gated design, so
+it is honored rather than collapsed to an unconditional mandate.
+
+## Codex Issue 2 (material, same root) — Acceptance criteria inherit the contradiction
+
+> Scenario 1 says a plain local run executes concurrently; Scenario 5 says the
+> outcome may instead be a separated opt-in path with a serial gate.
+
+**Accepted — resolved by the same fix.** Scenario 1 is now explicitly
+qualification-gated and cross-references Scenario 5's alternative branch, so the
+two scenarios describe one branching outcome rather than two mutually exclusive
+requirements. A builder can no longer satisfy one while violating the other:
+Decision 4 selects the branch, and both scenarios are consistent with whichever
+branch the recorded evidence dictates. Success Criteria 1/2/4 already carried the
+"or documented trade-off" phrasing and remain consistent with the now-canonical
+Decision 4.
+
+## Codex Issue 3 (minor) — "default scaled" underspecified for test assertion
+
+> FR8 requires asserting the default scaled value, but the spec should say
+> whether tests should assert the configured token (e.g. `'50%'`) or the resolved
+> runtime worker count, and whether the default must floor to at least 1.
+
+**Accepted — FR8 clarified.** FR8's "default ⇒ the scaled value" now states the
+spec-level requirement is that the default resolves to the hardware-relative
+scaled value (**not** `1`), and explicitly leaves the *form* of the assertion
+(configured token string like `'50%'` vs. a computed worker integer) as a
+plan/implementation decision — keeping the spec behavior-level, not prescribing
+test mechanics. It also records the ≥1 floor: Playwright floors the resolved
+worker count at 1, so a low-core host degrades gracefully rather than erroring
+(this also captures Claude's boundary observation about `'50%'` on a 1-core
+machine).
+
+---
+
+## Points from the APPROVE reviews (no blocking action, noted)
+
+- **Claude** — 1-core boundary (`'50%'` → 1 worker via Playwright's floor):
+  folded into the FR8 edit above. Claude's env-var string-vs-integer note
+  (`'4'` parses to int, `'50%'` stays a string) is already covered by FR2/FR8 and
+  is an implementation detail for the plan.
+- **Gemini** — no issues raised; endorsed the CI-invariance guard and pure-helper
+  architecture.
+
+## Net change to the spec
+
+Five surgical edits (Summary, Decision 4, FR1, FR8, Scenario 1); no requirement
+was added or removed and no baked decision was relitigated. The edits only make
+Decision 4's already-present evidence-gated rule the single authoritative source
+for the local-default question and remove the absolutist phrasing that
+contradicted it.

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:24:31.367Z'
+updated_at: '2026-07-22T21:25:40.448Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,7 +1,7 @@
 id: '41'
 title: parallelize-local-e2e-runs-sca
 protocol: spir
-phase: review
+phase: verify
 plan_phases:
   - id: phase_1
     title: Pure worker-resolution helper + unit tests
@@ -29,58 +29,10 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
-history:
-  - iteration: 1
-    plan_phase: phase_2
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
-  - iteration: 1
-    plan_phase: phase_3
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
-  - iteration: 2
-    plan_phase: phase_3
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
+build_complete: false
+history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:18:19.009Z'
+updated_at: '2026-07-22T23:18:25.520Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,7 +1,7 @@
 id: '41'
 title: parallelize-local-e2e-runs-sca
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:31:50.749Z'
+updated_at: '2026-07-22T21:31:55.186Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,9 +1,18 @@
 id: '41'
 title: parallelize-local-e2e-runs-sca
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: phase_1
+    title: Pure worker-resolution helper + unit tests
+    status: in_progress
+  - id: phase_2
+    title: Wire helper into config, migrate consumer, update comment
+    status: pending
+  - id: phase_3
+    title: Qualify parallel execution, finalize default, document
+    status: pending
+current_plan_phase: phase_1
 gates:
   spec-approval:
     status: approved
@@ -21,4 +30,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:43:24.156Z'
+updated_at: '2026-07-22T21:43:43.899Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -5,14 +5,14 @@ phase: implement
 plan_phases:
   - id: phase_1
     title: Pure worker-resolution helper + unit tests
-    status: in_progress
+    status: complete
   - id: phase_2
     title: Wire helper into config, migrate consumer, update comment
-    status: pending
+    status: in_progress
   - id: phase_3
     title: Qualify parallel execution, finalize default, document
     status: pending
-current_plan_phase: phase_1
+current_plan_phase: phase_2
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:47:27.006Z'
+updated_at: '2026-07-22T21:49:40.874Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -45,5 +45,21 @@ history:
         verdict: APPROVE
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
+  - iteration: 1
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:52:06.977Z'
+updated_at: '2026-07-22T22:56:00.056Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,7 +1,7 @@
 id: '41'
 title: parallelize-local-e2e-runs-sca
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: phase_1
     title: Pure worker-resolution helper + unit tests
@@ -11,8 +11,8 @@ plan_phases:
     status: complete
   - id: phase_3
     title: Qualify parallel execution, finalize default, document
-    status: in_progress
-current_plan_phase: phase_3
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 3
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -78,4 +78,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:02:32.794Z'
+updated_at: '2026-07-22T23:04:33.103Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 3
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -78,4 +78,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:01:38.475Z'
+updated_at: '2026-07-22T23:02:32.794Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:08:20.726Z'
+updated_at: '2026-07-22T22:52:06.977Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-07-22T21:30:56.336Z'
     approved_at: '2026-07-22T21:31:50.748Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T21:41:40.139Z'
+    approved_at: '2026-07-22T21:43:24.156Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:41:40.139Z'
+updated_at: '2026-07-22T21:43:24.156Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,7 +1,7 @@
 id: '41'
 title: parallelize-local-e2e-runs-sca
 protocol: spir
-phase: verify
+phase: verified
 plan_phases:
   - id: phase_1
     title: Pure worker-resolution helper + unit tests
@@ -34,7 +34,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:20:20.100Z'
+updated_at: '2026-07-22T23:20:21.254Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:56:00.056Z'
+updated_at: '2026-07-22T22:56:38.719Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-07-22T21:30:56.336Z'
   plan-approval:
     status: pending
   pr:
@@ -17,4 +18,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:25:40.448Z'
+updated_at: '2026-07-22T21:30:56.336Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:31:55.186Z'
+updated_at: '2026-07-22T21:38:19.695Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -26,8 +26,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: phase_2
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:01:00.019Z'
+updated_at: '2026-07-22T22:05:23.831Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -28,11 +28,12 @@ gates:
     approved_at: '2026-07-22T23:18:19.008Z'
   verify-approval:
     status: pending
+    requested_at: '2026-07-22T23:19:43.235Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:18:25.520Z'
+updated_at: '2026-07-22T23:19:43.235Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -23,8 +23,9 @@ gates:
     requested_at: '2026-07-22T21:41:40.139Z'
     approved_at: '2026-07-22T21:43:24.156Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T23:17:11.519Z'
+    approved_at: '2026-07-22T23:18:19.008Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -79,10 +80,10 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:17:11.519Z'
+updated_at: '2026-07-22T23:18:19.009Z'
 pr_history:
   - phase: review
     pr_number: 54
     branch: builder/spir-41
     created_at: '2026-07-22T23:12:51.996Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -1,0 +1,20 @@
+id: '41'
+title: parallelize-local-e2e-runs-sca
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-22T21:24:31.366Z'
+updated_at: '2026-07-22T21:24:31.367Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:49:40.874Z'
+updated_at: '2026-07-22T22:01:00.019Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:05:23.831Z'
+updated_at: '2026-07-22T22:06:12.847Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -8,11 +8,11 @@ plan_phases:
     status: complete
   - id: phase_2
     title: Wire helper into config, migrate consumer, update comment
-    status: in_progress
+    status: complete
   - id: phase_3
     title: Qualify parallel execution, finalize default, document
-    status: pending
-current_plan_phase: phase_2
+    status: in_progress
+current_plan_phase: phase_3
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_2-iter1-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:06:12.847Z'
+updated_at: '2026-07-22T22:08:20.726Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -78,4 +78,9 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:04:33.103Z'
+updated_at: '2026-07-22T23:12:51.996Z'
+pr_history:
+  - phase: review
+    pr_number: 54
+    branch: builder/spir-41
+    created_at: '2026-07-22T23:12:51.996Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,13 +27,14 @@ gates:
     requested_at: '2026-07-22T23:17:11.519Z'
     approved_at: '2026-07-22T23:18:19.008Z'
   verify-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T23:19:43.235Z'
+    approved_at: '2026-07-22T23:20:20.100Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:20:18.931Z'
+updated_at: '2026-07-22T23:20:20.100Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 3
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -61,5 +61,21 @@ history:
         verdict: APPROVE
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter1-claude.txt
+  - iteration: 2
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T22:56:38.719Z'
+updated_at: '2026-07-22T23:01:38.475Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -11,12 +11,13 @@ gates:
     approved_at: '2026-07-22T21:31:50.748Z'
   plan-approval:
     status: pending
+    requested_at: '2026-07-22T21:41:40.139Z'
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:38:19.695Z'
+updated_at: '2026-07-22T21:41:40.139Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T21:30:56.336Z'
+    approved_at: '2026-07-22T21:31:50.748Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:30:56.336Z'
+updated_at: '2026-07-22T21:31:50.749Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_2
@@ -78,7 +78,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:12:51.996Z'
+updated_at: '2026-07-22T23:12:58.563Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T21:43:43.899Z'
+updated_at: '2026-07-22T21:47:27.006Z'

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -24,6 +24,7 @@ gates:
     approved_at: '2026-07-22T21:43:24.156Z'
   pr:
     status: pending
+    requested_at: '2026-07-22T23:17:11.519Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -78,9 +79,10 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-41/codev/projects/41-parallelize-local-e2e-runs-sca/41-phase_3-iter2-claude.txt
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:12:58.563Z'
+updated_at: '2026-07-22T23:17:11.519Z'
 pr_history:
   - phase: review
     pr_number: 54
     branch: builder/spir-41
     created_at: '2026-07-22T23:12:51.996Z'
+pr_ready_for_human: true

--- a/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
+++ b/codev/projects/41-parallelize-local-e2e-runs-sca/status.yaml
@@ -30,10 +30,10 @@ gates:
     status: pending
     requested_at: '2026-07-22T23:19:43.235Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-22T21:24:31.366Z'
-updated_at: '2026-07-22T23:19:43.235Z'
+updated_at: '2026-07-22T23:20:18.931Z'
 pr_history:
   - phase: review
     pr_number: 54

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -13,13 +13,20 @@ run that one command; it runs a **contract-equivalent decomposition** of it,
 parallelized to cut wall clock (~15 min → ~5–6 min): a `quality` job (lint +
 typecheck + `npm test` + audit evidence) and an `e2e` matrix that builds and
 runs the FULL Playwright suite split at the test level across four Chromium
-shards (`playwright.config.ts` sets `fullyParallel: true` while keeping
-`workers: 1`, so each shard is strictly serial). The decomposition drops no
+shards (`playwright.config.ts` sets `fullyParallel: true`; `workers` is resolved
+by `resolveWorkers` in `scripts/e2e-workers.mjs`, which pins `1` whenever `CI` is
+set, so each shard is strictly serial). The decomposition drops no
 check: lint, typecheck, build, and every e2e test still run, the Chromium engine
 gate is pinned via `E2E_ENGINES=chromium`, and a `gate` job gives a single
-required status. Do not raise `workers` or trim the qualified per-test waits —
-the SwiftShader timing environment (one test at a time) is what the decomposition
-preserves. Full and production npm audits are separate evidence: CI validates
+required status. The SwiftShader timing environment (one test at a time) is what
+both CI and the local gate preserve: issue #41 qualified raising `workers` and
+found parallel execution destabilizes the timing-sensitive Chromium
+`matrix.spec.ts` camera-settle/drag assertions under SwiftShader CPU contention
+(4–5 of 22 tests fail on every parallel run — the problem is destabilization, not
+slowness), so the **local default is serial too**. Local parallelism is **opt-in**
+via `E2E_WORKERS` (integer or percentage; invalid ⇒ loud `WorkerConfigError`;
+`50%` is ~4× faster and mostly green only on the native-GPU lane). Do not trim the
+qualified per-test waits. Full and production npm audits are separate evidence: CI validates
 their JSON/original status and uploads them without turning existing advisory
 totals into a zero-findings gate. Contributor commands and artifact names live in
 `README.md`; implementation details live in `.github/workflows/validation.yml`,
@@ -48,8 +55,10 @@ fallback: no usable adapter ⇒ Chromium runs under SwiftShader with a loud bann
 while Firefox is **skipped** (no portable software equivalent — never an llvmpipe
 masquerade); `E2E_GPU_REQUIRE=1` hard-fails if any requested engine is
 unverified, `E2E_GPU_FORCE_FALLBACK=1` exercises the fallback deterministically.
-CI stays `E2E_ENGINES=chromium` SwiftShader-only; the lane keeps `workers: 1`
-(parallelizing on top is issue #41's qualification, sequenced after). Recipe and
+CI stays `E2E_ENGINES=chromium` SwiftShader-only; the lane inherits the serial
+default (`workers: 1`) and honors the `E2E_WORKERS` opt-in like any local run —
+issue #41 delivered that opt-in and measured the lane ~4× faster in parallel
+(mostly green; only the open flake #33 amplifies). Recipe and
 evidence: `README.md` ("Opt-in native-GPU e2e lane") and
 `codev/reviews/44-add-an-opt-in-native-gpu-local.md` +
 `codev/reviews/52-firefox-hardware-webgl-gpu-lane.md`.

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -70,6 +70,15 @@ gotcha, or constraint.
   otherwise orphans the browser and can hold the process open. Make the
   launcher/timeouts dependency-injectable so the timed-out-cleanup path has
   deterministic unit coverage instead of being untestable.
+- When qualifying a parallelism/performance change to the test harness, qualify on
+  the path that actually **gates**, not just the fastest available substrate. In
+  #41, hardware-parallel looked green (2/3 runs) while the SwiftShader gate path —
+  what `npm run validate` runs — failed 4–5/22 timing-sensitive tests on *every*
+  parallel run (parallel is faster there but destabilizes the camera-settle/drag
+  assertions); qualifying only on the fast hardware path would have shipped a
+  broken gate. Where the outcome is uncertain, write the safe fallback into the
+  spec up front as an evidence-gated default (spec 41 Decision 4) so an optimistic
+  "parallel by default" degrades to a one-line constant flip, not a redesign.
 
 ## Toolchain and Worktree Hygiene
 

--- a/codev/reviews/41-parallelize-local-e2e-runs.md
+++ b/codev/reviews/41-parallelize-local-e2e-runs.md
@@ -177,3 +177,237 @@ No test was skipped or weakened.
   result must never be generalized.
 - **`retries: 0` did its job**: the amplified flake surfaced immediately instead
   of being silently absorbed.
+
+## Appendix — Per-test results (verbatim, FR9)
+
+Full per-test pass/fail (`✓`/`✘`) for every qualification run, captured
+verbatim from Playwright's `list` reporter (worker index prefixes the test).
+
+### GPU lane · PARALLEL run 1/3 (hardware, 10 workers)
+```
+Running 22 tests using 10 workers
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  10 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   9 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓   7 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   2 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓   1 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+22 passed (44.9s)
+```
+
+### GPU lane · PARALLEL run 2/3 (hardware, 10 workers)
+```
+Running 22 tests using 10 workers
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  10 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   2 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓   1 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   9 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓   7 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+22 passed (44.0s)
+```
+
+### GPU lane · PARALLEL run 3/3 (hardware, 10 workers)
+```
+Running 22 tests using 10 workers
+✓   7 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   1 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓   2 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   9 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  10 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✘  15 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+1 failed
+21 passed (46.9s)
+```
+
+### GPU lane · SERIAL baseline (hardware, 1 worker)
+```
+Running 22 tests using 1 worker
+✓   1 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   2 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓   7 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓   9 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  10 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+22 passed (3.2m)
+```
+
+### SwiftShader · PARALLEL run 1/3 (10 workers)
+```
+Running 22 tests using 10 workers
+✓   9 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes (1.1m)
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses (1.1m)
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize (1.2m)
+✘   7 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag (1.2m)
+✘   8 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel (1.2m)
+✓  10 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control (1.9m)
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  21 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (2.8m)
+✘   2 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation (2.4m)
+✘  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (2.2m)
+✓  22 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓   1 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (3.1m)
+✓  20 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+4 failed
+18 passed (3.2m)
+```
+
+### SwiftShader · PARALLEL run 2/3 (10 workers)
+```
+Running 22 tests using 10 workers
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   2 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize (1.1m)
+✓   9 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control (1.3m)
+✘   1 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag (1.0m)
+✘   6 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel (1.1m)
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (2.6m)
+✘  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (2.1m)
+✘   7 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation (2.4m)
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  10 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (3.2m)
+4 failed
+18 passed (3.3m)
+```
+
+### SwiftShader · PARALLEL run 3/3 (10 workers)
+```
+Running 22 tests using 10 workers
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  10 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize (1.1m)
+✘   2 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control (1.6m)
+✘   9 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses (1.2m)
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✘   5 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel (1.3m)
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  16 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (2.8m)
+✘  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (2.2m)
+✘   7 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation (2.6m)
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓   1 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (3.1m)
+5 failed
+17 passed (3.3m)
+```
+
+### SwiftShader · SERIAL baseline / finalized default (1 worker)
+```
+Running 22 tests using 1 worker
+✓   1 [chromium] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓   2 [chromium] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓   3 [chromium] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓   4 [chromium] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✓   5 [chromium] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag (1.5m)
+✓   6 [chromium] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (1.2m)
+✓   7 [chromium] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓   8 [chromium] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓   9 [chromium] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  10 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (1.3m)
+✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+✓  12 [firefox] › tests/e2e/matrix.spec.ts:75:5 › settles an initial force layout with positioned nodes
+✓  13 [firefox] › tests/e2e/matrix.spec.ts:104:5 › rotates the camera automatically until paused, then resumes
+✓  14 [firefox] › tests/e2e/matrix.spec.ts:134:5 › keeps pointer navigation inert until the enable delay elapses
+✓  15 [firefox] › tests/e2e/matrix.spec.ts:194:5 › zooms out with the wheel
+✘  16 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+✓  17 [firefox] › tests/e2e/matrix.spec.ts:269:5 › click-to-focus fixes the node, animates the camera, and reset restores the view
+✓  18 [firefox] › tests/e2e/matrix.spec.ts:433:5 › toggles AxesHelper visibility through the axes control
+✓  19 [firefox] › tests/e2e/matrix.spec.ts:466:5 › keeps the canvas consistent and interactive across a resize
+✓  20 [firefox] › tests/e2e/matrix.spec.ts:527:5 › remounts a fresh working canvas on re-navigation
+✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz
+✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls
+1 failed
+21 passed (11.7m)
+```

--- a/codev/reviews/41-parallelize-local-e2e-runs.md
+++ b/codev/reviews/41-parallelize-local-e2e-runs.md
@@ -160,9 +160,10 @@ No test was skipped or weakened.
 - [x] `playwright.config.ts` comment reflects the new local-parallel rationale
       (replaces the stale "Do NOT raise workers" text).
 - [~] `npm run validate` wall-clock: the documented trade-off is taken instead of
-      a default speedup (Success Metric 4's permitted alternative) — parallel
-      gives no SwiftShader speedup and breaks the gate, so serial is retained;
-      the ~4× speedup is available opt-in on the GPU lane.
+      a default speedup (Success Metric 4's permitted alternative) — SwiftShader
+      parallel is faster (~3.3m vs 11.7m serial) but **breaks the gate** (4–5/22
+      timing failures every run), so serial is retained; the ~4× speedup is
+      available opt-in on the GPU lane, where the suite stays mostly green.
 
 ## Lessons Learned (to expand in the Review phase)
 

--- a/codev/reviews/41-parallelize-local-e2e-runs.md
+++ b/codev/reviews/41-parallelize-local-e2e-runs.md
@@ -1,0 +1,178 @@
+# Review 41: Parallelize Local E2E Runs Scaled to Hardware (CI Byte-for-Byte Unchanged)
+
+> Status: implementation complete (phases 1–3). This review is authored during
+> Phase 3 to preserve the qualification evidence verbatim (FR9); the Review-phase
+> pass expands lessons/methodology.
+
+## Summary of Outcome
+
+Local e2e worker resolution is now a single tested pure helper
+(`scripts/e2e-workers.mjs`) consumed by `playwright.config.ts`
+(`workers: resolveWorkers(process.env)`). The resolver:
+
+- **CI (any truthy `CI`) → `1`**, returning before it reads `E2E_WORKERS`, so the
+  sharded CI matrix's per-job serial contract is structural and un-overridable.
+- **`E2E_WORKERS` override** → a positive integer (`4`) or a percentage (`50%`);
+  an invalid value is a loud `WorkerConfigError` at config load, never a silent
+  serial fallback.
+- **Local default → `1` (serial).**
+
+**The headline "parallel by default" was NOT shipped, by design.** Phase-3
+qualification (below) showed parallel workers **destabilize** the timing-sensitive
+Chromium `matrix.spec.ts` assertions on the SwiftShader path that `npm run
+validate` actually gates on — 4–5 of 22 tests fail on every parallel run there
+(the failure is destabilization, not slowness: parallel is actually faster) — and
+amplify a known open Firefox flake even on hardware. Per **spec Decision 4** (the canonical, evidence-gated
+rule for the local default) and **Acceptance Scenario 5 / acceptance criterion 2**
+(separated parallel path + documented trade-off), the default stays **serial** and
+parallelism is **opt-in via `E2E_WORKERS`** — a strict superset of prior behavior
+(default identical to before) plus a new opt-in that is ~4× faster on the
+native-GPU lane. CI is byte-for-byte unchanged.
+
+## What Was Built (by phase)
+
+- **Phase 1** — `scripts/e2e-workers.mjs`: pure `resolveWorkers(env)`,
+  `DEFAULT_LOCAL_WORKERS`, `WorkerConfigError`; `tests/e2e-workers.test.mjs` (full
+  FR8 matrix, 24 tests). No I/O, no `process.env` access, no Playwright import.
+- **Phase 2** — wired the helper into `playwright.config.ts`
+  (`workers: resolveWorkers(process.env)`), replaced the stale "Do NOT raise
+  workers" comment block with the new contract, migrated the
+  `tests/automation.test.mjs` source-text assertion (`/workers: 1/` →
+  `/workers: resolveWorkers\(process\.env\)/`, i.e. assert delegation).
+- **Phase 3** — ran the qualification, **finalized the default to serial** in the
+  helper (`DEFAULT_LOCAL_WORKERS = 1`, flipped from the originally-proposed
+  `'50%'`), updated the config comment to the finalized contract, verified FR7
+  (the GPU lane inherits the worker count with no lane code change), updated the
+  README (FR11), and proved CI untouched (FR4).
+
+## Qualification Evidence (FR9 — verbatim)
+
+Host: WSL2, 20 cores (`nproc=20`), NVIDIA RTX 3080 via Mesa d3d12. `retries: 0`
+throughout. Full two-engine suite = 22 tests (11 Chromium + 11 Firefox).
+
+### A. Native-GPU lane — contention-free hardware (primary vehicle, `E2E_GPU_REQUIRE=1`)
+
+Renderers verified every run — `renderer.chromium: ANGLE (Microsoft Corporation,
+D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)`, `renderer.firefox: D3D12 (NVIDIA
+GeForce RTX 3080)`.
+
+| Run | Banner | Result | Wall-clock |
+|-----|--------|--------|-----------|
+| Parallel 1/3 | `Running 22 tests using 10 workers` | `22 passed (44.9s)` | `57s (build 10s, suite 46s)` |
+| Parallel 2/3 | `Running 22 tests using 10 workers` | `22 passed (44.0s)` | `57s (build 10s, suite 45s)` |
+| Parallel 3/3 | `Running 22 tests using 10 workers` | **`1 failed`**, `21 passed (46.9s)` | `60s (build 10s, suite 48s)` |
+| **Serial baseline** | `Running 22 tests using 1 worker` | `22 passed (3.2m)` | `207s (build 10s, suite 196s)` |
+
+Parallel hardware speedup: suite 46s vs serial 196s ≈ **4.3×**. But 1 of 3
+parallel runs failed. The failure (verbatim):
+
+```
+  ✘  15 [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag (23.9s)
+
+  1) [firefox] › tests/e2e/matrix.spec.ts:224:5 › zooms in with the wheel and rotates with a background drag
+    Error: a background drag should rotate the camera
+    expect(received).toBeGreaterThan(expected)
+    Expected: > 1
+    Received:   0.001966449662569139
+    - Timeout 5000ms exceeded while waiting on the predicate
+```
+
+This is the **known open flake #33** (Firefox synthetic-input-delivery
+nondeterminism, documented in the README as "survives on hardware"), which issue
+#41 explicitly warned "parallel contention may amplify." It did — 0 recurrences
+across 3 serial hardware runs (this set's baseline + review 52's set), 1 in 3
+parallel hardware runs.
+
+### B. SwiftShader — the path `npm run validate` actually gates on
+
+| Run | Banner | Result | Wall-clock |
+|-----|--------|--------|-----------|
+| **Serial baseline** | `Running 22 tests using 1 worker` | **`1 failed`** (flake #33), `21 passed` | `11.7m` |
+| Parallel 1/3 | `Running 22 tests using 10 workers` | **`4 failed`**, `18 passed` | `3.2m` |
+| Parallel 2/3 | `Running 22 tests using 10 workers` | **`4 failed`**, `18 passed` | `3.3m` |
+| Parallel 3/3 | `Running 22 tests using 10 workers` | **`5 failed`**, `17 passed` | `3.3m` |
+
+Failing tests under **SwiftShader parallel** (all **Chromium**, all timing-sensitive
+`matrix.spec.ts` / `smoke` interaction assertions — exactly the class the old "Do
+NOT raise workers" comment named):
+
+- `matrix.spec.ts:194 zooms out with the wheel` — 3/3 runs
+- `matrix.spec.ts:224 zooms in with the wheel and rotates with a background drag` — 3/3 runs
+- `matrix.spec.ts:527 remounts a fresh working canvas on re-navigation` — 3/3 runs
+- `smoke.spec.ts:78 renders the graph and exercises its core controls` — 3/3 runs
+- `matrix.spec.ts:134 keeps pointer navigation inert until the enable delay elapses` — 1/3 runs
+
+**Wall-clock is NOT the reason parallel loses here.** Parallel SwiftShader (~3.3m)
+is ~3.5× *faster* than serial SwiftShader (11.7m). The disqualifier is
+**destabilization**: 10 SwiftShader software rasterizers saturate the CPU, and the
+timing-sensitive camera-settle/wheel/drag assertions miss their deadlines — 4–5 of
+22 Chromium tests fail on **every** parallel run (0/3 green). A gate that fails
+4–5/22 every run is not a gate, however fast.
+
+### Serial gate note — pre-existing flake floor (#33 / #34)
+
+The serial default is the **pre-existing** local gate contract; `resolveWorkers({})
+=== 1` routes the default there, and issue #41 does not change it. It is honest to
+record that this pre-existing path is **not flawlessly green at `retries: 0`**: the
+serial SwiftShader baseline above hit the **same known open flake #33** once
+(`[firefox] matrix.spec.ts:224`, motion `0.0038` < `MOTION_FLOOR` 1). #33 and the
+click-to-focus flake #34 are pre-existing, open, and surface even serially at
+`retries: 0` — which is exactly why they are tracked and why CI runs `retries: 2`.
+Issue #41 neither introduces nor fixes them; it preserves the serial contract and
+adds opt-in parallel that **amplifies** them (hence opt-in, not default). The full
+`npm run validate` gate is proven on a clean checkout at PR time (local `eslint .`
+noise is the untracked `.claude/hooks/` builder-harness file, absent on a clean
+checkout — see lessons-critical).
+
+## Decision & Deviation (FR8 vs. Decision 4)
+
+Spec **FR8** literally asserts "default (no `CI`, no `E2E_WORKERS`) ⇒ the scaled
+value — i.e. … **not** `1`". The finalized default is `1`. This is a **deliberate,
+authorized deviation**: the approved spec makes **Decision 4 "the single canonical
+rule for the local default,"** evidence-gated, with an explicit serial-fallback
+branch (Scenario 5); FR1/Scenario 1/Summary already defer to it. FR8's "not 1"
+clause was written under the assumption the parallel default would qualify green;
+the evidence above shows it does not, so Decision 4 governs and the default is
+serial. The unit test row that asserted the `'50%'` default was updated to assert
+`1` (per the plan's Phase-3 note "if the default flips, update the matrix row").
+Architect endorsed this disposition (2026-07-22).
+
+## Flaky Tests / Disposition
+
+- **#33** (`[firefox] matrix.spec.ts:224`): pre-existing, open, amplified by
+  parallel contention. **Disposition:** accepted + documented, **not masked with
+  retries**, the canonical `MOTION_FLOOR` assertion **not weakened**. It is a
+  primary reason parallel is opt-in, not default. `retries: 0` keeps any
+  recurrence visible.
+- The SwiftShader-parallel Chromium failures are **contention artifacts of a
+  configuration we are not shipping as default**, not defects in shipped behavior;
+  the shipped serial default does not exhibit them.
+
+No test was skipped or weakened.
+
+## Acceptance Criteria
+
+- [x] Local runs can use multiple workers scaled to cores (`E2E_WORKERS=50%`);
+      CI unchanged (`validation.yml` zero-diff; `CI=1 ⇒ workers 1`, tested).
+- [x] The parallel path is **clearly separated from the qualified serial gate
+      with the trade-off documented** (acceptance criterion 2, second branch) —
+      the ≥3-run parallel qualification is recorded above.
+- [x] `playwright.config.ts` comment reflects the new local-parallel rationale
+      (replaces the stale "Do NOT raise workers" text).
+- [~] `npm run validate` wall-clock: the documented trade-off is taken instead of
+      a default speedup (Success Metric 4's permitted alternative) — parallel
+      gives no SwiftShader speedup and breaks the gate, so serial is retained;
+      the ~4× speedup is available opt-in on the GPU lane.
+
+## Lessons Learned (to expand in the Review phase)
+
+- **Evidence-gated defaults earn their keep.** The spec's Decision 4 anticipated
+  exactly this outcome; had the default been hard-committed to parallel, the gate
+  would ship flaky. Writing the "or serial fallback, documented" branch into the
+  spec up front made the honest landing a one-line constant flip, not a redesign.
+- **Qualify on the path that gates, not just the fast path.** Hardware parallel
+  looked ~green (2/3); only running the SwiftShader path — what `npm run validate`
+  actually executes — revealed the 4–5/22 destabilization. A single host's fast
+  result must never be generalized.
+- **`retries: 0` did its job**: the amplified flake surfaced immediately instead
+  of being silently absorbed.

--- a/codev/reviews/41-parallelize-local-e2e-runs.md
+++ b/codev/reviews/41-parallelize-local-e2e-runs.md
@@ -1,8 +1,8 @@
 # Review 41: Parallelize Local E2E Runs Scaled to Hardware (CI Byte-for-Byte Unchanged)
 
-> Status: implementation complete (phases 1–3). This review is authored during
-> Phase 3 to preserve the qualification evidence verbatim (FR9); the Review-phase
-> pass expands lessons/methodology.
+> Status: complete — phases 1–3 implemented and reviewed (3-way, unanimous
+> APPROVE each), qualification evidence preserved verbatim (FR9), governance docs
+> routed. Outcome: serial-default + opt-in-parallel (Decision 4 / Scenario 5).
 
 ## Summary of Outcome
 
@@ -119,10 +119,15 @@ serial SwiftShader baseline above hit the **same known open flake #33** once
 click-to-focus flake #34 are pre-existing, open, and surface even serially at
 `retries: 0` — which is exactly why they are tracked and why CI runs `retries: 2`.
 Issue #41 neither introduces nor fixes them; it preserves the serial contract and
-adds opt-in parallel that **amplifies** them (hence opt-in, not default). The full
-`npm run validate` gate is proven on a clean checkout at PR time (local `eslint .`
-noise is the untracked `.claude/hooks/` builder-harness file, absent on a clean
-checkout — see lessons-critical).
+adds opt-in parallel that **amplifies** them (hence opt-in, not default).
+
+**Gate cleanliness (lessons-critical):** local `eslint .` reports 21 errors, all in
+the **untracked** `.claude/hooks/worktree-write-guard.cjs` builder-harness file
+(absent from clean checkouts) — not project code. Every **tracked** `.ts/.mjs/.js`
+file lints clean (`git ls-files … | xargs eslint` → 0 errors), and `eslint .`
+flags no non-hooks file, so the lint gate is clean on a pristine tree. `npm run
+typecheck` is clean; #41 touches no `package.json`/lockfile, so `npm ci`
+reproducibility is unaffected. The noise was **not** suppressed in committed config.
 
 ## Decision & Deviation (FR8 vs. Decision 4)
 
@@ -165,18 +170,145 @@ No test was skipped or weakened.
       timing failures every run), so serial is retained; the ~4× speedup is
       available opt-in on the GPU lane, where the suite stays mostly green.
 
-## Lessons Learned (to expand in the Review phase)
+## Spec Compliance
 
+- [x] **FR1 (local parallel capability)** — delivered as **opt-in** per Decision 4
+      (evidence-gated); parallel runs via `E2E_WORKERS`, scaled to cores.
+- [x] **FR2 (`E2E_WORKERS` override)** — integer or percentage; invalid ⇒ loud
+      `WorkerConfigError` at config load; tested (FR8 matrix).
+- [x] **FR3 (absolute CI serial guard)** — `resolveWorkers` returns `1` before
+      reading `E2E_WORKERS`; tested; re-verified via `CI=1` run banner (1 worker).
+- [x] **FR4 (CI byte-for-byte unchanged)** — `.github/workflows/validation.yml`
+      zero-diff vs `main`.
+- [x] **FR5 (`retries: 0` preserved locally)** — unchanged; kept the amplified
+      flake visible.
+- [x] **FR7 (GPU lane inherits workers)** — verified: lane banner `22 tests using
+      10 workers`, zero `scripts/e2e-gpu-lane.mjs` change.
+- [x] **FR8 (worker-resolution coverage)** — `tests/e2e-workers.test.mjs` (24
+      tests); `automation.test.mjs` source-text assertion migrated to delegation.
+- [x] **FR9 (repeat-run qualification evidence)** — ≥3 parallel runs on both the
+      GPU lane and SwiftShader, verbatim per-test results (Appendix).
+- [x] **FR10 (config comment)** — stale "Do NOT raise workers" block replaced with
+      the finalized contract.
+- [x] **FR11 (README)** — new "Local test parallelism" note + lane/env-table/status
+      updates.
+- [~] **FR6 / Success Metric 4 (`validate` speedup)** — the documented trade-off is
+      taken instead (Decision 4 / Scenario 5): serial gate retained; ~4× speedup
+      available opt-in on the GPU lane.
+
+## Deviations from Plan
+
+- **Default finalized to serial, not parallel `'50%'`** (Phase 3). The plan
+  carried both branches; the evidence forced the serial-default + opt-in branch.
+  This deviates from FR8's literal "default ⇒ scaled, not 1" clause, authorized by
+  the canonical **Decision 4** (see "Decision & Deviation" above). Architect
+  endorsed.
+
+## Lessons Learned
+
+### What Went Well
 - **Evidence-gated defaults earn their keep.** The spec's Decision 4 anticipated
-  exactly this outcome; had the default been hard-committed to parallel, the gate
-  would ship flaky. Writing the "or serial fallback, documented" branch into the
-  spec up front made the honest landing a one-line constant flip, not a redesign.
-- **Qualify on the path that gates, not just the fast path.** Hardware parallel
-  looked ~green (2/3); only running the SwiftShader path — what `npm run validate`
-  actually executes — revealed the 4–5/22 destabilization. A single host's fast
-  result must never be generalized.
-- **`retries: 0` did its job**: the amplified flake surfaced immediately instead
+  this outcome; had the default been hard-committed to parallel, the gate would
+  ship flaky. The "or serial fallback, documented" branch made the honest landing
+  a one-line constant flip, not a redesign.
+- The **pure helper + config-consumer** split (Phase 1 before Phase 2) meant the
+  finalize-the-default step was a single constant change with the contract already
+  fully unit-tested.
+- **`retries: 0` did its job** — the amplified flake surfaced immediately instead
   of being silently absorbed.
+
+### Challenges Encountered
+- **A wrong-baseline speedup claim.** I first wrote "parallel gives no speedup"
+  by comparing parallel-SwiftShader against serial-*hardware*. The serial-default
+  confirmation run (11.7m serial SwiftShader) exposed it: parallel is *faster*
+  but *destabilizes*. Fixed across review/config/helper/README; Codex caught two
+  residual mentions I'd missed on the first sweep. Lesson: when correcting a claim,
+  grep for the *concept* (every `speedup|faster|slower`), not one phrasing.
+- **Per-test evidence granularity.** My first review summarized runs; FR9 wants
+  full per-test pass/fail. Added a verbatim 8-run appendix.
+
+### What Would Be Done Differently
+- Run the serial-SwiftShader baseline **early**, before framing any speedup claim,
+  so the comparison baselines are correct from the first draft.
+
+### Methodology Improvements
+- The evidence-gated-default pattern (spec writes both branches; builder picks from
+  recorded evidence) worked cleanly and is worth reusing for any "optimistic
+  headline that might not survive qualification" spec.
+
+## Consultation Feedback
+
+### Specify Phase (Round 1)
+- **Codex (REQUEST_CHANGES)** — FR1/Scenario 1/Summary asserted the parallel local
+  default *unconditionally*, contradicting Decision 4's evidence-gated framing.
+  **Addressed**: made Decision 4 the single canonical rule; FR1/Scenario 1/Summary
+  now defer to it. **Gemini / Claude**: APPROVE, no concerns.
+
+### Plan Phase (Round 1)
+- **Codex (COMMENT)** — `playwright test --list` proves the config *loads* but not
+  the resolved worker count. **Addressed**: Phase 2 asserts Playwright's `using M
+  worker(s)` run banner under default / `CI=1` / `E2E_WORKERS=4`. **Gemini /
+  Claude**: APPROVE.
+
+### Implement Phase 1 (Round 1)
+- **All three APPROVE** — no concerns raised.
+
+### Implement Phase 2 (Round 1 → 2)
+- **Codex (REQUEST_CHANGES, R1)** — config comment overstated qualification ("is
+  qualified" before Phase 3 recorded evidence). **Addressed**: reworded to "is
+  being qualified … that evidence decides the default." **R2: all three APPROVE.**
+
+### Implement Phase 3 (Rounds 1 → 2 → 3)
+- **Codex (REQUEST_CHANGES, R1)** — (a) review said parallel "gives no SwiftShader
+  speedup", contradicting the 3.3m-vs-11.7m data; (b) helper inline comment still
+  said "Scaled default". **Both addressed.**
+- **Codex (REQUEST_CHANGES, R2)** — (a) review lacked full per-test results (FR9);
+  (b) `automation.test.mjs` comment "local runs scale to hardware" stale. **Both
+  addressed** (verbatim per-test appendix; comment corrected).
+- **R3: all three APPROVE.** Gemini and Claude APPROVE'd every Phase-3 round.
+
+## Architecture Updates
+
+Routed to the **COLD** `codev/resources/arch.md` (§ Validation Baseline) — reference
+detail, not a hot always-inject fact:
+- Updated the (now-stale) "keeps `workers: 1`" / "Do not raise `workers`" text: the
+  config resolves `workers` via `resolveWorkers` (CI-guarded to `1`); the **local
+  default is serial** because #41 qualified parallel and found SwiftShader
+  destabilization; local parallelism is **opt-in** via `E2E_WORKERS`.
+- Updated the GPU-lane paragraph: the "sequenced after" future-reference is now
+  delivered; the lane inherits the serial default and honors `E2E_WORKERS`.
+
+No **HOT** `arch-critical.md` change: the hot fact "`npm run validate` is the green
+gate" still holds, and its map already routes worker/e2e changes to "Validation
+Baseline". No cap pressure, no displacement.
+
+## Lessons Learned Updates
+
+Routed to the **COLD** `codev/resources/lessons-learned.md` (§ Validation Evidence):
+- "Qualify a parallelism/performance change on the path that **gates** (SwiftShader
+  for local e2e), not just the fastest substrate — hardware-parallel looked green
+  while the gate path failed 4–5/22 every run; and write the safe fallback into the
+  spec up front as an evidence-gated default."
+
+No **HOT** `lessons-critical.md` change: the hot lesson "'tests pass' is not 'it
+works' — verify the real user path" already carries the spirit; this is a
+harness-qualification refinement (reference detail), so it belongs cold. No cap
+pressure.
+
+## Technical Debt
+
+- **Open flakes #33 (Firefox drag-rotate) and #34 (click-to-focus)** remain open —
+  pre-existing, not in #41's scope. #41 documents that parallelism amplifies them
+  and keeps them unmasked. Fixing them is follow-up work that would make opt-in
+  parallel more reliable.
+
+## Follow-up Items
+
+- If #33/#34 are fixed, re-run the parallel qualification — a green parallel path
+  could justify revisiting the default (the machinery is already in place; only the
+  `DEFAULT_LOCAL_WORKERS` constant would change).
+- Consider a convenience script (e.g. `test:smoke:parallel`) if opt-in parallel on
+  the GPU lane becomes a common local workflow.
 
 ## Appendix — Per-test results (verbatim, FR9)
 

--- a/codev/specs/41-parallelize-local-e2e-runs.md
+++ b/codev/specs/41-parallelize-local-e2e-runs.md
@@ -10,7 +10,10 @@ gets its speed from a 4-shard matrix of isolated VMs (each shard still
 `workers: 1`). This issue makes local runs use multiple workers **scaled to the
 machine's cores** (Playwright-native `'50%'`-style scaling with an explicit
 `E2E_WORKERS` override), leveraging the `fullyParallel: true` that is already
-set.
+set. Whether this parallel worker count ships as the **local default** (versus an
+opt-in atop a retained serial default) is evidence-gated per **Decision 4, the
+canonical rule** for the local default; the headline capability is that local
+runs *can and, once qualified, do* run parallel and hardware-scaled.
 
 The **GitHub Actions workflow stays byte-for-byte the same**: same 4-shard
 matrix, same `workers: 1` inside each shard, same `E2E_ENGINES=chromium`, same
@@ -140,7 +143,12 @@ the FR8 methodology").
    FR8 methodology (`E2E_GPU_REQUIRE=1`, ≥3 consecutive green full-suite runs,
    per-test results and wall-clocks recorded).
 
-4. **Local default: parallel, evidence-gated; documented serial fallback.** The
+4. **Local default: parallel, evidence-gated; documented serial fallback.**
+   **This decision is the canonical rule for the no-`CI`/no-`E2E_WORKERS` local
+   default. Wherever the Summary, FR1, FR11, or Scenario 1 describe the local
+   default as parallel, they mean this qualification-gated target — not an
+   unconditional guarantee — and defer to this decision on any apparent
+   conflict.** The
    target is that the local default is parallel (the scaled value from Decision
    2) so `npm run validate` wall-clock improves (Success Criterion 4). This is
    contingent on qualification: the full two-engine **local** suite must pass
@@ -318,7 +326,13 @@ evidence-gated upgrade (Decision 4), not chosen as the sole path.
 A local e2e run (no `CI`, no `E2E_WORKERS`) runs the suite under multiple
 workers scaled to the machine via Playwright's hardware-relative percentage
 form, leveraging the existing `fullyParallel: true`. The scaling adapts to the
-host's core count with no hard-coded number.
+host's core count with no hard-coded number. Whether this parallel count is the
+**default** (vs. an opt-in behind a retained serial default) is governed by
+Decision 4, the canonical default rule: it ships as the default only if the
+parallel qualification (FR9) is green; if qualification fails, the default is
+serial (`workers: 1`) and this parallel path is reached opt-in via `E2E_WORKERS`
+(and the GPU lane's scaled default). Either way, whenever parallel workers are
+used the scaling is hardware-relative with no hard-coded number.
 
 ### FR2 — `E2E_WORKERS` override
 
@@ -369,7 +383,13 @@ semantics from #44/#52 intact.
 Automated coverage asserts the worker-resolution contract: `CI` set ⇒ `1`;
 `E2E_WORKERS` integer ⇒ that integer; `E2E_WORKERS` percentage ⇒ that
 percentage; invalid `E2E_WORKERS` ⇒ throws; `CI` precedence over `E2E_WORKERS`;
-default (no `CI`, no `E2E_WORKERS`) ⇒ the scaled value. The existing
+default (no `CI`, no `E2E_WORKERS`) ⇒ the scaled value — i.e. the resolved
+contract is the hardware-relative default, **not** `1` (Playwright floors the
+resolved worker count at ≥1, so a low-core host degrades gracefully rather than
+erroring). Whether the assertion inspects the configured token the helper
+produces (e.g. the string `'50%'`) or a computed worker integer is a
+plan/implementation decision; the spec-level requirement is only that the
+default resolves to the scaled parallel value, not to serial. The existing
 `tests/automation.test.mjs` source-text assertions (`/workers: 1/`, retries) are
 migrated to the new contract so the suite reflects reality.
 
@@ -445,9 +465,13 @@ touched config comment reflects the new reality.
 ## Acceptance Scenarios
 
 ### Scenario 1 — Scaled parallel local run
-On multi-core hardware, a local run (`npm run test:smoke` or the qualified
-parallel path) executes tests concurrently across workers scaled to the cores,
-and the full two-engine suite passes.
+On multi-core hardware, once the parallel local default is qualified green
+(Decision 4), a plain local run (`npm run test:smoke`) executes tests
+concurrently across workers scaled to the cores, and the full two-engine suite
+passes. If qualification fails and the serial-default fallback is taken, the same
+concurrent execution is instead reached through the opt-in path (`E2E_WORKERS` or
+the GPU lane's scaled default) — Scenario 5's alternative branch. Either way, when
+parallel workers run, the full two-engine suite passes.
 
 ### Scenario 2 — `E2E_WORKERS` override
 `E2E_WORKERS=4` runs with 4 workers; `E2E_WORKERS=50%` runs with a

--- a/codev/specs/41-parallelize-local-e2e-runs.md
+++ b/codev/specs/41-parallelize-local-e2e-runs.md
@@ -1,0 +1,533 @@
+# Specification 41: Parallelize Local E2E Runs Scaled to Hardware (CI Byte-for-Byte Unchanged)
+
+## Summary
+
+Give the **local** Playwright e2e suite hardware-scaled parallelism. Today
+`playwright.config.ts` pins `workers: 1` for every environment, so a local run
+(`npm run test:smoke` / `npm run validate`) executes every test one at a time —
+across both engines (Chromium + Firefox) — even on a 20-core machine, while CI
+gets its speed from a 4-shard matrix of isolated VMs (each shard still
+`workers: 1`). This issue makes local runs use multiple workers **scaled to the
+machine's cores** (Playwright-native `'50%'`-style scaling with an explicit
+`E2E_WORKERS` override), leveraging the `fullyParallel: true` that is already
+set.
+
+The **GitHub Actions workflow stays byte-for-byte the same**: same 4-shard
+matrix, same `workers: 1` inside each shard, same `E2E_ENGINES=chromium`, same
+blob-report merge. `.github/workflows/validation.yml` must not appear in the PR
+diff at all. The config must pin `workers: 1` **whenever `CI` is set**, so the
+sharded matrix's per-job serial contract is preserved automatically regardless
+of any local default (arch-critical: Validation Baseline).
+
+The one contract this issue **deliberately revisits** is the local
+`workers: 1` qualification. The current config comment
+(`playwright.config.ts:96-113`) forbids raising workers on purpose: Chromium
+renders WebGL through SwiftShader (CPU-bound software rasterization) and the
+compound interaction tests in `tests/e2e/matrix.spec.ts` carry timing-sensitive
+camera-settle / drag / click-to-focus assertions qualified against a
+contention-free **serial** environment. Implementing this issue means
+re-qualifying the local arm under parallel execution and recording the evidence
+— not merely deleting the comment. The **native-GPU local e2e lane** shipped by
+specs #44 (Chromium) and #52 (Firefox) — `npm run test:e2e:gpu`,
+`scripts/e2e-gpu-lane.mjs` — is the primary qualification vehicle: on
+hardware-accelerated WebGL the SwiftShader CPU-contention rationale for
+`workers: 1` largely evaporates, exactly as those issues' reviews sequenced
+(#44 review Follow-up: "#41 should qualify `workers > 1` **on this lane** using
+the FR8 methodology").
+
+### Why this is worth building
+
+1. **Faster local iteration and a faster local gate.** On multi-core hardware a
+   serial two-engine run leaves most cores idle; parallel workers cut local
+   wall-clock materially.
+2. **Local finally mirrors CI's parallelism model** — CI already fans the suite
+   out (across VMs); local has had no equivalent.
+3. **The prerequisite already exists.** `fullyParallel: true` is set, the
+   native-GPU lane (#44/#52) provides a contention-free environment to qualify
+   parallelism honestly, and Playwright's `workers` accepts a hardware-relative
+   percentage natively.
+
+## Problem Analysis
+
+### Current state
+
+- `playwright.config.ts` hard-codes `workers: 1` (line 105) for **every**
+  environment. `fullyParallel: true` (line 104) is set only so CI's `--shard`
+  splits the suite at the test level; within any single process execution is
+  strictly serial.
+- Local runs (`npm run test:smoke`, `npm run validate`) therefore execute the
+  full two-engine suite — 11 Chromium tests + 11 Firefox tests (22 total) —
+  one test at a time, regardless of available cores.
+- CI (`.github/workflows/validation.yml`) gets its speed from a 4-shard matrix
+  (`shard: [1, 2, 3, 4]`), 4 isolated VMs, each shard still `workers: 1` with
+  `E2E_ENGINES=chromium`; blob reports are merged by `merge-reports`. This is
+  the qualified CI timing environment and must not change.
+- The `workers: 1` comment block (lines 96-113) documents the rationale: raising
+  in-job parallelism reintroduces SwiftShader CPU contention that the
+  timing-sensitive `matrix.spec.ts` assertions were qualified against.
+- Local `retries: 0` (line 113) is intentional so flakes surface immediately;
+  CI uses `retries: 2`. Two flake classes are still open — the click-to-focus
+  test (#34, flaked even under serial CI) and the Firefox pointer-nav race
+  (#33) — and parallel CPU contention could amplify both.
+- `tests/automation.test.mjs` asserts the current config source directly:
+  `/workers: 1/` (line 90) and `/retries: process\.env\.CI \? 2 : 0/` (line 93).
+  These source-text assertions are consumers that must migrate with the config
+  change.
+- The native-GPU lane (specs #44/#52, `scripts/e2e-gpu-lane.mjs`) runs the full
+  suite on verified hardware WebGL and already delegates the suite run to
+  `playwright.config.ts` (it sets `E2E_ENGINES` / `PW_CHROMIUM_ARGS`, not
+  workers). Its reviews recorded serial-hardware baselines (Chromium ≈ 94-97 s
+  suite; two-engine ≈ 196 s suite) and explicitly deferred `workers > 1`
+  qualification to this issue.
+
+### Desired state
+
+- A local e2e run uses **multiple workers scaled to the machine's cores** by
+  default, via Playwright-native percentage scaling (e.g. `'50%'`), with an
+  explicit `E2E_WORKERS` override (integer or percentage) so users can tune it.
+- **CI is provably unchanged**: `.github/workflows/validation.yml` does not
+  appear in the PR diff; `workers` resolves to `1` whenever `CI` is set,
+  ignoring any `E2E_WORKERS`; the 4-shard matrix, engine pinning, and
+  blob-merge are untouched.
+- The parallel local path is **qualified** — the full two-engine local suite
+  passes repeatedly (≥3 consecutive parallel runs) — with the primary
+  qualification on the native-GPU lane (contention-free) and, where the target
+  is a parallel `npm run validate`, on the SwiftShader path as well. If
+  SwiftShader parallel contention proves the timing-qualified tests unstable,
+  parallelism is scoped to the opt-in path and the serial gate is retained,
+  with the trade-off documented (never masked with retries).
+- The `workers: 1` comment block is replaced with the actual new contract:
+  local hardware-scaled parallel, CI hard-pinned serial, the retries policy,
+  and the qualification rationale.
+- `npm run validate` wall-clock improves measurably on multi-core hardware
+  (when the parallel local default is qualified green).
+
+### Stakeholders
+
+- **Primary**: the project developer(s) running local e2e iteration and the
+  local `npm run validate` gate.
+- **Secondary**: the native-GPU lane (#44/#52) — this issue consumes its
+  contention-free environment as the qualification substrate; flake triage for
+  #34 (click-to-focus) and #33 (Firefox pointer race), which parallel execution
+  stresses.
+- **Technical**: builder implementing this spec; CI is a stakeholder only in
+  that it must be provably unaffected.
+
+## Confirmed Decisions
+
+1. **CI is byte-for-byte unchanged and hard-guarded.**
+   `.github/workflows/validation.yml` must not appear in the PR diff. The config
+   pins `workers: 1` whenever `CI` is set — an unconditional guard so the
+   4-shard matrix's per-job serial contract holds automatically, independent of
+   any local default. `CI` precedence is absolute: when `CI` is set,
+   `E2E_WORKERS` is ignored and workers resolve to `1`.
+
+2. **Playwright-native, hardware-relative scaling with an env override.** Local
+   worker count uses Playwright's percentage form (adapts to any machine) — not
+   a hard-coded core count — with an explicit `E2E_WORKERS` override accepting
+   either a positive integer or a percentage string (e.g. `4` or `'50%'`). The
+   recommended scaled default is `'50%'`; the exact default value is confirmed
+   by qualification (Decision 4). An invalid `E2E_WORKERS` value is a loud
+   hard failure (fail-closed, mirroring the config's existing
+   `E2E_ENGINES`-matched-no-engines guard), never a silent fallback.
+
+3. **The native-GPU lane is the primary qualification vehicle.** Parallelism is
+   qualified first on `npm run test:e2e:gpu` (hardware WebGL), where the
+   SwiftShader CPU-contention rationale for `workers: 1` does not exist — the
+   sequencing #44 and #52 established. The lane runs the full suite under scaled
+   parallel workers; its machine-greppable report and wall-clock reflect the
+   parallel run and become this issue's qualification evidence, using the #44/#52
+   FR8 methodology (`E2E_GPU_REQUIRE=1`, ≥3 consecutive green full-suite runs,
+   per-test results and wall-clocks recorded).
+
+4. **Local default: parallel, evidence-gated; documented serial fallback.** The
+   target is that the local default is parallel (the scaled value from Decision
+   2) so `npm run validate` wall-clock improves (Success Criterion 4). This is
+   contingent on qualification: the full two-engine **local** suite must pass
+   ≥3 consecutive parallel runs at the scaled worker count. If SwiftShader
+   parallel contention destabilizes the timing-qualified `matrix.spec.ts` tests
+   (the exact risk the current comment names; #34/#33 may amplify), the local
+   default reverts to serial (`workers: 1`) and parallelism becomes opt-in via
+   `E2E_WORKERS` plus the GPU lane's own scaled default — with the trade-off
+   recorded as a qualification finding. The decision is driven by recorded
+   evidence, never assumed, and any instability is dispositioned per the
+   project's flake discipline (fixed or explicitly accepted+documented), **never
+   masked with retries and never by weakening a canonical assertion**.
+
+5. **Local `retries: 0` is preserved, parallel or not.** The parallel local path
+   keeps `retries: 0`; it does **not** adopt CI's `retries: 2`. Parallel
+   contention amplifying a flake is precisely what must surface, not be hidden —
+   consistent with the config's existing rationale and spec #52 Decision 10.
+
+6. **Shared web server, one invocation, no local sharding.** All workers reuse
+   the single `webServer` on port 3000 (Playwright starts it once per
+   invocation); no port parameterization is needed or added. Running the suite
+   as multiple concurrent `--shard` processes locally is explicitly out of scope
+   — workers on one machine subsume it.
+
+7. **No new dependencies or toolchain movement.** Worker scaling is
+   Playwright-native. `engines`, `dependencies`, `devDependencies`, and the
+   lockfile are untouched — the lockfile shows no delta (arch-critical:
+   reproducibility contract: Node 22.23.1, npm 10.9.8, lockfile v3, `npm ci`).
+
+8. **App code is not touched.** This is test-harness / config / tooling work.
+   `app/**` is not modified; committed test assertions are not retuned for
+   parallel timing (Decision 4 governs any instability). Test/harness changes
+   are limited to what the worker-scaling contract and its migration require.
+
+## Scope
+
+### In scope
+
+- Making `playwright.config.ts` `workers` resolve to: `1` under `CI`; otherwise
+  a hardware-scaled value governed by an `E2E_WORKERS` override (integer or
+  percentage) with a scaled default. Invalid overrides fail loudly.
+- Recommended (plan's choice): extracting the worker-resolution logic into a
+  small importable pure helper so it is directly unit-testable (mirroring the
+  way `scripts/e2e-gpu-lane.mjs` exports pure functions for
+  `tests/gpu-lane.test.mjs`), keeping the config a thin consumer.
+- Ensuring the native-GPU lane runs the full suite under scaled parallel workers
+  (inheriting the parallel default and/or honoring `E2E_WORKERS`), and that its
+  report/wall-clock reflect the parallel run — the primary qualification vehicle.
+- Updating the config's `workers: 1` comment block (lines 96-113) to the new
+  contract: local hardware-scaled parallel, CI hard-pinned serial, retries
+  policy, qualification rationale.
+- Migrating the source-text consumers in `tests/automation.test.mjs` (the
+  `/workers: 1/` and retries assertions) to the new contract, and adding
+  coverage that asserts the worker-resolution matrix (CI→1; `E2E_WORKERS`
+  integer/percentage parsed; invalid→throws; CI precedence over `E2E_WORKERS`;
+  default scaled).
+- Repeat-run qualification evidence (≥3 consecutive full two-engine parallel
+  runs) recorded in the review, primarily on the GPU lane, with a
+  contemporaneous serial baseline wall-clock for comparison, and — if the
+  parallel `validate` default is adopted — SwiftShader-parallel stability
+  evidence too.
+- Documentation of the new local-parallel contract and `E2E_WORKERS` (README /
+  the surface where the e2e workflow and the GPU lane are already documented),
+  including the CI-unchanged guarantee and the qualification outcome.
+- Proof the CI workflow is untouched (Success Criterion 1 / Scenario "CI
+  untouched").
+
+### Out of scope (non-goals)
+
+- Any change to `.github/workflows/validation.yml`, the 4-shard matrix, CI
+  `E2E_ENGINES=chromium`, CI `workers: 1`, CI `retries: 2`, or the blob-report
+  merge. CI stays byte-for-byte identical.
+- Local sharding (multiple concurrent `--shard` processes on one machine).
+- Adopting CI's `retries: 2` locally, or otherwise masking flakes with retries.
+- Retuning / loosening committed `matrix.spec.ts` (or any test's) timing
+  assertions to accommodate parallel contention (Decision 4/8).
+- App (`app/**`) code changes, new dependencies, toolchain/lockfile movement.
+- Fixing the open #34 / #33 flakes (they are dispositioned per the flake
+  discipline if they recur under parallel execution; a code fix is not mandated
+  here).
+- Any GPU-in-CI work (the #42 lesson stands; CI stays SwiftShader-only).
+
+## Constraints and Invariants
+
+- **CI untouched** (arch-critical: Validation Baseline): `npm run validate` is
+  the green gate and its CI decomposition is contract-equivalent;
+  `.github/workflows/validation.yml` must not appear in the PR diff, and
+  `workers: 1` must be effective whenever `CI` is set.
+- **Reproducibility contract** (arch-critical): Node 22.23.1, npm 10.9.8,
+  lockfile v3, `npm ci`; no dependency regeneration. This work adds no packages —
+  the lockfile shows no delta.
+- **Evidence honesty** (lessons-critical: Validation Evidence): record the exact
+  worker count, per-run and per-test results, and wall-clocks verbatim; never
+  broaden a single machine's parallel result into a universal claim; preserve
+  nonzero/diagnostic evidence rather than normalizing it. A parallel run that
+  flakes is reported as flaky — that visibility is intentional.
+- **No flake masking** (lessons-critical; spec #52 Decision 10): the parallel
+  path keeps `retries: 0` locally; instability is fixed or explicitly
+  accepted+documented, never hidden behind retries or a weakened assertion.
+- **Committed-tree proof discipline** (lessons-critical): if a local gate check
+  fails only on an untracked harness file, prove the gate on a clean worktree
+  (`git worktree add --detach HEAD` + real `npm ci`) rather than suppressing it
+  in committed config.
+
+## Solution Exploration
+
+### Approach A: Separate parallel script, serial config untouched
+
+**Description**: Keep `playwright.config.ts` at `workers: 1`; add a new npm
+script that invokes `playwright test --workers=<n>` for a parallel local run.
+
+**Pros**: The qualified serial gate is literally byte-for-byte untouched; zero
+config risk.
+
+**Cons**: A `--workers` CLI flag is not hardware-relative (no percentage on the
+CLI without extra plumbing), so it can't "scale to the machine" without a
+wrapper computing a count — reintroducing exactly the hard-coded-count the issue
+warns against. It also does not make `npm run validate` faster (Success
+Criterion 4), and it forks suite invocation into a second command that drifts
+from `validate`/`test:smoke` and the GPU lane. Fails the "scaled to hardware"
+and "validate improves" criteria.
+
+**Complexity**: Low. **Risk**: Low (but under-delivers).
+
+### Approach B: Config-level hardware-scaled `workers` with a CI guard and env override (selected)
+
+**Description**: `playwright.config.ts` resolves `workers` to `1` under `CI`,
+otherwise to a hardware-relative scaled value governed by an `E2E_WORKERS`
+override (integer or percentage) with a scaled default. Worker-resolution logic
+lives in a small importable pure helper so it is unit-testable and the config
+stays a thin consumer. Parallelism is qualified primarily on the native-GPU lane
+(contention-free), with the local default's parallel/serial disposition
+evidence-gated (Decision 4). CI is provably untouched by the guard + a zero-diff
+`validation.yml`.
+
+**Pros**: Uses Playwright-native percentage scaling (adapts to any machine);
+`E2E_WORKERS` gives explicit tuning; one suite invocation for all paths (no
+drift); `npm run validate` and the GPU lane both benefit from a single change;
+the CI guard is a one-line, testable invariant; qualification lands where it is
+safe (hardware lane) per the #44/#52 sequencing.
+
+**Cons**: Touches the qualified config, so the byte-identical-default posture of
+#44/#52 does **not** fully apply to the local arm — the local serial
+qualification is deliberately revisited and must be re-qualified with evidence;
+the `tests/automation.test.mjs` source-text assertions must migrate.
+
+**Complexity**: Medium. **Risk**: Medium (mitigated by the CI guard, the
+evidence-gated default, and the GPU-lane qualification).
+
+**Selected** — it is the only approach that delivers hardware-relative scaling,
+a faster `npm run validate`, a single non-drifting suite invocation, and a
+provably untouched CI, while placing qualification where the architecture says
+it is safe.
+
+### Approach C: Re-qualify a parallel SwiftShader `validate` as the sole path
+
+**Description**: Make the local default parallel and qualify only the SwiftShader
+path, without leaning on the GPU lane.
+
+**Pros**: Directly targets Success Criterion 4 (faster `validate`).
+
+**Cons**: SwiftShader is CPU-bound; N parallel workers all software-rasterizing
+contend heavily, and the timing-sensitive `matrix.spec.ts` assertions were
+qualified against a contention-free serial environment — with #34/#33 open, this
+is the highest-flake-risk path and ignores the contention-free lane the project
+built specifically to qualify this safely.
+
+**Complexity**: Medium. **Risk**: High. Folded into Approach B as the
+evidence-gated upgrade (Decision 4), not chosen as the sole path.
+
+## Functional Requirements
+
+### FR1 — Hardware-scaled local workers
+
+A local e2e run (no `CI`, no `E2E_WORKERS`) runs the suite under multiple
+workers scaled to the machine via Playwright's hardware-relative percentage
+form, leveraging the existing `fullyParallel: true`. The scaling adapts to the
+host's core count with no hard-coded number.
+
+### FR2 — `E2E_WORKERS` override
+
+`E2E_WORKERS` (working name; final name is a plan decision) overrides the local
+worker count and accepts a positive integer or a percentage string (e.g. `4` or
+`50%`). An invalid value (non-positive, non-numeric, malformed percentage) is a
+loud hard failure at config resolution — consistent with the config's existing
+fail-closed `E2E_ENGINES` guard — never a silent fallback to a default. The
+override is lane/local-only: it is read by the config, not required by any
+committed test.
+
+### FR3 — Absolute CI serial guard
+
+Whenever `CI` is set, `workers` resolves to `1`, ignoring `E2E_WORKERS`. This
+preserves the sharded matrix's per-job serial contract automatically. `CI`
+precedence over `E2E_WORKERS` is explicit and tested.
+
+### FR4 — CI workflow provably untouched
+
+`.github/workflows/validation.yml` does not appear in the PR diff (the 4-shard
+matrix, `E2E_ENGINES=chromium`, per-shard `workers: 1`, `retries: 2`, and the
+blob-report merge are all unchanged). PR CI (quality + 4 SwiftShader e2e shards
++ gate) is green.
+
+### FR5 — Preserved local `retries: 0`
+
+The local run keeps `retries: 0` under parallel execution; it does not adopt
+CI's `retries: 2`. Flakes surface immediately in both serial and parallel local
+modes.
+
+### FR6 — Shared web server, unchanged
+
+All workers reuse the single `webServer` on port 3000; the `webServer` block is
+functionally unchanged (one server per invocation, all workers attached). No
+port parameterization.
+
+### FR7 — Native-GPU lane runs parallel (primary qualification vehicle)
+
+The native-GPU lane (`npm run test:e2e:gpu`) runs the full suite under the
+scaled parallel workers (inheriting the parallel default and/or honoring
+`E2E_WORKERS`), and its machine-greppable report / wall-clock reflect the
+parallel run. This is the qualification substrate for FR9 per the #44/#52 FR8
+methodology. The lane keeps its honest-reporting, verification, and fallback
+semantics from #44/#52 intact.
+
+### FR8 — Worker-resolution coverage
+
+Automated coverage asserts the worker-resolution contract: `CI` set ⇒ `1`;
+`E2E_WORKERS` integer ⇒ that integer; `E2E_WORKERS` percentage ⇒ that
+percentage; invalid `E2E_WORKERS` ⇒ throws; `CI` precedence over `E2E_WORKERS`;
+default (no `CI`, no `E2E_WORKERS`) ⇒ the scaled value. The existing
+`tests/automation.test.mjs` source-text assertions (`/workers: 1/`, retries) are
+migrated to the new contract so the suite reflects reality.
+
+### FR9 — Repeat-run parallel qualification evidence
+
+Before the parallel path is documented as trusted: **≥3 consecutive full
+two-engine parallel runs** recorded in the review — per-run pass/fail per test,
+wall-clock, worker count, and `retries: 0` — primarily on the native-GPU lane
+(`E2E_GPU_REQUIRE=1` so a silent fallback cannot pollute the evidence), with a
+contemporaneous serial baseline wall-clock for comparison. If the parallel
+`npm run validate` default is adopted (Decision 4), SwiftShader-parallel
+stability evidence is recorded the same way. Any instability beyond an already
+-documented flake blocks the "trusted" designation until root-caused and
+dispositioned (fixed or explicitly accepted+documented) — never masked.
+
+### FR10 — Updated config rationale comment
+
+The config's `workers: 1` comment block is replaced with the actual contract:
+local hardware-scaled parallel via `E2E_WORKERS`/scaled default, CI hard-pinned
+serial (the guard), local `retries: 0` preserved, and the qualification
+rationale (why parallelism is safe — the GPU lane / recorded evidence). The
+stale "Do NOT raise `workers`" guidance is removed, not merely edited around.
+
+### FR11 — Documentation
+
+The repo docs (README's e2e / GPU-lane sections, which already describe the
+serial local run and the lane) are updated to state: local runs are parallel and
+hardware-scaled by default; how to tune with `E2E_WORKERS` (integer or
+percentage); the CI-unchanged guarantee (`workers: 1` whenever `CI` is set);
+local `retries: 0` is preserved; and the qualification outcome (parallel
+`validate` default, or opt-in with the documented serial trade-off). If the
+serial fallback is taken, the trade-off is documented explicitly (Success
+Criterion 2's alternative branch).
+
+## Non-Functional Requirements
+
+### Reproducibility
+No dependency, lockfile, or toolchain movement; the change runs on the pinned
+Node/npm. Worker scaling is Playwright-native.
+
+### Behavior preservation (CI)
+CI behavior — the 4-shard matrix, engine pinning, per-shard serial execution,
+retries, blob merge, and the gate — is provably identical to today, guaranteed
+by the `CI`→`1` guard and a zero-diff `validation.yml`.
+
+### Performance
+On multi-core hardware the parallel local run measurably reduces wall-clock
+versus the serial baseline; when the parallel `validate` default is qualified,
+`npm run validate` wall-clock improves measurably.
+
+### Evidence honesty
+Worker counts, per-run/per-test results, and wall-clocks are recorded verbatim;
+a single host's parallel result is never generalized; flaky parallel runs are
+reported as flaky.
+
+### Maintainability
+Worker-resolution logic is small, pure, and unit-tested (not scattered
+conditionals); one suite invocation serves local, lane, and CI (no drift); the
+touched config comment reflects the new reality.
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| SwiftShader parallel contention destabilizes timing-qualified `matrix.spec.ts` tests | Medium-High | Medium | FR9 repeat-run qualification at `retries: 0`; Decision 4 evidence-gated default with a documented serial fallback; primary qualification on the contention-free GPU lane |
+| Open flakes #34 (click-to-focus) / #33 (Firefox pointer race) amplified under parallel contention | Medium | Medium | `retries: 0` keeps them visible (FR5); disposition per flake discipline, never masked (Decision 5) |
+| A stray `E2E_WORKERS` in a CI-like env parallelizes a shard | Low | High | FR3 absolute `CI`→`1` guard (CI precedence over `E2E_WORKERS`), explicitly tested (FR8) |
+| Config change drifts the qualified CI contract | Low | High | FR4 zero-diff `validation.yml` + CI green; the guard is a one-line, tested invariant |
+| Invalid `E2E_WORKERS` silently falls back and misleads | Low | Medium | FR2 fail-closed loud error, tested (FR8) |
+| Worker-resolution logic diverges from what Playwright actually runs | Low | Medium | Pure helper unit-tested (FR8) **and** qualification runs exercise the real resolved config end-to-end (FR9) |
+| `automation.test.mjs` source-text assertions left stale, hiding the change | Medium | Low | FR8 migrates them as part of scope |
+
+## Acceptance Scenarios
+
+### Scenario 1 — Scaled parallel local run
+On multi-core hardware, a local run (`npm run test:smoke` or the qualified
+parallel path) executes tests concurrently across workers scaled to the cores,
+and the full two-engine suite passes.
+
+### Scenario 2 — `E2E_WORKERS` override
+`E2E_WORKERS=4` runs with 4 workers; `E2E_WORKERS=50%` runs with a
+hardware-relative count; an invalid value (e.g. `0`, `abc`, `12x`) fails loudly
+at config resolution rather than silently running serial.
+
+### Scenario 3 — CI untouched and serial
+`git diff` on the PR shows no change to `.github/workflows/validation.yml` or the
+CI e2e/gate contract; with `CI` set, `workers` resolves to `1` even if
+`E2E_WORKERS` is present; PR CI (quality + 4 SwiftShader e2e shards + gate) is
+green.
+
+### Scenario 4 — Parallel qualification recorded
+The review contains ≥3 consecutive full two-engine parallel runs (per-test
+results, wall-clock, worker count, `retries: 0`) — primarily on the native-GPU
+lane under `E2E_GPU_REQUIRE=1` — plus a contemporaneous serial baseline
+wall-clock, showing a measurable multi-core speedup. If the parallel `validate`
+default is adopted, SwiftShader-parallel stability evidence is included.
+
+### Scenario 5 — Faster gate or documented trade-off
+Either `npm run validate` wall-clock improves measurably on multi-core hardware
+(parallel default qualified green), **or** the parallel path is clearly
+separated from the qualified serial gate with the trade-off documented (Success
+Criterion 2's alternative branch) — with the choice justified by the recorded
+evidence.
+
+### Scenario 6 — Documentation
+A developer who has not read this spec can find, in the repo docs, that local
+runs are parallel and hardware-scaled, how to tune with `E2E_WORKERS`, that CI
+is unchanged, that local `retries: 0` is preserved, and what the qualification
+concluded.
+
+## Success Criteria
+
+- [ ] Local e2e runs use multiple workers scaled to the machine's cores; CI runs
+  are unchanged (`validation.yml` untouched and `workers: 1` effective under
+  `CI=1`).
+- [ ] The full two-engine local suite passes repeatedly (≥3 consecutive runs)
+  under parallel execution, **or** the parallel path is clearly separated from
+  the qualified serial gate with the trade-off documented.
+- [ ] `playwright.config.ts` comments updated to reflect the new local-parallel
+  rationale (replacing the stale "Do NOT raise workers" guidance with the actual
+  contract).
+- [ ] `npm run validate` wall-clock improves measurably on multi-core hardware
+  (when the parallel local default is qualified), or the documented trade-off
+  path is taken.
+- [ ] `E2E_WORKERS` override works (integer + percentage); invalid values fail
+  loudly; CI precedence is tested.
+- [ ] No dependency/lockfile/toolchain movement; `app/**` untouched; local
+  `retries: 0` preserved; flakes never masked.
+
+## Dependencies
+
+- **Internal**: `playwright.config.ts` (`fullyParallel: true`, `workers`,
+  `E2E_ENGINES` handling); the native-GPU lane
+  (`scripts/e2e-gpu-lane.mjs`, specs/reviews #44 and #52) as the primary
+  qualification substrate and serial-hardware baseline; `tests/automation.test.mjs`
+  (source-text config consumers) and `tests/gpu-lane.test.mjs` (pure-helper test
+  pattern to mirror).
+- **External services**: none.
+- **Sequencing**: this issue consumes the #44/#52 lane qualification per their
+  reviews' Follow-up Items ("#41 should qualify `workers > 1` on this lane using
+  the FR8 methodology"); both have landed, so the substrate exists.
+
+## References
+
+- Issue #41 (this spec) and its cross-link to #44/#52; issues #34 (click-to-focus
+  flake) and #33 (Firefox pointer-nav race) — open flake classes parallel
+  execution stresses.
+- Spec / plan / review #44 (`codev/{specs,plans,reviews}/44-add-an-opt-in-native-gpu-local.md`),
+  #52 (`codev/{specs,plans,reviews}/52-firefox-hardware-webgl-gpu-lane.md`) — the
+  native-GPU lane, its FR8 qualification methodology, and the explicit #41
+  sequencing / serial-hardware baselines.
+- `playwright.config.ts` (`workers: 1` comment block lines 96-113,
+  `fullyParallel: true`, `retries` line 113), `.github/workflows/validation.yml`
+  (4-shard matrix), `tests/automation.test.mjs` (config source-text assertions),
+  `tests/e2e/matrix.spec.ts` (timing-sensitive assertions), README (e2e / GPU-lane
+  docs).
+- `codev/resources/arch-critical.md` — Validation Baseline (canonical gate; CI
+  contract; do not raise workers / trim waits without re-qualification).
+- `codev/resources/lessons-critical.md` — Validation Evidence (record evidence
+  honestly, never mask flakes); Toolchain and Worktree Hygiene (clean-checkout
+  proof).

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -281,3 +281,13 @@ criterion 2b). Guardrails all honored:
   WAITING FOR HUMAN APPROVAL.** STOPPED — NOT calling porch approve (human-only).
   Codex #1 (commit format) is rebutted-on-record; human decides at the gate.
   Architect notified. Awaiting `porch approve 41 pr`.
+
+## Verify phase (architect-directed merge ordering)
+
+- pr gate APPROVED. Architect directive: advance porch to write the
+  'chore(porch): 41 protocol complete' commit, PUSH to origin/builder/spir-41,
+  and merge PR #54 ONLY AFTER that commit is on the remote (architect verifies).
+- Change already verified end-to-end via Phase-2/3 real-run evidence. `porch done 41`
+  (verify) → **GATE REQUIRED: verify-approval** → `porch gate 41` requested.
+  STOPPED — NOT approving (human-only), NOT merging yet. Awaiting verify-approval;
+  then porch writes protocol-complete commit → I push → architect verifies → I merge.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -231,3 +231,11 @@ criterion 2b). Guardrails all honored:
   fixed to "faster but breaks the gate"; (2) helper inline comment still said
   "Scaled default" → fixed to "Serial default". Broad speedup-audit now clean.
   Wrote 41-phase_3-iter1-rebuttals.md. Signaling porch done → re-verification.
+
+- Phase 3 iter2 consult: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**
+  (HIGH). Both Codex points ACCEPTED: (1) FR9 wanted full per-test pass/fail →
+  appended "Appendix — Per-test results (verbatim, FR9)" to the review with all
+  8×22 ✓/✘ verdicts (3 GPU parallel + GPU serial + 3 SwiftShader parallel +
+  SwiftShader serial default); (2) automation.test.mjs comment "local runs scale to
+  hardware" stale → fixed to serial-default + E2E_WORKERS opt-in. suite 121/121,
+  lint clean. Wrote 41-phase_3-iter2-rebuttals.md. Signaling porch done.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -291,3 +291,10 @@ criterion 2b). Guardrails all honored:
   (verify) → **GATE REQUIRED: verify-approval** → `porch gate 41` requested.
   STOPPED — NOT approving (human-only), NOT merging yet. Awaiting verify-approval;
   then porch writes protocol-complete commit → I push → architect verifies → I merge.
+
+- verify-approval APPROVED. `porch next` → **PROTOCOL COMPLETE (phase: verified)**.
+  porch wrote+pushed `3b9b877 chore(porch): 41 protocol complete`. Confirmed on
+  the remote: local HEAD == origin/builder/spir-41 == 3b9b877.
+- Per architect's "I verify the protocol-complete commit is on the remote before
+  the merge lands": PAUSING before merge. Notified architect; awaiting go-ahead to
+  merge PR #54 (regular merge commit, no squash).

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -276,3 +276,8 @@ criterion 2b). Guardrails all honored:
   for impl commits); the `chore(porch):` commits are porch state commits, not
   builder commits, and strict-mode forbids rewriting pushed porch history. Wrote
   41-review-iter1-rebuttals.md. Committing plan fix + rebuttal, pushing to PR #54.
+
+- porch done → **GATE REQUIRED: pr**. Ran `porch gate 41` → **pr gate active,
+  WAITING FOR HUMAN APPROVAL.** STOPPED — NOT calling porch approve (human-only).
+  Codex #1 (commit format) is rebutted-on-record; human decides at the gate.
+  Architect notified. Awaiting `porch approve 41 pr`.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -239,3 +239,32 @@ criterion 2b). Guardrails all honored:
   SwiftShader serial default); (2) automation.test.mjs comment "local runs scale to
   hardware" stale → fixed to serial-default + E2E_WORKERS opt-in. suite 121/121,
   lint clean. Wrote 41-phase_3-iter2-rebuttals.md. Signaling porch done.
+
+- Phase 3 iter3 consult: **UNANIMOUS APPROVE** (Gemini/Codex/Claude, HIGH, zero
+  issues). Per-test appendix + automation comment fixes verified. Phase 3 DONE.
+  Advancing porch → should commit phase_3 and enter the Review (R) phase.
+
+## Review (R) phase
+
+- All 3 implement phases committed + 3-way approved (phase_1 unanimous; phase_2
+  iter2 unanimous; phase_3 iter3 unanimous). Entered R phase.
+- Completed review: Spec Compliance (FR1-11), Deviations, expanded Lessons,
+  Consultation Feedback (every phase/round/model), mandatory Architecture Updates
+  + Lessons Learned Updates, Technical Debt, Follow-up. Per-test FR9 appendix kept.
+- Governance docs (COLD tier, via update-arch-docs skill):
+  - arch.md § Validation Baseline: replaced stale "keeps workers:1 / Do not raise"
+    text with the resolveWorkers CI-guard + serial-local-default + E2E_WORKERS
+    opt-in contract; updated GPU-lane para ("#41 sequenced after" now delivered).
+  - lessons-learned.md § Validation Evidence: "qualify on the gating path, not the
+    fast substrate; write the evidence-gated fallback into the spec up front."
+  - No HOT change (reference detail; hot maps already route to those sections; no
+    cap pressure/displacement).
+- Clean-checkout gate proof (lessons-critical): tracked tree lints clean
+  (`git ls-files … | xargs eslint` = 0); `eslint .` flags ONLY untracked
+  .claude/hooks/; typecheck clean; no package.json/lockfile delta. Noise NOT
+  suppressed in committed config.
+- e2e_tests porch check = `npm run test:e2e || echo skipped` → no such script →
+  skips (per sibling threads air-30/spir-12). review_has_arch/lessons_updates ✓.
+- Committing review + governance + consult artifacts (convention: consult .txt
+  tracked, cf. project 12). Builder-harness files (.builder-*, .claude/hooks/)
+  left untracked (not deliverables; not suppressing in config). Opening PR next.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -16,6 +16,211 @@ stays byte-for-byte unchanged, guarded by `CI`→`workers: 1`.
     the retries regex (93) — these are the consumers that must migrate.
   - GPU lane present: `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`;
     scripts `test:smoke`, `test:e2e:gpu`, `validate` all present.
-- No factual corrections needed. Signaling specify build complete → porch runs
-  the 3-way consultation (Gemini/Codex/Claude). Then STOP at `spec-approval`
-  gate for human approval.
+- No factual corrections needed. Signaled specify build complete → porch ran
+  the 3-way consultation (Gemini/Codex/Claude).
+- Consult iter1 verdicts: **Gemini APPROVE**, **Claude APPROVE**, **Codex
+  REQUEST_CHANGES**. Codex's material point was a real contradiction: FR1 /
+  Scenario 1 / Summary stated the local parallel default *unconditionally*, but
+  Decision 4 / Scenario 5 made it *evidence-gated* with a serial fallback.
+- Fix: made Decision 4 the single canonical rule for the local default; FR1,
+  Scenario 1, Summary now defer to it; clarified FR8's default-scaled assertion
+  (≥1 Playwright floor; token-vs-integer form deferred to plan). Wrote rebuttal
+  (`41-specify-iter1-rebuttals.md`). Committed as `a40a0c9` "[Spec 41]
+  Specification with multi-agent review".
+- `porch done` → advanced to **spec-approval GATE**. `porch gate 41` requested.
+  **STOPPED — waiting for human approval.** Not calling `porch approve` (human
+  only). Architect notified.
+- **spec-approval APPROVED by architect.** Advanced to Plan phase.
+
+## Plan phase
+
+Recon before drafting (verified against code):
+- `playwright.config.ts`: `workers: 1` (105), comment block (96-103), `retries:
+  process.env.CI ? 2 : 0` (113), `E2E_ENGINES` fail-closed guard (68-85) — the
+  model to mirror for `E2E_WORKERS`.
+- Module format: `node --test tests/*.test.mjs` runs plain ESM (no TS). Helper
+  must be `.mjs` (mirrors `scripts/e2e-gpu-lane.mjs` ⇐ `tests/gpu-lane.test.mjs`).
+  tsconfig `include` covers `playwright.config.ts`; `checkJs` off ⇒ importing the
+  `.mjs` adds no typecheck errors (JSDoc for clean inferred signature).
+- GPU lane (`suiteEnvFor`) never sets workers ⇒ inherits config default; FR7 = no
+  lane code change, just verify + doc.
+- No new `package.json` script (`E2E_WORKERS` is an env var) ⇒ automation.test
+  script-list assertion stays green. `npm test` runs in CI `quality` job ⇒ new
+  helper unit test is CI-gated.
+- automation.test.mjs consumer to migrate: line 90 `/workers: 1/` (retries
+  assertion 93 stays — retries unchanged).
+- README FR11 spots: 70-72 (scripts), 178 (lane "same workers: 1"), 284-285
+  ("#41 sequenced after"), 222-228 (env table → add E2E_WORKERS).
+- **Risk flagged for implement**: builder is WSL2; GPU lane (`E2E_GPU_REQUIRE=1`)
+  may not verify hardware here. Plan carries the Decision-4 evidence-gated
+  branch: GPU-lane primary; if unavailable, SwiftShader-parallel qualifies the
+  `validate` default; if unstable ⇒ serial default + opt-in parallel, documented.
+
+Planned phases: (1) pure helper + unit tests; (2) wire into config + migrate
+consumer + comment; (3) qualify parallel, finalize default, document.
+
+- Plan drafted, checks pass (plan_exists/has_phases_json/min_two_phases=3),
+  committed `e063feb` "[Spec 41] Initial implementation plan".
+- Plan 3-way consult: **Gemini APPROVE**, **Claude APPROVE**, **Codex COMMENT**.
+  Codex's point (legit): `playwright test --list` proves the config loads but
+  does NOT print the resolved worker count. Fixed Phase 2 to assert Playwright's
+  "using M worker(s)" run banner under default(M>1)/CI=1(M=1)/E2E_WORKERS=4(M=4);
+  `--list` kept only as the .mjs-import load check. Committed `2b78e93` "[Spec 41]
+  Plan with multi-agent review". Both APPROVE reviewers independently verified
+  file refs + confirmed GPU lane never sets workers (FR7 no-code-change holds).
+- `porch next` → passing consensus (no rebuttal). `porch gate 41` → **plan-approval
+  GATE**. **STOPPED — waiting for human approval.** Architect notified.
+
+## Implement phase — Phase 1 (pure worker-resolution helper + tests)
+
+- plan-approval GATE **APPROVED by architect** (mid-turn). `porch next` → advanced
+  to implement/phase_1.
+- Scope: ONLY phase_1 — new `scripts/e2e-workers.mjs` (pure `resolveWorkers(env)`,
+  `DEFAULT_LOCAL_WORKERS='50%'`, `WorkerConfigError`) + `tests/e2e-workers.test.mjs`
+  (full FR8 matrix). Mirror `scripts/e2e-gpu-lane.mjs` conventions (LaneUsageError
+  class pattern, 4-space, double-quote, JSDoc, pure/no-I/O exports).
+- Contract confirmed vs spec FR2/FR8 + plan: CI truthy⇒number 1 (first, matches
+  config's `process.env.CI ? …` idiom); E2E_WORKERS undefined/empty⇒default;
+  `/^[1-9][0-9]*%$/`⇒string; `/^[1-9][0-9]*$/`⇒Number; else throw
+  WorkerConfigError; default⇒'50%'. Leading-zero/1e2/1.5/%/12x/0/0%/-1 all throw
+  (locked with explicit negative test rows per plan risk).
+
+- Built `scripts/e2e-workers.mjs` (pure `resolveWorkers`, `DEFAULT_LOCAL_WORKERS`,
+  `WorkerConfigError`, JSDoc) + `tests/e2e-workers.test.mjs` (24 tests: full FR8
+  matrix + 13 negative rows locking leading-zero/1e2/1.5/%/hex/whitespace-pct).
+- Checks GREEN: `node --test` 24/24; full `npm test` 121/121; `npm run typecheck`
+  clean; `npm run build` clean; `npx eslint` on the two NEW files clean.
+- KNOWN NOISE: `npm run lint` (`eslint .`) reports 21 errors, ALL in the untracked
+  builder-harness file `.claude/hooks/worktree-write-guard.cjs` (git `?? .claude/hooks/`),
+  absent from clean checkouts. Per lessons-critical: environment noise, NOT suppressed
+  in committed config; full-gate clean-checkout proof deferred to PR (Phase 3).
+- Staged the 2 deliverables (explicit add, no -A) so the 3-way consult diff sees them.
+  Signaling `porch done 41` → triggers Gemini/Codex/Claude review of phase_1.
+
+## Phase 2 — wire helper into config, migrate consumer, update comment
+
+- phase_1 APPROVED unanimously (Gemini/Codex/Claude, HIGH, zero issues) → porch
+  committed (a104583) and advanced to phase_2.
+- Edits: `playwright.config.ts` — added `import {resolveWorkers} from
+  "./scripts/e2e-workers.mjs"`; replaced `workers: 1` → `workers:
+  resolveWorkers(process.env)`; rewrote the ~96-103 comment block to the new
+  contract (CI hard-pinned 1 via guard-returns-first; local '50%' default /
+  E2E_WORKERS override; retries:0 preserved; qualification rationale). "Do NOT
+  raise workers" text removed.
+- `tests/automation.test.mjs` — migrated line-90 assertion `/workers: 1/` →
+  `/workers: resolveWorkers\(process\.env\)/` (delegation, not re-testing the FR8
+  matrix — that lives in e2e-workers.test.mjs); updated adjacent comment.
+  fullyParallel + retries assertions untouched.
+- ACCEPTANCE PROOFS (real run banners, 20-core host, chromium arm = 11 tests):
+  - default (no CI/no override) ⇒ `Running 11 tests using 10 workers` (50%→10, M>1)
+  - `CI=1` ⇒ `Running 11 tests using 1 worker` (M=1, guard)
+  - `E2E_WORKERS=4` ⇒ `Running 11 tests using 4 workers` (M=4)
+  - `E2E_WORKERS=50%` ⇒ `Running 11 tests using 10 workers` (hardware-relative)
+  - `E2E_WORKERS=abc` ⇒ loud `WorkerConfigError` at config LOAD, exit 1, NO run
+  - `E2E_ENGINES=chromium --list` loads config (novel .mjs-from-.ts import path OK)
+  (banner capture via `timeout … | grep -m1`; cleaned orphaned webServer/workers
+   after; port 3000 free, 0 stray procs.)
+- Checks GREEN: typecheck (mjs import resolves), npm test 121/121, build clean,
+  validation.yml NOT in `git diff` (CI byte-for-byte unchanged). Staging config +
+  automation test; signaling `porch done 41` → 3-way review of phase_2.
+
+- Phase 2 iter1 consult: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**
+  (all HIGH). Codex point (legit, ACCEPTED): config comment said parallel default
+  "is qualified by…" — present-tense/complete, but qualification is Phase 3's job.
+  Reworded to "is being qualified by … that evidence, not this wiring, decides
+  whether it remains the default or reverts to serial." Comment-only; workers line
+  untouched ⇒ automation assertion still matches; npm test 121/121, typecheck clean.
+  Wrote 41-phase_2-iter1-rebuttals.md. Signaling `porch done 41` for re-verification.
+
+- Phase 2 iter2 consult: **UNANIMOUS APPROVE** (Gemini/Codex/Claude, HIGH). Codex
+  verified the comment fix applied. Advancing porch → should commit phase_2 and
+  move to phase_3 (qualify parallel default, finalize, document).
+
+## Phase 3 — qualify parallel, finalize default, document
+
+- Phase 2 UNANIMOUS APPROVE → committed (e93855f) → advanced to phase_3.
+- Step A: probe the native-GPU lane to pick the qualification path (GPU-hardware
+  primary vs SwiftShader-validate contingency). This is WSL2 — hardware may not verify.
+
+- **GPU lane VERIFIES HARDWARE** on this builder: NVIDIA RTX 3080 via WSL2 d3d12
+  (Chromium: "ANGLE (…D3D12 (NVIDIA GeForce RTX 3080), OpenGL 4.6)"; Firefox:
+  "D3D12 (NVIDIA GeForce RTX 3080)"). Primary contention-free path AVAILABLE
+  (Decision 3, best case) — no contingency needed.
+- FR7 CONFIRMED: GPU lane run banner = `Running 22 tests using 10 workers` — the
+  lane inherits the scaled parallel default with NO code change to e2e-gpu-lane.mjs.
+- **GPU parallel run 1/3: PASS** — 22/22 (both engines) under 10 workers, retries:0.
+  Report: mode=hardware, suite=pass, wall-clock 57s (build 10s, suite 46s). The
+  pre-existing Firefox flake matrix.spec.ts:224 PASSED (19.0s). ~4x faster than the
+  ~196s serial two-engine baseline.
+- Batched GPU runs 2, 3 + serial baseline (E2E_WORKERS=1) in background.
+
+### Qualification evidence — parallel is NOT green as a retries:0 default
+
+GPU HARDWARE (RTX 3080, contention-free WebGL), retries:0:
+- parallel run1 (10w): 22/22 PASS, suite 46s
+- parallel run2 (10w): 22/22 PASS, suite 45s
+- parallel run3 (10w): **1 FAILED**, 21 passed, suite 48s
+  - FAIL = `[firefox] matrix.spec.ts:224 "zooms in … rotates with a background
+    drag"`: "a background drag should rotate the camera" — motion 0.00196 < floor 1
+    (Timeout 5000ms on predicate). This is the KNOWN OPEN flake **#33** (Firefox
+    synthetic-input-delivery nondeterminism; README already documents it "survives
+    on hardware"). Issue #41 explicitly warned parallel contention may amplify #33.
+- serial baseline (1w): 22/22 PASS, suite 196s (3.2m).
+
+READ: parallel amplified the known #33 flake to 1/3 even on contention-free
+hardware. A retries:0 LOCAL GATE cannot be intermittently red. Per spec Decision 4
+(canonical rule, evidence-gated) + acceptance criterion 2 ("or the parallel path is
+clearly separated from the qualified serial gate with the trade-off documented"),
+the evidence points to the **serial-default + opt-in-parallel** branch (Scenario 5),
+NOT the parallel-default branch. Decisive confirmation pending: SwiftShader parallel
+(the actual `validate` gate path) ×3 — expected to be worse (CPU contention). Running.
+NOT masking with retries; NOT weakening the assertion.
+
+### Phase 3 finalized — serial default + opt-in parallel (ARCHITECT ENDORSED)
+
+SwiftShader parallel (the actual `validate` gate path), 10 workers, retries:0:
+- run1: 4 failed / 18 passed (3.2m); run2: 4 failed / 18 passed (3.3m);
+  run3: 5 failed / 17 passed (3.3m). ALL failures = Chromium timing-sensitive
+  matrix.spec (:194 wheel-zoom-out, :224 drag-rotate, :527 remount, smoke:78
+  core-controls; :134 pointer-inert 1/3) — the exact class the old "Do NOT raise
+  workers" comment named. NO speedup (~3.3m vs 196s serial). Parallel-default =
+  broken gate. Conclusive.
+
+Architect ENDORSED serial-default + opt-in-parallel (Decision 4 / Scenario 5 /
+criterion 2b). Guardrails all honored:
+- DEFAULT_LOCAL_WORKERS flipped '50%' → 1 (serial) in scripts/e2e-workers.mjs
+  (+ header/JSDoc rationale). Opt-in via E2E_WORKERS (int+%) intact; invalid still
+  loud WorkerConfigError; CI→1 guard intact.
+- Unit tests updated (default⇒1, empty/whitespace⇒1, empty-CI⇒1); 24/24 pass.
+- Config comment (FR10) rewritten to the finalized contract.
+- README (FR11): new "Local test parallelism" note (serial default, E2E_WORKERS
+  int+% opt-in, CI workers:1, retries:0 preserved, trade-off + ~4x GPU-lane); lane
+  "same workers:1" line, timing para, #33 note, env table (+E2E_WORKERS row), and
+  "#41 sequenced after" status note all updated. Full suite 121/121, typecheck clean.
+- FR7 CONFIRMED (GPU lane inherits workers, banner `22 tests using 10 workers`,
+  ZERO lane code change).
+- CI-untouched: `git diff main` shows validation.yml UNCHANGED (zero-diff). No app
+  code / no lockfile delta.
+- Review written: codev/reviews/41-parallelize-local-e2e-runs.md with VERBATIM
+  evidence (both SwiftShader 4-5/22 AND GPU ~4x + #33 1/3) + FR8-vs-Decision-4
+  deviation + #33 disposition (accept+document, not masked).
+- Confirming serial-default gate green end-to-end via `npm run test:smoke` (running;
+  banner already shows `22 tests using 1 worker`). Clean-checkout full `npm run
+  validate` proof deferred to pre-PR (after phase_3 commit) per lessons-critical
+  (local `eslint .` noise is the untracked .claude/hooks/ harness file only).
+
+### Honesty corrections after serial-default confirmation run
+
+- Serial-default `npm run test:smoke` (banner `22 tests using 1 worker`): 21 passed,
+  **1 FAILED** = the SAME known flake **#33** (`[firefox] matrix.spec.ts:224`, motion
+  0.0038 < floor 1), real exit 1. Two corrections:
+  1. **#33 flakes even SERIALLY** at retries:0 — it's a pre-existing OPEN flake
+     (like #34), NOT introduced by #41 and not purely parallelism. #41 preserves the
+     serial gate (status quo) → NO regression; parallel AMPLIFIES #33 (hence opt-in).
+  2. **"No speedup" was WRONG** — I'd compared parallel-SwiftShader (3.3m) to serial-
+     HARDWARE (196s). Correct baseline: serial-SwiftShader = **11.7m**. So parallel-
+     SwiftShader is ~3.5x FASTER but breaks 4-5/22 timing tests. The disqualifier is
+     DESTABILIZATION, not slowness. Corrected in review, config comment, helper
+     header+const, and README (all "no speedup" claims removed/reframed).
+- Re-verified: unit 24/24, suite 121/121, typecheck clean, helper lint clean, no
+  lingering "no speedup" text anywhere.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -1,0 +1,21 @@
+# spir-41 thread — Parallelize local e2e runs scaled to hardware
+
+Strict-mode SPIR builder. Issue #41: local Playwright e2e gets hardware-scaled
+parallel workers; CI (`validation.yml` 4-shard matrix, per-shard `workers: 1`)
+stays byte-for-byte unchanged, guarded by `CI`→`workers: 1`.
+
+## Specify phase
+
+- Spec pre-existed (architect commit `10251b1`). Read it fully; it is
+  comprehensive (8 confirmed decisions, 11 FRs, 6 acceptance scenarios).
+- Verified its factual claims against the codebase — all accurate:
+  - `playwright.config.ts`: `fullyParallel: true` (104), `workers: 1` (105),
+    `retries: process.env.CI ? 2 : 0` (113), "Do NOT raise workers" comment
+    block (~96-113).
+  - `tests/automation.test.mjs`: source-text asserts `/workers: 1/` (90) and
+    the retries regex (93) — these are the consumers that must migrate.
+  - GPU lane present: `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`;
+    scripts `test:smoke`, `test:e2e:gpu`, `validate` all present.
+- No factual corrections needed. Signaling specify build complete → porch runs
+  the 3-way consultation (Gemini/Codex/Claude). Then STOP at `spec-approval`
+  gate for human approval.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -268,3 +268,11 @@ criterion 2b). Guardrails all honored:
 - Committing review + governance + consult artifacts (convention: consult .txt
   tracked, cf. project 12). Builder-harness files (.builder-*, .claude/hooks/)
   left untracked (not deliverables; not suppressing in config). Opening PR next.
+
+- PR #54 3-way (type pr): **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**
+  (HIGH). Codex #2 (plan Status: draft) ACCEPTED → reconciled to "complete" with
+  the Decision-4 finalized-outcome note. Codex #1 (commit format) REBUTTED: `[Spec
+  41] Description` IS a documented AGENTS.md form (two forms listed; [Phase:] only
+  for impl commits); the `chore(porch):` commits are porch state commits, not
+  builder commits, and strict-mode forbids rewriting pushed porch history. Wrote
+  41-review-iter1-rebuttals.md. Committing plan fix + rebuttal, pushing to PR #54.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -224,3 +224,10 @@ criterion 2b). Guardrails all honored:
      header+const, and README (all "no speedup" claims removed/reframed).
 - Re-verified: unit 24/24, suite 121/121, typecheck clean, helper lint clean, no
   lingering "no speedup" text anywhere.
+
+- Phase 3 iter1 consult: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**
+  (all HIGH). Both Codex points ACCEPTED (consistency residue from the honesty
+  correction): (1) review acceptance bullet still said "no SwiftShader speedup" →
+  fixed to "faster but breaks the gate"; (2) helper inline comment still said
+  "Scaled default" → fixed to "Serial default". Broad speedup-audit now clean.
+  Wrote 41-phase_3-iter1-rebuttals.md. Signaling porch done → re-verification.

--- a/codev/state/spir-41_thread.md
+++ b/codev/state/spir-41_thread.md
@@ -298,3 +298,12 @@ criterion 2b). Guardrails all honored:
 - Per architect's "I verify the protocol-complete commit is on the remote before
   the merge lands": PAUSING before merge. Notified architect; awaiting go-ahead to
   merge PR #54 (regular merge commit, no squash).
+
+- Architect GO-AHEAD to merge (protocol-complete commit 3b9b877 verified on remote,
+  included in PR #54). Merge attempt via pr-merge.sh (`gh pr merge 54 --merge`)
+  BLOCKED by base-branch protection: required CI (Quality + 4 E2E shards) PENDING.
+  Repo auto-merge DISABLED (--auto rejected). Did NOT use --admin (won't bypass the
+  CI gate — respecting it is the point of #41). Watching required checks
+  (`gh pr checks 54 --watch --required`); will merge (regular merge, no squash) on
+  green. Expect green: CI=1 → serial shards (guard), retries:2 absorbs #34,
+  validation.yml unchanged.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -113,9 +113,11 @@ export default defineConfig({
     //     an invalid value is a loud WorkerConfigError, never a silent serial).
     // Local `retries: 0` (below) is preserved so flakes still surface immediately.
     // The timing-sensitive matrix.spec.ts assertions were originally qualified
-    // against a contention-free serial environment; the parallel local default is
-    // qualified by repeated full two-engine runs on the native-GPU lane (issue
-    // #41), while CI keeps that serial contract automatically via the guard above.
+    // against a contention-free serial environment; this parallel local default
+    // is being qualified by repeated full two-engine runs on the native-GPU lane
+    // (issue #41) — that evidence, not this wiring, decides whether it remains the
+    // default or reverts to serial. CI keeps its serial contract automatically via
+    // the guard above regardless of that outcome.
     fullyParallel: true,
     workers: resolveWorkers(process.env),
     // CI-only retries absorb SwiftShader rendering nondeterminism. The

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -96,9 +96,9 @@ export default defineConfig({
     // click-to-focus test keeps its own explicit 240 s override either way.)
     timeout: process.env.CI ? 240_000 : 120_000,
     // `fullyParallel` marks every test as an independently schedulable unit,
-    // which serves two consumers at once: CI's `--shard` splits the suite at the
-    // TEST level (not the file level), and local runs fan those units out across
-    // multiple workers.
+    // which serves two consumers: CI's `--shard` splits the suite at the TEST
+    // level (not the file level), and a local opt-in parallel run (E2E_WORKERS)
+    // can fan those units out across workers.
     //
     // `workers` is resolved by resolveWorkers(process.env) (scripts/e2e-workers.mjs,
     // issue #41) — the single tested source of truth for the worker count:
@@ -107,17 +107,17 @@ export default defineConfig({
     //     test at a time, no SwiftShader CPU contention. The qualified CI timing
     //     environment is byte-for-byte unchanged, and a stray E2E_WORKERS can
     //     never parallelize a shard.
-    //   - Local: hardware-scaled parallel — the '50%' default (Playwright derives
-    //     the count from os.cpus().length, floored at >=1 so low-core hosts still
-    //     run), overridable via E2E_WORKERS (a positive integer or a percentage;
-    //     an invalid value is a loud WorkerConfigError, never a silent serial).
+    //   - Local default: SERIAL (1). Issue #41 qualified parallel workers and
+    //     found they DESTABILIZE these timing-sensitive matrix.spec.ts
+    //     camera-settle/drag assertions under SwiftShader CPU contention (4-5 of
+    //     22 Chromium tests fail on every parallel run — even though parallel is
+    //     faster) and amplify the known Firefox flake #33 even on hardware — so
+    //     the `retries: 0` local gate stays serial, matching the environment
+    //     these assertions were qualified against.
+    //   - Local opt-in parallel: E2E_WORKERS=<int|percent> (e.g. 50%) — for fast
+    //     local iteration, most useful on the native-GPU lane (~4x faster). An
+    //     invalid value is a loud WorkerConfigError, never a silent fallback.
     // Local `retries: 0` (below) is preserved so flakes still surface immediately.
-    // The timing-sensitive matrix.spec.ts assertions were originally qualified
-    // against a contention-free serial environment; this parallel local default
-    // is being qualified by repeated full two-engine runs on the native-GPU lane
-    // (issue #41) — that evidence, not this wiring, decides whether it remains the
-    // default or reverts to serial. CI keeps its serial contract automatically via
-    // the guard above regardless of that outcome.
     fullyParallel: true,
     workers: resolveWorkers(process.env),
     // CI-only retries absorb SwiftShader rendering nondeterminism. The

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import {defineConfig, devices} from "@playwright/test";
 import process from "node:process";
 
+import {resolveWorkers} from "./scripts/e2e-workers.mjs";
+
 const baseURL = "http://127.0.0.1:3000";
 
 // Env-gated Chromium WebGL launch args.
@@ -93,16 +95,29 @@ export default defineConfig({
     // headroom over the local budget; local timing is unchanged. (The
     // click-to-focus test keeps its own explicit 240 s override either way.)
     timeout: process.env.CI ? 240_000 : 120_000,
-    // `fullyParallel` marks every test as an independently schedulable unit so
-    // `--shard` splits the suite at the TEST level (not the file level). With
-    // `workers: 1` still pinned, execution within any single job stays strictly
-    // serial — one test at a time, no SwiftShader CPU contention — so the
-    // qualified timing environment is unchanged. CI fans the shards out across
-    // parallel jobs; local `npm run validate` still runs one worker start to
-    // finish. Do NOT raise `workers`: in-job parallelism reintroduces the
-    // contention these timing-sensitive assertions were qualified against.
+    // `fullyParallel` marks every test as an independently schedulable unit,
+    // which serves two consumers at once: CI's `--shard` splits the suite at the
+    // TEST level (not the file level), and local runs fan those units out across
+    // multiple workers.
+    //
+    // `workers` is resolved by resolveWorkers(process.env) (scripts/e2e-workers.mjs,
+    // issue #41) — the single tested source of truth for the worker count:
+    //   - CI (any truthy `CI`): hard-pinned to 1. The resolver returns BEFORE it
+    //     reads E2E_WORKERS, so every sharded job stays strictly serial — one
+    //     test at a time, no SwiftShader CPU contention. The qualified CI timing
+    //     environment is byte-for-byte unchanged, and a stray E2E_WORKERS can
+    //     never parallelize a shard.
+    //   - Local: hardware-scaled parallel — the '50%' default (Playwright derives
+    //     the count from os.cpus().length, floored at >=1 so low-core hosts still
+    //     run), overridable via E2E_WORKERS (a positive integer or a percentage;
+    //     an invalid value is a loud WorkerConfigError, never a silent serial).
+    // Local `retries: 0` (below) is preserved so flakes still surface immediately.
+    // The timing-sensitive matrix.spec.ts assertions were originally qualified
+    // against a contention-free serial environment; the parallel local default is
+    // qualified by repeated full two-engine runs on the native-GPU lane (issue
+    // #41), while CI keeps that serial contract automatically via the guard above.
     fullyParallel: true,
-    workers: 1,
+    workers: resolveWorkers(process.env),
     // CI-only retries absorb SwiftShader rendering nondeterminism. The
     // click-to-focus test (matrix.spec.ts) intermittently misses a camera-motion
     // or node-click timing predicate; this predates sharding — it also flaked the

--- a/scripts/e2e-workers.mjs
+++ b/scripts/e2e-workers.mjs
@@ -1,0 +1,85 @@
+// Pure worker-count resolution for the local Playwright e2e suite (issue #41).
+//
+// `playwright.config.ts` historically pinned `workers: 1` for every environment;
+// this module is the single tested source of truth for the LOCAL worker count so
+// the config becomes a thin consumer (`workers: resolveWorkers(process.env)`).
+// It has NO I/O, NO `process.env` access, and NO Playwright import — env is
+// passed in explicitly so the contract is trivially unit-testable in isolation
+// (see tests/e2e-workers.test.mjs) and decoupled from Playwright.
+//
+// Resolution contract (spec 41 FR2/FR8), in precedence order:
+//   1. CI guard (absolute, first): `env.CI` truthy ⇒ the number 1. Returning
+//      before reading E2E_WORKERS makes CI precedence structural — the sharded
+//      matrix's per-job serial contract is preserved automatically and cannot be
+//      overridden by a stray E2E_WORKERS in the environment. The truthy check
+//      mirrors the config's existing `process.env.CI ? … : …` idiom (retries,
+//      timeout), so CI resolution stays consistent across the config.
+//   2. E2E_WORKERS override: a positive integer (`4`) resolves to that number; a
+//      percentage (`50%`) is passed through to Playwright as a string (Playwright
+//      computes the count from `os.cpus().length`). Empty/unset falls to the
+//      default; anything malformed is a LOUD failure (WorkerConfigError), never a
+//      silent fallback — mirroring the config's fail-closed E2E_ENGINES guard.
+//   3. Scaled default: DEFAULT_LOCAL_WORKERS (`'50%'`). Playwright floors a
+//      percentage at ≥1 worker, so a low-core host degrades gracefully rather
+//      than erroring.
+
+// The hardware-relative local default (spec 41 Decision 2). Kept as a named
+// constant so the config and the tests reference one value; Phase 3 confirms it
+// or, on adverse qualification evidence, flips the default to serial (Decision 4).
+export const DEFAULT_LOCAL_WORKERS = "50%";
+
+// A malformed E2E_WORKERS value — a hard configuration failure, never a silent
+// fallback (spec 41 FR2). Mirrors LaneUsageError in scripts/e2e-gpu-lane.mjs: a
+// distinct class so the config (and tests) can tell operator misconfiguration
+// apart from any other error.
+export class WorkerConfigError extends Error {}
+
+// A bare positive integer: one or more digits, no leading zero, no sign, no
+// decimal point, no exponent. `1e2`, `01`, `1.5`, `-1`, `0` all fail this.
+const INTEGER_PATTERN = /^[1-9][0-9]*$/;
+// The same positive integer followed by a literal `%`. `0%`, `%`, `50 %` fail.
+const PERCENTAGE_PATTERN = /^[1-9][0-9]*%$/;
+
+/**
+ * Resolve the Playwright `workers` value for a local run from the environment.
+ *
+ * Pure: reads only the passed `env`, never mutates it, performs no I/O.
+ *
+ * @param {Record<string, string | undefined>} env - environment map (the config
+ *   passes `process.env`).
+ * @returns {number | string} `1` when `CI` is set; otherwise the `E2E_WORKERS`
+ *   override — a positive integer as a `number`, a percentage as a `string` —
+ *   or the scaled default `'50%'` when `E2E_WORKERS` is unset/empty.
+ * @throws {WorkerConfigError} when `E2E_WORKERS` is set to a malformed value.
+ */
+export function resolveWorkers(env) {
+    // 1. CI guard — absolute and first. A truthy CI value forces serial (1)
+    //    before E2E_WORKERS is even read, so nothing can weaken the sharded
+    //    matrix's per-job serial contract.
+    if (env.CI) {
+        return 1;
+    }
+
+    // 2. E2E_WORKERS override. Undefined or whitespace-only is treated as unset
+    //    (a wrapper exporting E2E_WORKERS="" must fall through, not hard-fail).
+    const raw = env.E2E_WORKERS;
+    if (raw !== undefined) {
+        const value = raw.trim();
+        if (value.length > 0) {
+            if (INTEGER_PATTERN.test(value)) {
+                return Number(value);
+            }
+            if (PERCENTAGE_PATTERN.test(value)) {
+                return value;
+            }
+            throw new WorkerConfigError(
+                `E2E_WORKERS="${raw}" is not a valid worker count — expected a ` +
+                    "positive integer (e.g. 4) or a percentage (e.g. 50%), " +
+                    "not zero, negative, decimal, or non-numeric",
+            );
+        }
+    }
+
+    // 3. Scaled default.
+    return DEFAULT_LOCAL_WORKERS;
+}

--- a/scripts/e2e-workers.mjs
+++ b/scripts/e2e-workers.mjs
@@ -90,6 +90,7 @@ export function resolveWorkers(env) {
         }
     }
 
-    // 3. Scaled default.
+    // 3. Serial default (see DEFAULT_LOCAL_WORKERS). Parallel is opt-in only,
+    //    via the E2E_WORKERS branch above.
     return DEFAULT_LOCAL_WORKERS;
 }

--- a/scripts/e2e-workers.mjs
+++ b/scripts/e2e-workers.mjs
@@ -19,14 +19,24 @@
 //      computes the count from `os.cpus().length`). Empty/unset falls to the
 //      default; anything malformed is a LOUD failure (WorkerConfigError), never a
 //      silent fallback — mirroring the config's fail-closed E2E_ENGINES guard.
-//   3. Scaled default: DEFAULT_LOCAL_WORKERS (`'50%'`). Playwright floors a
-//      percentage at ≥1 worker, so a low-core host degrades gracefully rather
-//      than erroring.
+//   3. Default: DEFAULT_LOCAL_WORKERS (`1`, serial). Phase-3 qualification (issue
+//      #41) showed parallel workers destabilize the timing-sensitive Chromium
+//      matrix.spec.ts camera-settle/drag assertions under SwiftShader CPU
+//      contention (4-5 of 22 tests fail on every parallel run — the problem is
+//      destabilization, not slowness: parallel is faster) and amplify the known
+//      Firefox flake #33 even on hardware — so a `retries: 0` gate cannot default
+//      to parallel. Parallelism is therefore OPT-IN via E2E_WORKERS (most useful
+//      on the native-GPU lane, where it runs ~4x faster and mostly green; see the
+//      review for the recorded evidence and spec Decision 4 / Scenario 5).
 
-// The hardware-relative local default (spec 41 Decision 2). Kept as a named
-// constant so the config and the tests reference one value; Phase 3 confirms it
-// or, on adverse qualification evidence, flips the default to serial (Decision 4).
-export const DEFAULT_LOCAL_WORKERS = "50%";
+// The local default worker count. Phase-3 qualification (issue #41) flipped this
+// from the originally-proposed parallel `'50%'` to serial `1` (spec Decision 4 /
+// Scenario 5): parallel workers destabilize the timing-sensitive SwiftShader gate
+// (4-5 of 22 tests fail on every parallel run — destabilization, not slowness), so
+// the qualified `retries: 0` local gate stays serial. Parallelism is opt-in via
+// E2E_WORKERS (`'50%'` is the recommended value, most useful on the native-GPU
+// lane). Kept as a named constant so the config and tests reference one value.
+export const DEFAULT_LOCAL_WORKERS = 1;
 
 // A malformed E2E_WORKERS value — a hard configuration failure, never a silent
 // fallback (spec 41 FR2). Mirrors LaneUsageError in scripts/e2e-gpu-lane.mjs: a
@@ -49,7 +59,7 @@ const PERCENTAGE_PATTERN = /^[1-9][0-9]*%$/;
  *   passes `process.env`).
  * @returns {number | string} `1` when `CI` is set; otherwise the `E2E_WORKERS`
  *   override — a positive integer as a `number`, a percentage as a `string` —
- *   or the scaled default `'50%'` when `E2E_WORKERS` is unset/empty.
+ *   or the serial default `1` when `E2E_WORKERS` is unset/empty.
  * @throws {WorkerConfigError} when `E2E_WORKERS` is set to a malformed value.
  */
 export function resolveWorkers(env) {

--- a/tests/automation.test.mjs
+++ b/tests/automation.test.mjs
@@ -84,10 +84,14 @@ test("enforces lint, typecheck, and unit contracts in the quality job", () => {
 });
 
 test("shards the full Chromium e2e suite at the test level", () => {
-    // fullyParallel makes --shard split at the TEST level; workers stays 1 so
-    // execution within a shard is strictly serial (no SwiftShader contention).
+    // fullyParallel makes --shard split at the TEST level. The worker count is
+    // delegated to the tested resolver (scripts/e2e-workers.mjs, issue #41): CI is
+    // hard-pinned to 1 so execution within a shard stays strictly serial (no
+    // SwiftShader contention), while local runs scale to hardware. The CI-serial
+    // matrix in that resolver is covered by tests/e2e-workers.test.mjs; here we
+    // assert only that the config delegates to it.
     assert.match(playwrightConfig, /fullyParallel: true/);
-    assert.match(playwrightConfig, /workers: 1/);
+    assert.match(playwrightConfig, /workers: resolveWorkers\(process\.env\)/);
     // CI-only retries (count 2) absorb pre-existing SwiftShader flake (issue #34)
     // so a single flaky attempt can't red the gate; local stays 0 so flakes show.
     assert.match(playwrightConfig, /retries: process\.env\.CI \? 2 : 0/);

--- a/tests/automation.test.mjs
+++ b/tests/automation.test.mjs
@@ -87,9 +87,11 @@ test("shards the full Chromium e2e suite at the test level", () => {
     // fullyParallel makes --shard split at the TEST level. The worker count is
     // delegated to the tested resolver (scripts/e2e-workers.mjs, issue #41): CI is
     // hard-pinned to 1 so execution within a shard stays strictly serial (no
-    // SwiftShader contention), while local runs scale to hardware. The CI-serial
-    // matrix in that resolver is covered by tests/e2e-workers.test.mjs; here we
-    // assert only that the config delegates to it.
+    // SwiftShader contention); locally the default is also serial (1), with
+    // parallelism opt-in via E2E_WORKERS (Phase-3 qualification kept the gate
+    // serial). The CI-serial and default matrices in that resolver are covered by
+    // tests/e2e-workers.test.mjs; here we assert only that the config delegates
+    // to it.
     assert.match(playwrightConfig, /fullyParallel: true/);
     assert.match(playwrightConfig, /workers: resolveWorkers\(process\.env\)/);
     // CI-only retries (count 2) absorb pre-existing SwiftShader flake (issue #34)

--- a/tests/e2e-workers.test.mjs
+++ b/tests/e2e-workers.test.mjs
@@ -1,0 +1,110 @@
+// Unit coverage for the pure local-worker resolution contract (issue #41 FR8).
+//
+// Everything here drives the pure `resolveWorkers(env)` directly with literal
+// env objects — no Playwright, no `process.env` mutation, no I/O. The function's
+// return value IS the contract; these rows are the spec FR8 matrix made
+// executable, plus explicit negative rows locking the leading-zero / exponent /
+// decimal disposition called out as a risk in the plan.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    DEFAULT_LOCAL_WORKERS,
+    WorkerConfigError,
+    resolveWorkers,
+} from "../scripts/e2e-workers.mjs";
+
+test("DEFAULT_LOCAL_WORKERS is the scaled '50%' token", () => {
+    assert.equal(DEFAULT_LOCAL_WORKERS, "50%");
+});
+
+test("CI guard: CI set ⇒ serial 1 (the number, not a string)", () => {
+    assert.strictEqual(resolveWorkers({CI: "1"}), 1);
+    assert.strictEqual(resolveWorkers({CI: "true"}), 1);
+});
+
+test("CI precedence: CI wins over E2E_WORKERS", () => {
+    assert.strictEqual(resolveWorkers({CI: "1", E2E_WORKERS: "4"}), 1);
+    assert.strictEqual(resolveWorkers({CI: "true", E2E_WORKERS: "50%"}), 1);
+    // Even a value that would otherwise throw never surfaces under CI, because
+    // the CI guard returns before E2E_WORKERS is read.
+    assert.strictEqual(resolveWorkers({CI: "1", E2E_WORKERS: "abc"}), 1);
+});
+
+test("E2E_WORKERS positive integer ⇒ that number", () => {
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "4"}), 4);
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "1"}), 1);
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "16"}), 16);
+});
+
+test("E2E_WORKERS percentage ⇒ that percentage string (passed to Playwright)", () => {
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "50%"}), "50%");
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "100%"}), "100%");
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "25%"}), "25%");
+});
+
+test("default: no CI, no E2E_WORKERS ⇒ scaled '50%' (NOT serial 1)", () => {
+    assert.strictEqual(resolveWorkers({}), DEFAULT_LOCAL_WORKERS);
+    assert.strictEqual(resolveWorkers({}), "50%");
+});
+
+test("empty / whitespace E2E_WORKERS is treated as unset ⇒ default", () => {
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: ""}), "50%");
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "   "}), "50%");
+});
+
+test("surrounding whitespace is trimmed before matching", () => {
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: " 4 "}), 4);
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "\t50%\n"}), "50%");
+});
+
+test("empty CI value is falsy ⇒ falls through to E2E_WORKERS / default", () => {
+    // The truthy check mirrors the config's `process.env.CI ? … : …` idiom:
+    // an unset/empty CI must not force serial locally.
+    assert.strictEqual(resolveWorkers({CI: "", E2E_WORKERS: "4"}), 4);
+    assert.strictEqual(resolveWorkers({CI: ""}), "50%");
+    assert.strictEqual(resolveWorkers({CI: undefined}), "50%");
+});
+
+// --- Malformed values: loud WorkerConfigError, never a silent fallback ------
+
+const INVALID_VALUES = [
+    "0", // zero is not a positive worker count
+    "0%", // zero percent
+    "-1", // negative
+    "abc", // non-numeric
+    "12x", // trailing garbage
+    "1.5", // decimal
+    "%", // bare percent
+    "01", // leading zero (disposition: rejected)
+    "1e2", // exponent form (disposition: rejected)
+    "50 %", // internal whitespace in a percentage
+    "4.0", // decimal integer
+    "0x10", // hex
+    "  %  ", // whitespace around a bare percent
+];
+
+for (const value of INVALID_VALUES) {
+    test(`E2E_WORKERS=${JSON.stringify(value)} ⇒ throws WorkerConfigError`, () => {
+        assert.throws(
+            () => resolveWorkers({E2E_WORKERS: value}),
+            WorkerConfigError,
+        );
+    });
+}
+
+test("WorkerConfigError message names the offending value and accepted forms", () => {
+    try {
+        resolveWorkers({E2E_WORKERS: "12x"});
+        assert.fail("expected resolveWorkers to throw");
+    } catch (error) {
+        assert.ok(error instanceof WorkerConfigError);
+        assert.match(error.message, /12x/); // names the offending value
+        assert.match(error.message, /positive integer/);
+        assert.match(error.message, /percentage/);
+    }
+});
+
+test("WorkerConfigError is a subclass of Error", () => {
+    assert.ok(new WorkerConfigError("x") instanceof Error);
+});

--- a/tests/e2e-workers.test.mjs
+++ b/tests/e2e-workers.test.mjs
@@ -14,8 +14,8 @@ import {
     resolveWorkers,
 } from "../scripts/e2e-workers.mjs";
 
-test("DEFAULT_LOCAL_WORKERS is the scaled '50%' token", () => {
-    assert.equal(DEFAULT_LOCAL_WORKERS, "50%");
+test("DEFAULT_LOCAL_WORKERS is serial 1 (Phase-3 qualification flipped it from parallel)", () => {
+    assert.strictEqual(DEFAULT_LOCAL_WORKERS, 1);
 });
 
 test("CI guard: CI set ⇒ serial 1 (the number, not a string)", () => {
@@ -43,14 +43,14 @@ test("E2E_WORKERS percentage ⇒ that percentage string (passed to Playwright)",
     assert.strictEqual(resolveWorkers({E2E_WORKERS: "25%"}), "25%");
 });
 
-test("default: no CI, no E2E_WORKERS ⇒ scaled '50%' (NOT serial 1)", () => {
+test("default: no CI, no E2E_WORKERS ⇒ serial 1 (parallel is opt-in via E2E_WORKERS)", () => {
     assert.strictEqual(resolveWorkers({}), DEFAULT_LOCAL_WORKERS);
-    assert.strictEqual(resolveWorkers({}), "50%");
+    assert.strictEqual(resolveWorkers({}), 1);
 });
 
-test("empty / whitespace E2E_WORKERS is treated as unset ⇒ default", () => {
-    assert.strictEqual(resolveWorkers({E2E_WORKERS: ""}), "50%");
-    assert.strictEqual(resolveWorkers({E2E_WORKERS: "   "}), "50%");
+test("empty / whitespace E2E_WORKERS is treated as unset ⇒ serial default", () => {
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: ""}), 1);
+    assert.strictEqual(resolveWorkers({E2E_WORKERS: "   "}), 1);
 });
 
 test("surrounding whitespace is trimmed before matching", () => {
@@ -58,12 +58,13 @@ test("surrounding whitespace is trimmed before matching", () => {
     assert.strictEqual(resolveWorkers({E2E_WORKERS: "\t50%\n"}), "50%");
 });
 
-test("empty CI value is falsy ⇒ falls through to E2E_WORKERS / default", () => {
-    // The truthy check mirrors the config's `process.env.CI ? … : …` idiom:
-    // an unset/empty CI must not force serial locally.
+test("empty CI value is falsy ⇒ CI guard doesn't fire; E2E_WORKERS opt-in still applies", () => {
+    // The truthy check mirrors the config's `process.env.CI ? … : …` idiom: an
+    // unset/empty CI must NOT trigger the CI guard, so a local E2E_WORKERS opt-in
+    // still takes effect (and absent one, the serial default applies).
     assert.strictEqual(resolveWorkers({CI: "", E2E_WORKERS: "4"}), 4);
-    assert.strictEqual(resolveWorkers({CI: ""}), "50%");
-    assert.strictEqual(resolveWorkers({CI: undefined}), "50%");
+    assert.strictEqual(resolveWorkers({CI: ""}), 1);
+    assert.strictEqual(resolveWorkers({CI: undefined}), 1);
 });
 
 // --- Malformed values: loud WorkerConfigError, never a silent fallback ------


### PR DESCRIPTION
## Summary

Makes local e2e worker resolution a single tested pure helper
(`scripts/e2e-workers.mjs` → `resolveWorkers(process.env)`) consumed by
`playwright.config.ts`, and adds **opt-in hardware-scaled parallelism** via
`E2E_WORKERS`. Per spec **Decision 4** (evidence-gated) the local **default stays
serial** — Phase-3 qualification showed parallel workers destabilize the
timing-sensitive Chromium `matrix.spec.ts` assertions on the SwiftShader path that
`npm run validate` gates on (4–5 of 22 tests fail on **every** parallel run), so
shipping parallel-by-default would flake the `retries: 0` gate. Parallelism is
therefore opt-in and is ~4× faster (mostly green) on the native-GPU lane.

**CI is byte-for-byte unchanged** — `.github/workflows/validation.yml` has zero
diff; the sharded matrix stays serial via the resolver's absolute `CI → 1` guard.

Closes #41

## Changes

- **`scripts/e2e-workers.mjs`** (new): pure `resolveWorkers(env)` +
  `DEFAULT_LOCAL_WORKERS` (`1`, serial) + `WorkerConfigError`. CI ⇒ `1` (returns
  before reading `E2E_WORKERS`); `E2E_WORKERS` integer/percentage override;
  invalid ⇒ loud error; default serial.
- **`playwright.config.ts`**: `workers: resolveWorkers(process.env)`; the stale
  "Do NOT raise workers" block replaced with the finalized contract.
- **`tests/e2e-workers.test.mjs`** (new): 24-test FR8 matrix.
- **`tests/automation.test.mjs`**: migrated the `/workers: 1/` source-text
  assertion to assert delegation to the resolver.
- **`README.md`**: "Local test parallelism" note (serial default, `E2E_WORKERS`
  int/%, CI `workers:1`, `retries:0` preserved, the qualification trade-off);
  lane/env-table/status updates.
- **`codev/reviews/41-*.md`**: full FR9 verbatim per-test evidence + consultation
  feedback + deviation record.
- **`codev/resources/arch.md` / `lessons-learned.md`**: governance-doc routing.

## Testing

- `npm test` 121/121; `node --test tests/e2e-workers.test.mjs` 24/24; typecheck
  clean; tracked-tree lint clean (the only `eslint .` errors are the untracked
  `.claude/hooks/` builder-harness file, absent from clean checkouts).
- **Qualification (WSL2 / RTX 3080, `retries: 0`):** GPU-hardware parallel 2/3
  green (flake #33 amplified at 1/3, ~4× faster); GPU serial 22/22; **SwiftShader
  parallel 0/3 green (4–5/22 fail every run)**; SwiftShader serial baseline. Run
  banners confirm the resolved worker count (default ⇒ 1; `E2E_WORKERS=4` ⇒ 4;
  `50%` ⇒ 10 on this 20-core host; `CI=1` ⇒ 1). Verbatim per-test results in the
  review appendix.
- **CI unchanged:** `git diff --name-only main` does not list `validation.yml`.

## Spec / Plan / Review

- Spec: `codev/specs/41-parallelize-local-e2e-runs.md`
- Plan: `codev/plans/41-parallelize-local-e2e-runs.md`
- Review: `codev/reviews/41-parallelize-local-e2e-runs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)