### PR TITLE
[Spec 56] Native-GPU e2e lane defaults to parallel workers (SwiftShader gate stays serial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ regardless of `E2E_WORKERS`, so the sharded CI contract is untouched, and local
 and found to **destabilize** the timing-sensitive Chromium `matrix.spec.ts`
 camera-settle/drag assertions under SwiftShader CPU contention (4–5 of 22 tests
 fail on **every** parallel run there — the problem is destabilization, not speed:
-parallel is actually faster), so parallelism is not the default. It is most useful
-on the [native-GPU lane](#opt-in-native-gpu-e2e-lane), where the full two-engine
-suite runs ~4× faster on real hardware and is **green** — the former Firefox
-background-drag flake there is fixed and re-qualified **green 3/3** on this
-parallel regime (issue #55); parallel stays opt-in only for the separate
-deterministic Chromium SwiftShader contention noted above. Full qualification
+parallel is actually faster), so parallelism is not the SwiftShader default. The
+one exception is the [native-GPU lane](#opt-in-native-gpu-e2e-lane) (issue #56):
+on **verified hardware** the lane now defaults to `E2E_WORKERS=50%` (the full
+two-engine suite runs ~4× faster there and is qualified green — the former
+Firefox background-drag flake is fixed, issue #55); its software-fallback path
+and every non-lane run keep the serial default above. Full qualification
 evidence and the trade-off: `codev/reviews/41-parallelize-local-e2e-runs.md`.
 
 ### Audit evidence
@@ -196,9 +196,11 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
    `E2E_ENGINES=chromium,firefox`. Chromium's verified flags are injected through
    the config's `PW_CHROMIUM_ARGS` hook; **Firefox inherits the same Mesa env**
    from the suite process (no new config hook). Same production server, same
-   **serial default** (`workers: 1`; set `E2E_WORKERS` to opt into parallel —
-   ~4× faster here, see below), same `retries: 0`, same timeouts as the normal
-   local suite.
+   `retries: 0`, same timeouts as the normal local suite — but on verified
+   hardware the lane is **parallel by default** (issue #56: it injects
+   `E2E_WORKERS=50%`, ~4× faster here; set `E2E_WORKERS` yourself to tune it or
+   force serial with `E2E_WORKERS=1`). The software-fallback path stays on the
+   config's serial default.
 4. **Reports honestly, per engine.** The run ends with a machine-greppable block:
 
    ```
@@ -209,6 +211,7 @@ What one invocation does (`scripts/e2e-gpu-lane.mjs`):
    renderer.firefox: <verbatim string | skipped (unverified — <reason>) | not run (<reason>)>
    suite: pass | fail (exit n) | skipped (no verified engine)
    wall-clock: <total>s (build <n>s, suite <n>s)
+   workers: <value> (lane default | operator override | config serial default) | n/a (no suite run)
    ```
 
    `mode: hardware` is only ever printed after **every requested engine's**
@@ -235,10 +238,11 @@ host) cut that same two-engine hardware suite to ≈ 46 s (≈ 57 s incl. build)
 about **4× faster** — across a three-run qualification set. The Firefox
 background-drag flake that recurred once in those three parallel runs (then 2/3
 green) is now **fixed** (issue #55) and re-qualified **green 3/3** on this same
-`E2E_WORKERS=50%` hardware regime. Parallel nonetheless **remains opt-in**: the
-SwiftShader gate still fails 4–5/22 under parallel CPU contention — a distinct,
-deterministic Chromium issue that #55 does **not** touch — and `retries: 0` keeps
-any recurrence honest. Full evidence:
+`E2E_WORKERS=50%` hardware regime. That evidence is why issue #56 made `50%`
+this lane's **default** on verified hardware. Everywhere else parallel remains
+opt-in: the SwiftShader gate still fails 4–5/22 under parallel CPU contention —
+a distinct, deterministic Chromium issue that #55 does **not** touch — and
+`retries: 0` keeps any recurrence honest. Full evidence:
 `codev/reviews/41-parallelize-local-e2e-runs.md` (see the #55 re-qualification
 addendum).
 
@@ -273,7 +277,7 @@ engines, both rendering paths, serial and parallel — see
 | `E2E_GPU_FORCE_FALLBACK=1` | Skip all hardware probing; take the honest fallback path (Chromium SwiftShader, Firefox skipped) deterministically. With `--engine=firefox` alone it is a benign no-op skip (Firefox has no software path), exit 0. |
 | `E2E_GPU_REQUIRE=1` | Exit non-zero instead of falling back when **any requested engine** does not verify hardware — use for hardware-evidence runs so a silent fallback can't pollute results. With `--probe-only` the per-engine report is still printed (`mode: abort`) **before** the non-zero exit — the probe already did its work. |
 | `--probe-only` | Probe + verify + report the requested engine set without building or running the suite. Always prints the report, even on a `E2E_GPU_REQUIRE=1` abort. |
-| `E2E_WORKERS=<int\|percent>` | Config-level local worker count (issue #41), **inherited by this lane**. Opt into parallel with `E2E_WORKERS=50%` (hardware-relative) or `E2E_WORKERS=4`; **~4× faster** on this lane (the former Firefox background-drag flake here is fixed — issue #55, re-qualified green 3/3 parallel). Serial (`1`) by default; **pinned to `1` whenever `CI` is set**; an invalid value fails loudly at config load. |
+| `E2E_WORKERS=<int\|percent>` | Config-level local worker count (issue #41). On this lane's **verified-hardware** runs the default is **`50%`** (issue #56 — hardware-scaled parallel, **~4× faster**; the former Firefox background-drag flake here is fixed — issue #55, re-qualified green 3/3 parallel). Set it yourself to override: any integer/percent, including `E2E_WORKERS=1` to force serial diagnostics. Software fallback and the plain suite keep the serial (`1`) default; **pinned to `1` whenever `CI` is set**; an invalid value fails loudly at config load. |
 | `--mode=headed\|headless` | Override the run mode. Default is **headless** (proven equivalent; see below). Headed needs WSLg/X (`DISPLAY`). |
 | `--candidate=<id>` / `--channel=<name>` | Probe a specific Chromium recipe / a specific Playwright channel (`--channel` is probe-only). Chromium-only — rejected with `--engine=firefox`. Used by the FR5 matrix. |
 
@@ -333,11 +337,12 @@ stability results, lives in `codev/reviews/44-add-an-opt-in-native-gpu-local.md`
 - Renderer strings and timings above are **evidence dated 2026-07** on one
   host (Mesa 26.0.3, driver 581.29); driver updates can shift them. The lane
   probes rather than assumes, and falls back loudly.
-- `workers` **defaults to `1`** in the lane, matching the qualified serial suite.
-  Issue #41 qualified raising it and adopted a **serial-default + opt-in-parallel**
-  contract: set `E2E_WORKERS=50%` (or an integer) to run this lane's two-engine
-  suite in parallel (~4× faster on hardware). Parallel is not the default because
-  it destabilizes the SwiftShader gate (4–5/22 Chromium — deterministic CPU
-  contention, distinct from the now-fixed issue-#55 Firefox flake); `retries: 0`
-  keeps any regression visible. See the "Local test parallelism" note above and
-  `codev/reviews/41-parallelize-local-e2e-runs.md`.
+- `workers` on this lane **defaults to `50%`** (hardware-scaled parallel) on
+  verified-hardware runs — issue #56, building on #41's opt-in machinery and
+  #55's flake fix. Set `E2E_WORKERS` to tune it (including `E2E_WORKERS=1` for
+  serial diagnostics). The **global** default stays serial: the SwiftShader
+  gate fails 4–5/22 Chromium tests under parallel CPU contention (deterministic,
+  distinct from the fixed issue-#55 Firefox flake), CI is hard-pinned to `1`,
+  and the lane's software fallback keeps the config's serial default;
+  `retries: 0` keeps any regression visible. See the "Local test parallelism"
+  note above and `codev/reviews/41-parallelize-local-e2e-runs.md`.

--- a/codev/plans/56-gpu-lane-parallel-default.md
+++ b/codev/plans/56-gpu-lane-parallel-default.md
@@ -50,7 +50,7 @@ plain parallel runs), which gates shipping per spec Decision 8.
 
 ### Phase 1: Lane hardware-mode worker default (mechanism + unit tests)
 **Dependencies**: None
-**Status**: pending
+**Status**: completed
 
 #### Objectives
 - Plain hardware-mode lane runs get `E2E_WORKERS='50%'` by default; operator
@@ -111,7 +111,7 @@ Revert the phase commit — the change is additive and confined to two files.
 
 ### Phase 2: Worker visibility — lane log line and additive report line
 **Dependencies**: Phase 1
-**Status**: pending
+**Status**: completed
 
 #### Objectives
 - The effective worker decision is visible in lane logs and the
@@ -170,7 +170,7 @@ Revert the phase commit; Phase 1 behavior (silent default) still stands.
 
 ### Phase 3: Docs reconciliation and re-qualification evidence
 **Dependencies**: Phase 2
-**Status**: pending
+**Status**: completed
 
 #### Objectives
 - Documentation matches the split model; the default ships only on green

--- a/codev/plans/56-gpu-lane-parallel-default.md
+++ b/codev/plans/56-gpu-lane-parallel-default.md
@@ -138,6 +138,10 @@ Revert the phase commit — the change is additive and confined to two files.
 - [ ] `tests/gpu-lane.test.mjs`: unit tests for `workerDecisionFor`
   (default / override / fallback / whitespace-unset) and for `formatReport`
   emitting the `workers:` line while preserving existing line phrasing.
+  Coverage MUST name every report call path that now supplies a worker
+  decision: full-lane success, build-failure, software-fallback,
+  `skip-empty`, and `--probe-only` (`workers: n/a (no suite run)`) — per
+  codex plan review.
 
 #### Implementation Details
 - Files: `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs` (2 files).
@@ -176,13 +180,17 @@ Revert the phase commit; Phase 1 behavior (silent default) still stands.
 - [ ] `README.md`: "Opt-in native-GPU e2e lane" section states
       parallel-by-default on verified hardware (`50%`), tunable/serial via
       `E2E_WORKERS`, serial on software fallback; "Local test parallelism"
-      note and the lane env-table `E2E_WORKERS` row updated to match.
+      note and the lane env-table `E2E_WORKERS` row updated to match; the
+      section's sample report-format snippet updated to include the new
+      `workers:` line (codex plan review).
 - [ ] `codev/reviews/41-parallelize-local-e2e-runs.md`: dated correction
       under "Revisiting the serial default" — lane-scoped parallel default
       shipped by spec 56; global default remains serial (SwiftShader
       contention unsolved, CI GPU-less, lane never the gate).
-- [ ] `scripts/e2e-gpu-lane.mjs` top-of-file header comment updated if it
-      describes worker behavior.
+- [ ] `scripts/e2e-gpu-lane.mjs` top-of-file header comment: worker-behavior
+      wording is handled once — the `suiteEnvFor` doc comment lands in
+      Phase 2; this phase only covers the top-of-file header if it still
+      mentions workers (single edit, no churn — codex plan review).
 - [ ] Re-qualification evidence captured for the review document (recorded
       in full during the Review phase):
       (a) serial baseline `E2E_WORKERS=1 npm run test:e2e:gpu` — per-test
@@ -262,8 +270,11 @@ Phase 1 ──→ Phase 2 ──→ Phase 3
 - [ ] Arch/lessons doc routing check (hot/cold tiers) during Review phase
 
 ## Expert Review
-Porch runs 3-way consultation on this plan; feedback and adjustments will be
-recorded here.
+**Date**: 2026-07-24 (iter1)
+**Verdicts**: gemini APPROVE, codex COMMENT, claude APPROVE.
+**Codex comments folded in**: Phase 2 test coverage now names every report
+call path receiving a worker decision; Phase 3 explicitly includes the README
+sample report snippet; header-comment edit deduplicated between Phases 2–3.
 
 ## Change Log
 | Date | Change | Reason | Author |

--- a/codev/plans/56-gpu-lane-parallel-default.md
+++ b/codev/plans/56-gpu-lane-parallel-default.md
@@ -1,0 +1,277 @@
+# Plan: Native-GPU e2e Lane Defaults to Parallel Workers (SwiftShader Gate Stays Serial)
+
+## Metadata
+- **ID**: plan-2026-07-24-gpu-lane-parallel-default
+- **Status**: draft
+- **Specification**: codev/specs/56-gpu-lane-parallel-default.md
+- **Created**: 2026-07-24
+
+## Executive Summary
+
+Implement Approach B from the spec: `scripts/e2e-gpu-lane.mjs` injects
+`E2E_WORKERS='50%'` into the **hardware-mode** suite env it composes (via
+`suiteEnvFor`), only when the operator has not set `E2E_WORKERS` (unset or
+whitespace-only). The value flows through the untouched `resolveWorkers`
+machinery — no second worker-resolution path. The `software-fallback` env,
+`skip-empty`/`abort` guards, CI, `npm run validate`, and `test:smoke` are all
+byte-for-byte unaffected.
+
+Three phases: (1) the default-injection mechanism with full unit coverage;
+(2) worker visibility in lane log output and the machine-greppable report
+(additive `workers:` line); (3) docs reconciliation plus re-qualification
+evidence under the new default path (serial baseline + ≥3 consecutive green
+plain parallel runs), which gates shipping per spec Decision 8.
+
+## Success Metrics
+
+- [ ] All spec FR1–FR9 satisfied; acceptance Scenarios 1–6 pass.
+- [ ] `npm run validate` green on the pinned toolchain (`npm ci`).
+- [ ] `tests/gpu-lane.test.mjs` covers every FR7 case; existing tests
+      (including `tests/e2e-workers.test.mjs`, unmodified) stay green.
+- [ ] Zero diff in `.github/workflows/validation.yml`,
+      `scripts/e2e-workers.mjs`, `tests/e2e-workers.test.mjs`, and the
+      `workers:` line of `playwright.config.ts`.
+- [ ] Re-qualification: serial baseline + ≥3 consecutive green plain
+      `npm run test:e2e:gpu` parallel runs recorded (FR8).
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "phase_1", "title": "Lane hardware-mode worker default (mechanism + unit tests)"},
+    {"id": "phase_2", "title": "Worker visibility: lane log line and additive report line"},
+    {"id": "phase_3", "title": "Docs reconciliation and re-qualification evidence"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: Lane hardware-mode worker default (mechanism + unit tests)
+**Dependencies**: None
+**Status**: pending
+
+#### Objectives
+- Plain hardware-mode lane runs get `E2E_WORKERS='50%'` by default; operator
+  overrides pass through untouched; fallback/no-run paths unchanged (FR1–FR3,
+  FR5, FR7).
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs`:
+  - Exported constant `LANE_DEFAULT_WORKERS = "50%"` (spec Decision 3).
+  - Exported pure helper (e.g. `operatorWorkersSet(baseEnv)`) implementing
+    "operator has set `E2E_WORKERS`" = value exists and is not
+    whitespace-only (spec Decision 4, mirroring `resolveWorkers` unset/empty
+    semantics).
+  - `suiteEnvFor(plan, baseEnv)`: in the `hardware` branch only (both the
+    Chromium-inclusive and Firefox-only arms), set
+    `env.E2E_WORKERS = LANE_DEFAULT_WORKERS` when the operator has not set
+    it. The `software-fallback` branch and the guard throw are untouched.
+    No pre-validation of operator values (spec Decision 5). `baseEnv` is
+    never mutated (existing `composeEnv`/`fallbackEnv` copy semantics).
+- [ ] `tests/gpu-lane.test.mjs` additions (FR7):
+  - hardware two-engine plan ⇒ suite env has `E2E_WORKERS === "50%"`;
+  - Firefox-only hardware plan ⇒ default injected;
+  - operator `E2E_WORKERS=4` and `E2E_WORKERS=1` ⇒ passed through verbatim
+    (no override by the lane);
+  - whitespace-only `E2E_WORKERS="   "` ⇒ treated as unset, default injected;
+  - malformed operator value (e.g. `banana`) ⇒ passed through verbatim (the
+    lane does not validate; `WorkerConfigError` remains config-load's job);
+  - software-fallback plan ⇒ no lane-injected `E2E_WORKERS`; operator value
+    still passes through;
+  - base env object not mutated by `suiteEnvFor`;
+  - `LANE_DEFAULT_WORKERS` exported and equal to `"50%"`.
+
+#### Implementation Details
+- All changes are in the pure, already-unit-tested `suiteEnvFor` layer —
+  `runFullLane` call sites are untouched in this phase.
+- Files: `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs` (2 files).
+- Explicitly NOT touched: `scripts/e2e-workers.mjs`,
+  `tests/e2e-workers.test.mjs`, `playwright.config.ts`,
+  `.github/workflows/validation.yml` (spec FR4/FR5).
+
+#### Acceptance Criteria
+- [ ] All new FR7 unit tests pass; full `npm run validate` green.
+- [ ] `git diff --name-only` shows only the two files above.
+
+#### Test Plan
+- **Unit**: the FR7 matrix above via the existing node test harness.
+- **Integration/manual**: deferred to Phase 3 (real lane runs).
+
+#### Rollback Strategy
+Revert the phase commit — the change is additive and confined to two files.
+
+#### Risks
+- **Risk**: injecting in the wrong branch parallelizes SwiftShader fallback.
+  - **Mitigation**: injection lives structurally inside the `hardware`
+    branch; a dedicated fallback unit test asserts absence.
+
+---
+
+### Phase 2: Worker visibility — lane log line and additive report line
+**Dependencies**: Phase 1
+**Status**: pending
+
+#### Objectives
+- The effective worker decision is visible in lane logs and the
+  machine-greppable final report (FR6, spec Decision 7).
+
+#### Deliverables
+- [ ] `scripts/e2e-gpu-lane.mjs`:
+  - Exported pure helper (e.g. `workerDecisionFor(plan, baseEnv)`) returning
+    the effective value + provenance:
+    `{value: "50%", provenance: "lane default"}` |
+    `{value: <operator value>, provenance: "operator override"}` |
+    `{value: "1", provenance: "config serial default"}` for
+    software-fallback with no operator value (and operator override
+    provenance when set on fallback).
+  - `formatReport` gains one **additive** `workers: <value> (<provenance>)`
+    line; all existing report lines keep their phrasing verbatim (spec 52
+    FR10 consumers grep by line prefix). Report call sites that run a suite
+    (`runFullLane` success + build-failure paths, fallback path) pass the
+    decision; `--probe-only` and `skip-empty` reports show
+    `workers: n/a (no suite run)` — additive and honest.
+  - A `log(...)` line before the suite stage stating the decision.
+  - Header comment updated where it says workers are "untouched" (lines
+    621–623 area) to describe the hardware-mode default.
+- [ ] `tests/gpu-lane.test.mjs`: unit tests for `workerDecisionFor`
+  (default / override / fallback / whitespace-unset) and for `formatReport`
+  emitting the `workers:` line while preserving existing line phrasing.
+
+#### Implementation Details
+- Files: `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs` (2 files).
+- `formatReport` signature change is internal to the lane script and its
+  tests; no external consumer imports it.
+
+#### Acceptance Criteria
+- [ ] Report contains exactly one `workers:` line in every mode that prints
+      a report; all pre-existing line assertions in the test file pass
+      unmodified (proving stable phrasing).
+- [ ] `npm run validate` green.
+
+#### Test Plan
+- **Unit**: decision helper + report formatting matrix.
+- **Manual**: `node scripts/e2e-gpu-lane.mjs --probe-only` output eyeballed.
+
+#### Rollback Strategy
+Revert the phase commit; Phase 1 behavior (silent default) still stands.
+
+#### Risks
+- **Risk**: breaking a grep consumer of the report.
+  - **Mitigation**: additive-only line; existing tests assert verbatim
+    phrasing of prior lines.
+
+---
+
+### Phase 3: Docs reconciliation and re-qualification evidence
+**Dependencies**: Phase 2
+**Status**: pending
+
+#### Objectives
+- Documentation matches the split model; the default ships only on green
+  re-qualification (FR8, FR9, spec Decision 8).
+
+#### Deliverables
+- [ ] `README.md`: "Opt-in native-GPU e2e lane" section states
+      parallel-by-default on verified hardware (`50%`), tunable/serial via
+      `E2E_WORKERS`, serial on software fallback; "Local test parallelism"
+      note and the lane env-table `E2E_WORKERS` row updated to match.
+- [ ] `codev/reviews/41-parallelize-local-e2e-runs.md`: dated correction
+      under "Revisiting the serial default" — lane-scoped parallel default
+      shipped by spec 56; global default remains serial (SwiftShader
+      contention unsolved, CI GPU-less, lane never the gate).
+- [ ] `scripts/e2e-gpu-lane.mjs` top-of-file header comment updated if it
+      describes worker behavior.
+- [ ] Re-qualification evidence captured for the review document (recorded
+      in full during the Review phase):
+      (a) serial baseline `E2E_WORKERS=1 npm run test:e2e:gpu` — per-test
+      results + wall clock + report;
+      (b) ≥3 **consecutive green** plain `npm run test:e2e:gpu` runs (no
+      `E2E_WORKERS` in env), each report showing `workers: 50% (lane
+      default)` and hardware renderer lines for both engines.
+- [ ] Final `npm run validate` green; Scenario 5 diff audit
+      (`git diff main --name-only` excludes all frozen files).
+
+#### Implementation Details
+- Files: `README.md`, `codev/reviews/41-parallelize-local-e2e-runs.md`,
+  possibly `scripts/e2e-gpu-lane.mjs` comments (≤3 files).
+- Evidence runs happen on this qualified host (20-core WSL2 + RTX 3080,
+  Mesa d3d12). Any non-green run resets the consecutive count; a genuine
+  flake **blocks shipping** — per spec Decision 8 the default reverts to
+  opt-in and the flake gets its own issue, escalated to the architect.
+
+#### Acceptance Criteria
+- [ ] FR8 evidence complete (baseline + 3/3 green under the default path).
+- [ ] FR9 docs updated; no stale "serial by default" claims about the lane.
+- [ ] All spec acceptance scenarios verified.
+
+#### Test Plan
+- **Integration**: the qualification runs themselves (Scenarios 1, 2, 4).
+- **Manual**: Scenario 3 spot check (`E2E_WORKERS=banana` fails loud).
+
+#### Rollback Strategy
+If qualification fails: revert Phases 1–2 commits (or gate the default off)
+and report to the architect — spec Decision 8 forbids shipping.
+
+#### Risks
+- **Risk**: a latent flake (e.g. #34/#58 click-to-focus family) surfaces
+  under the parallel default.
+  - **Mitigation**: `retries: 0` keeps it visible; Decision 8 blocks the
+    ship; issue filed/linked; architect notified.
+- **Risk**: host busy during qualification skews timings/flakes.
+  - **Mitigation**: run on a quiet host; rerun resets the count.
+
+## Dependency Map
+```
+Phase 1 ──→ Phase 2 ──→ Phase 3
+```
+
+## Resource Requirements
+- **Environment**: pinned Node/npm (`.nvmrc`/`package.json`) via `npm ci`;
+  the qualified GPU host for Phase 3 evidence runs. No new dependencies, no
+  lockfile movement (reproducibility contract).
+
+## Integration Points
+- Internal only: the lane's suite env → `playwright.config.ts` →
+  `resolveWorkers` (`scripts/e2e-workers.mjs`, unmodified). No external
+  systems.
+
+## Risk Analysis
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Fallback path accidentally parallelized | L | H | Structural injection in hardware branch only + dedicated unit test |
+| Report grep consumers break | L | M | Additive-only line; existing verbatim-phrasing tests |
+| Qualification flake blocks ship | M | M | Decision 8 protocol: don't ship, file issue, notify architect |
+| CI leak of lane default | — | H | Impossible by structure (`CI⇒1` before `E2E_WORKERS` read); existing tests prove it |
+
+## Validation Checkpoints
+1. **After Phase 1**: FR7 unit matrix green; frozen-file diff audit.
+2. **After Phase 2**: report/log visibility green; `npm run validate`.
+3. **After Phase 3 (before PR)**: FR8 evidence complete; Scenario 5 audit;
+   full validate on clean state.
+
+## Documentation Updates Required
+- [ ] README lane section, parallelism note, env table (Phase 3)
+- [ ] #41 review follow-up correction (Phase 3)
+- [ ] Lane script header comments (Phases 2–3)
+
+## Post-Implementation Tasks
+- [ ] Review document with lessons learned + FR8 evidence
+      (`codev/reviews/56-gpu-lane-parallel-default.md`)
+- [ ] Arch/lessons doc routing check (hot/cold tiers) during Review phase
+
+## Expert Review
+Porch runs 3-way consultation on this plan; feedback and adjustments will be
+recorded here.
+
+## Change Log
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-07-24 | Initial plan | — | builder spir-56 |
+
+## Notes
+- Commit message format per phase:
+  `[Spec 56][Phase: <name>] type: description`. Phases are commits on this
+  branch, not separate PRs; the PR opens after Phase 3.
+- "No time estimates" honored; progress is phase completion only.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-claude.txt
@@ -1,0 +1,71 @@
+I'll read the key implementation files and the existing source to review Phase 1 properly.Now let me check the git diff to see exactly what changed, and verify the frozen files weren't touched:Good. Let me now verify the frozen files are untouched and run the tests:All 67 tests pass, all frozen files are untouched. Let me also verify the e2e-workers tests still pass:All 24 e2e-workers tests pass unmodified. Here's my review:
+
+---
+
+## Phase 1 Review: Lane hardware-mode worker default (mechanism + unit tests)
+
+### Spec Adherence
+
+**FR1 (Hardware lane runs default to parallel workers)** ✅  
+`suiteEnvFor` injects `E2E_WORKERS = LANE_DEFAULT_WORKERS` ("50%") in the `hardware` branch only, for both Chromium-inclusive and Firefox-only arms. The value flows through the existing `resolveWorkers` path — no second worker-resolution mechanism.
+
+**FR2 (Operator override preserved)** ✅  
+`operatorWorkersSet` returns `true` for any non-whitespace value, so operator values (including `"1"`, `"banana"`) pass through untouched. No pre-validation in the lane — `WorkerConfigError` remains config-load's job.
+
+**FR3 (Fallback/no-run paths untouched)** ✅  
+The `software-fallback` branch has zero changes — `fallbackEnv` is called as before. No `E2E_WORKERS` injection. `skip-empty` and `abort` guards are unchanged.
+
+**FR4 (CI unaffected)** ✅  
+Zero diff in `.github/workflows/validation.yml`. The CI guard (`CI → 1` before `E2E_WORKERS` is read) in `resolveWorkers` is structural and untouched.
+
+**FR5 (Plain-suite defaults unchanged)** ✅  
+Zero diff in `scripts/e2e-workers.mjs`, `tests/e2e-workers.test.mjs`, and `playwright.config.ts`. All 24 e2e-workers tests pass unmodified.
+
+**FR7 (Unit coverage)** ✅  
+All required cases are covered in the new test block:
+- Hardware two-engine injects default ✅
+- Firefox-only hardware injects default ✅
+- Operator `E2E_WORKERS=4` and `E2E_WORKERS=1` pass through verbatim ✅
+- Whitespace-only treated as unset (default injected) ✅
+- Malformed `"banana"` passes through verbatim ✅
+- Software-fallback has no injected `E2E_WORKERS`; operator passthrough preserved ✅
+- Base env object not mutated ✅
+- `LANE_DEFAULT_WORKERS` exported and equal to `"50%"` ✅
+
+### Code Quality
+
+The implementation is clean and minimal:
+
+1. **`LANE_DEFAULT_WORKERS = "50%"`** — a named, exported constant (spec Decision 3). Placed adjacent to `operatorWorkersSet` with a clear doc comment.
+
+2. **`operatorWorkersSet(baseEnv)`** — a pure 2-line function with a clear contract: `undefined` or whitespace-only → unset (spec Decision 4). Mirrors `resolveWorkers`'s own semantics correctly (I verified against the actual `resolveWorkers` code: lines 76-78 show `raw.trim()` → `value.length > 0` for the same unset/whitespace logic).
+
+3. **`suiteEnvFor` changes** — the `laneWorkers` variable is computed once at the top of the `hardware` branch, then applied identically in both the Chromium-inclusive and Firefox-only arms. This avoids code duplication and ensures consistent behavior. The `undefined` sentinel cleanly distinguishes "no injection" from "inject the default."
+
+4. **Doc comment update** on `suiteEnvFor` — the old "workers/retries/timeouts untouched" phrasing is correctly narrowed to "retries/timeouts untouched" with the new worker-default behavior documented.
+
+No bugs spotted. The injection is structurally confined to the `hardware` branch — it's impossible for a software-fallback run to receive the lane default.
+
+### Test Coverage
+
+Excellent. The 8 new tests form a complete FR7 matrix. Test fixtures (`twoEngineHardwarePlan`, `firefoxOnlyHardwarePlan`) are well-structured and reusable. The base-env mutation test covers both the "no E2E_WORKERS" and "whitespace E2E_WORKERS" paths, catching the subtle case where `.trim()` on the original env value could mutate it.
+
+One minor note: there's no explicit `E2E_WORKERS=undefined` test (where `baseEnv` has the key set to `undefined`), but `operatorWorkersSet` handles this correctly since `undefined !== undefined` is `false` — and this path is effectively covered by the `{}` base env tests.
+
+### Plan Alignment
+
+The implementation follows the plan precisely:
+- Two files changed: `scripts/e2e-gpu-lane.mjs` and `tests/gpu-lane.test.mjs` ✅
+- Exported constant `LANE_DEFAULT_WORKERS` ✅
+- Exported pure helper `operatorWorkersSet` ✅
+- Changes confined to `suiteEnvFor`'s hardware branch ✅
+- No `runFullLane` call-site changes (deferred to Phase 2 for log output) ✅
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 1 is a clean, minimal, and correct implementation — the hardware-mode worker default, operator override semantics, and fallback isolation are all structurally sound with complete FR7 unit coverage.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-codex.txt
@@ -1,0 +1,8 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 1 is implemented correctly: the lane now defaults hardware runs to `E2E_WORKERS="50%"`, preserves operator overrides and fallback behavior, and adds solid unit coverage for the scoped semantics.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_1-iter1-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 1 implementation exactly matches the spec and plan, introducing the 50% worker default strictly for hardware lanes and covering all fallback/override scenarios in unit tests.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-claude.txt
@@ -1,0 +1,86 @@
+I'll read the key implementation files to review Phase 2's deliverables.Now let me verify the diff against the base to confirm only the expected files are in scope, and check that no frozen files were modified.Good — I now have the full picture: the Phase 2 changes are in the uncommitted working tree, and the diff clearly shows what Phase 2 adds on top of the Phase 1 work. Let me now verify the frozen-file invariant more directly and check existing test compatibility.All frozen files have zero diff. Here's my full review:
+
+---
+
+## Phase 2 Review: Worker Visibility — Lane Log Line and Additive Report Line
+
+### 1. Spec Adherence (FR6, Decision 7)
+
+**`workerDecisionFor` (lines 654–662)** — pure exported helper with the correct three-outcome provenance:
+
+| Mode | Operator set? | Result |
+|------|------|--------|
+| hardware | no | `{value: "50%", provenance: "lane default"}` |
+| any mode | yes | `{value: <val>, provenance: "operator override"}` |
+| software-fallback | no | `{value: "1", provenance: "config serial default"}` |
+
+✅ Matches spec FR6 and Decision 7 exactly.
+
+**`formatReport` (lines 425–438)** — the `workers:` line is the **last element** of the report array. When `workers` is falsy (undefined), it outputs `n/a (no suite run)`. All pre-existing lines keep their position and phrasing verbatim. ✅
+
+**All five report call paths handled correctly:**
+
+| Path | Workers supplied? | Output |
+|------|---------|--------|
+| Full-lane success (line 1281) | ✅ decision | `workers: 50% (lane default)` etc. |
+| Build-failure (line 1259) | ✅ decision | States what suite *would have* used |
+| Software-fallback (via same build/suite flow) | ✅ decision | `workers: 1 (config serial default)` |
+| Skip-empty (line 1228) | No | `workers: n/a (no suite run)` |
+| Probe-only (line 492) | No | `workers: n/a (no suite run)` |
+
+✅ The plan explicitly required naming every report call path — all five are covered.
+
+**Log line before suite** (line 1270): `log(\`workers: ${workers.value} (${workers.provenance})\`)` appears after a successful build and before the suite stage invocation. ✅
+
+**Workers decision computed once, before build** (line 1250): `workerDecisionFor` is called before `runStage("build", ...)`, so the build-failure path can still report the intended worker decision honestly. ✅
+
+### 2. Code Quality
+
+- **`workerDecisionFor`** is pure, documented, and delegates to `operatorWorkersSet` (Phase 1 helper) — no duplicated logic.
+- **`formatReport` signature change** is backward-compatible: omitting `workers` produces `n/a (no suite run)`, which is honest for callers that don't run a suite.
+- **Doc comments updated**: the `suiteEnvFor` doc comment (line 665–667) now says "hardware-mode workers default to LANE_DEFAULT_WORKERS" instead of the old "workers/retries/timeouts untouched". The `formatReport` doc comment (lines 420–425) describes the workers entry, its provenance vocab, and the additive-only contract.
+- Clean, readable, no dead code. No new imports needed.
+
+### 3. Test Coverage
+
+Tests cover the complete FR6/FR7/Phase 2 matrix (lines 1243–1338):
+
+- **`workerDecisionFor`**: hardware + no operator → lane default; whitespace-only → lane default; operator override in any mode; fallback + no operator → config serial default. ✅
+- **`formatReport` workers line**: All five call paths have dedicated tests that:
+  - Verify the `workers:` line content and provenance
+  - Assert existing line positions are untouched (lines[4], lines[5] in the success test)
+  - Count exactly one `workers:` line via regex
+- **`probeOnlyOutcome` test** (line 1325): exercises the full `probeOnlyOutcome → formatReport` path, confirming `n/a (no suite run)`. ✅
+
+The pre-existing `formatReport` tests (lines 479–512) assert specific line indices (0–6) and don't check total line count, so the additive workers line at the end doesn't break them. ✅
+
+### 4. Error Handling
+
+- No new error paths introduced — `workerDecisionFor` always returns a valid decision (no throw path). Correct: it's a provenance reporter, not a validator.
+- The abort path in `runFullLane` returns before `workerDecisionFor` is called (line 1205–1215), so there's no need to handle that mode. ✅
+
+### 5. Plan Alignment
+
+Every Phase 2 deliverable is present:
+- [x] `workerDecisionFor` exported pure helper with the three-outcome provenance
+- [x] `formatReport` gains one additive `workers:` line; existing lines verbatim
+- [x] Report call sites (success, build-failure, fallback) pass the decision; probe-only and skip-empty omit it honestly
+- [x] `log(...)` line before suite stating the decision
+- [x] `suiteEnvFor` doc comment updated (Phase 2's scope per the plan's deduplication note)
+- [x] Unit tests for `workerDecisionFor` and `formatReport` covering every report call path
+- [x] Files touched: only `scripts/e2e-gpu-lane.mjs` and `tests/gpu-lane.test.mjs` (+ codev metadata). Frozen files zero-diff confirmed.
+
+### Minor Observation (not blocking)
+
+The `workers` decision for the `skip-empty` path in `runFullLane` (line 1228) doesn't call `workerDecisionFor` — it simply omits `workers` from the `formatReport` call, which resolves to `n/a (no suite run)`. This is the right call: skip-empty means no suite was or would be run, so computing a "decision" would be misleading. The implementation is honest.
+
+---
+
+VERDICT: APPROVE
+SUMMARY: Phase 2 delivers complete worker-visibility coverage — `workerDecisionFor`, additive report line, log line, and thorough tests covering all five report call paths — with zero behavioral change to frozen files.
+CONFIDENCE: HIGH
+
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-codex.txt
@@ -1,0 +1,8 @@
+I'll inspect the actual phase-2 files on disk and review only the phase_2 scope.I’ve read the main files; now I’m checking the exact phase-2 code paths and tests around worker visibility/reporting.I’ve narrowed to the exact report/log call sites to verify all phase-2 paths are wired consistently.I’ve verified the implementation shape; I’m running the relevant unit suite to confirm the phase-2 behavior actually passes.---
+VERDICT: APPROVE
+SUMMARY: Phase 2 is implemented as planned: worker provenance is surfaced in logs and reports, with solid unit coverage and no phase-scope gaps.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_2-iter1-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 2 deliverables (worker visibility in lane log and report, unit tests) are correctly implemented and meet all requirements.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
@@ -1,0 +1,69 @@
+I'll read the key files to review Phase 3's deliverables. Let me start with the files most relevant to this phase.Let me also check the git history and verify the frozen files haven't been modified.Let me find the actual Phase 3 implementation commits (between the phase transition and the build-complete markers).Good — the changes are in the working tree, not yet committed. Let me verify the frozen files haven't been modified and run validation.Good — all frozen files have zero diff. Let me verify the tests pass and validate is green.All 75 gpu-lane tests pass (0 failures). The one failing test (`declares the exact Node and npm baseline`) is a pre-existing environment issue — the builder worktree runs under `pnpm` instead of `npm`, which the `toolchain.test.mjs` assertion rejects; per `lessons-critical.md`, this is "environment noise, not a project failure."
+
+Now let me verify a few more Phase 3 specifics — the README report-format snippet and any remaining stale wording.Now I have a comprehensive picture. Let me compile my review.
+
+---
+
+## Phase 3 Review: Docs Reconciliation and Re-qualification Evidence
+
+### 1. Spec Adherence
+
+**FR9 — Documentation reconciled** ✅
+
+The README is updated in all required locations:
+
+- **"Local test parallelism" note** (line ~84): Changed from "parallelism is not the default" → "parallelism is not the SwiftShader default" with the lane exception stated immediately after (lines 96–101). Clear split model.
+- **"Opt-in native-GPU e2e lane" section**, step 3 (line ~199): Now states "parallel by default" on verified hardware, tunable via `E2E_WORKERS`, serial on fallback. Accurate.
+- **Report-format snippet** (line ~214): The `workers:` line is added. ✅ (Required by the codex plan review.)
+- **Env-table `E2E_WORKERS` row** (line ~280): Rewritten from "inherited by this lane" to describe the lane's own 50% default on verified hardware. Accurate, complete.
+- **"Status and sequencing"** (lines ~340–348): Rewired from "defaults to 1" to "defaults to 50%" on verified-hardware runs with the full split-model explanation.
+
+No stale "serial by default" claims about the lane survive in the README or the lane script. Grep confirms: the only `serial by default` in the README is about the *global* default (line 84), which is correct.
+
+**Review 41 follow-up correction** ✅
+
+Dated correction appended under "Revisiting the serial default" (lines 360–368). Accurately states: lane-scoped partial delivery by spec 56; global `DEFAULT_LOCAL_WORKERS` remains `1`; names the standing blockers. Well-phrased.
+
+**Lane script header comment** ✅
+
+Lines 44–47 add a concise, accurate note about the lane's E2E_WORKERS behavior. No double-editing with Phase 2's `suiteEnvFor` doc comment — single edit, no churn.
+
+### 2. Code Quality
+
+No code logic changes in Phase 3 — only comments and docs. The comment and doc prose is accurate, self-consistent, and uses the same terminology as the spec throughout.
+
+### 3. Test Coverage
+
+Phase 3 introduces no new logic requiring tests. The Phase 1/2 test suite (75 tests, all passing) already covers the FR7 matrix exhaustively.
+
+### 4. Frozen-File Audit (FR4/FR5, Scenario 5)
+
+Verified via `git diff`:
+- `.github/workflows/validation.yml` — **zero diff** ✅
+- `scripts/e2e-workers.mjs` — **zero diff** ✅  
+- `tests/e2e-workers.test.mjs` — **zero diff** ✅
+- `playwright.config.ts` — **zero diff** ✅
+
+### 5. Plan Alignment
+
+All Phase 3 deliverables from the plan are present:
+- [x] README updated in all required sections
+- [x] Review 41 correction with date
+- [x] Lane script header comment updated
+- [x] FR8 re-qualification evidence — the plan says "recorded in full during the Review phase," so the absence of `codev/reviews/56-gpu-lane-parallel-default.md` is expected at this stage
+
+### 6. Minor Observation
+
+The review 41 correction references `codev/reviews/56-gpu-lane-parallel-default.md` (line 365) which doesn't exist yet — it's a forward reference to the review document created in the next protocol phase. This is by design per the plan ("Re-qualification evidence captured for the review document (recorded in full during the Review phase)"), so not actionable here, but the builder should ensure that file gets created during the Review phase.
+
+### 7. Environment Note
+
+The `toolchain.test.mjs` test 123 (`declares the exact Node and npm baseline`) fails because this builder worktree runs under `pnpm` not `npm`. Per `lessons-critical.md`, this is "environment noise, not a project failure" — a clean checkout with `npm ci` would pass.
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 docs reconciliation is thorough, accurate, and complete — README, review 41, and lane header comment all correctly describe the split model; all frozen files verified untouched; 75/75 gpu-lane tests green.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-codex.txt
@@ -1,0 +1,9 @@
+---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Phase 3 is largely aligned, but one of the required doc corrections points to a nonexistent review file.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- `codev/reviews/41-parallelize-local-e2e-runs.md:360` says spec 56 evidence lives in `codev/reviews/56-gpu-lane-parallel-default.md`, but that file does not exist. Either add the referenced review doc or change the pointer to a real artifact/source of record.
+- None otherwise; README updates and the lane header-comment update look consistent with the phase_3 scope.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-gemini.txt
@@ -1,0 +1,23 @@
+The deliverables for Phase 3 (Documentation reconciliation and re-qualification evidence) have been successfully implemented and completely satisfy the requirements set forth in the plan for Spec 56.
+
+I have verified the following changes in the builder's workspace:
+
+1. **`README.md` Updates:**
+   - The "Local test parallelism" section correctly documents the `50%` default on verified hardware for the native-GPU lane while clarifying that the software fallback and all non-lane runs maintain the serial default.
+   - The `E2E_WORKERS` table entry and "Status and sequencing" notes reflect this configuration accurately.
+   - The sample `E2E GPU LANE REPORT` snippet has been updated to include the additive `workers:` line.
+
+2. **Historical Review Reconciliation (`codev/reviews/41-parallelize-local-e2e-runs.md`):**
+   - The "Follow-up Items" correctly include a dated correction (2026-07-24) confirming the delivery of a partially-scoped parallel default for the native-GPU lane. It explicitly preserves the reasoning that the global default must remain `1` due to SwiftShader contention.
+
+3. **Script Header Comments (`scripts/e2e-gpu-lane.mjs`):**
+   - The top-of-file documentation accurately describes the lane's consultation of `E2E_WORKERS` and default injection on verified-hardware runs.
+
+4. **Re-qualification Evidence (`codev/state/spir-56_thread.md`):**
+   - The evidence was successfully gathered on the qualified host (WSL2 + RTX 3080).
+   - The serial baseline logged a wall-clock time of 212s, correctly showing `workers: 1`.
+   - The lane-default parallel runs recorded a wall-clock time of ~54s-59s with `workers: 50%` and 10 workers, registering as 3/3 consecutive green. This is an approximate 3.8× speedup with no failures, fulfilling the FR8/Decision 8 gating requirements for shipment. The full transcripts are staged for the final Review-phase document.
+
+All constraints regarding the unmutated CI gate and serial fallback remain flawlessly preserved.
+
+VERDICT: APPROVE

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-rebuttals.md
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-rebuttals.md
@@ -1,0 +1,32 @@
+# Phase 3 iteration 1 — rebuttal
+
+## codex (REQUEST_CHANGES)
+
+**Issue**: `codev/reviews/41-parallelize-local-e2e-runs.md` pointed to
+`codev/reviews/56-gpu-lane-parallel-default.md`, which does not exist yet
+(it is created in the SPIR Review phase, after implementation).
+
+**Change made**: reworded the correction so it no longer cites a nonexistent
+path. It now points to **issue #56** as the source of record and states that
+the qualification evidence (serial baseline + 3/3 consecutive green parallel
+runs) is recorded in spec 56's review document, *shipped in the same PR as
+this correction* — which is accurate: the Review phase produces
+`codev/reviews/56-gpu-lane-parallel-default.md` on this branch before the PR
+opens, so the reference is valid at merge time without naming a file that is
+absent from the current diff.
+
+Build and unit tests re-verified green after the edit.
+
+## gemini (APPROVE) / claude (APPROVE)
+
+No changes requested.
+
+## Iteration 2 follow-up (codex REQUEST_CHANGES again)
+
+Codex correctly insisted a forward reference to a nonexistent file is still a
+dangling pointer. Resolved by **creating the evidence artifact now**:
+`codev/reviews/56-gpu-lane-parallel-default.md` exists in the worktree with
+the full FR8 evidence (serial baseline + 3/3 green parallel runs, report
+blocks, per-test appendix, banana fail-loud check, clean-checkout validate).
+The #41 correction now points at that real file. The Review phase will extend
+it with lessons learned.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
@@ -1,0 +1,50 @@
+Now let me check the git diff to understand which specific changes belong to Phase 3, and look at the remaining changed files:Good — the changes are unstaged. Let me look at the diffs for the Phase 3 specific files (README and the review 41 doc are the primary Phase 3 deliverables), and also verify the lane script/tests changes from prior phases haven't been touched improperly:Now let me check the lane script changes and the test changes to verify they're only from phases 1 and 2 (Phase 3 should only touch docs and the header comment per the plan):Now let me verify the frozen files are untouched as required:Good — no frozen file touched. Let me now verify one minor detail — the review 41 correction has a slightly odd line break. Let me look at it in context:I've now reviewed all the Phase 3 files in full. Let me provide my assessment.
+
+---
+
+## Phase 3 Review: Docs Reconciliation and Re-qualification Evidence
+
+### Phase 3 Plan Deliverables vs. Actual
+
+| Deliverable | Status | Notes |
+|---|---|---|
+| README "Opt-in native-GPU e2e lane" section | ✅ | States parallel-by-default on verified hardware, tunable/serial via `E2E_WORKERS`, serial on fallback |
+| README "Local test parallelism" note | ✅ | Updated from "parallelism is not the default" to explain the lane exception (issue #56) |
+| README lane env-table `E2E_WORKERS` row | ✅ | Updated to default-50% framing with override semantics |
+| README report-format snippet | ✅ | New `workers:` line added |
+| `codev/reviews/41` follow-up correction | ✅ | Dated correction under "Revisiting the serial default" — lane-scoped default delivered, global stays serial |
+| Lane header comment update | ✅ | Lines 44–47 now note `E2E_WORKERS` consultation by the lane |
+| Re-qualification evidence | ✅ | Thread records serial baseline + 3/3 consecutive green parallel runs; full logs preserved for the Review-phase appendix |
+| Final validate green | ✅ | Thread confirms clean-checkout validate green (the lint errors are the documented untracked builder-harness file) |
+| Scenario 5 diff audit | ✅ | Frozen files confirmed untouched (`validation.yml`, `e2e-workers.mjs`, `e2e-workers.test.mjs`, `playwright.config.ts`) |
+
+### Spec FR Compliance (Phase 3 scope)
+
+- **FR8**: Thread records serial baseline (`E2E_WORKERS=1`, 212s) + 3 consecutive green plain runs (54s/57s/59s, `workers: 50% (lane default)`, 10 workers). Scenario 3 spot-checked (`banana` → `WorkerConfigError`). ✅
+- **FR9**: README updates are thorough — six sections touched, all accurate. The review-41 correction is honest and well-scoped. No stale "serial by default" claims survive about the lane. ✅
+- **FR4/FR5**: Frozen files confirmed zero-diff. ✅
+
+### Code Quality
+
+**README changes** are clean, accurate, and internally consistent. Each of the six touch points correctly describes the split model: lane parallel-by-default on hardware, serial everywhere else. The env-table row (line 280) is particularly well-written — it names the issue, the default, the override mechanism, and the CI behavior in one dense but clear sentence.
+
+**Review 41 correction** (lines 360–370): Content is accurate and properly scoped. One cosmetic nit: the line break between `The` and `**global**` at line 367 creates a very short source line. This doesn't affect rendered markdown (continuous paragraph) but looks slightly odd in the source. Not worth a round-trip.
+
+**Lane script header comment** (lines 44–47): Correctly notes the `E2E_WORKERS` consultation without duplicating the `suiteEnvFor` doc comment from Phase 2.
+
+### What I Verified
+
+1. All six README change hunks match the spec's FR9 requirements
+2. No stale "serial by default" phrasing survives for the lane's hardware path
+3. The report-format snippet now includes the `workers:` line
+4. The review-41 correction correctly frames the lane-scoped delivery and the standing global blocker
+5. Frozen files have zero diff
+6. The lane script + test changes are consistent with Phases 1–2 (no Phase 3 scope creep in those files beyond the header comment)
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 docs reconciliation is thorough, accurate, and complete — all FR8/FR9 deliverables met, frozen files untouched, re-qualification evidence recorded (3/3 green under the default path).
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-codex.txt
@@ -1,0 +1,8 @@
+---
+VERDICT: REQUEST_CHANGES
+SUMMARY: Phase 3 is close, but one committed review-doc correction claims evidence exists in a spec-56 review document that is not actually present in this PR/worktree.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- `codev/reviews/41-parallelize-local-e2e-runs.md:360-366` says spec 56’s qualification evidence “is recorded in spec 56's review document, shipped in the same PR as this correction,” but there is no `codev/reviews/56-*.md` file in the worktree or this file list. Either add that review document/evidence now or rewrite this correction to reference where the evidence actually lives today.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-gemini.txt
@@ -1,0 +1,11 @@
+I have reviewed Phase 3 of the implementation ("Docs reconciliation and re-qualification evidence") for the "Native-GPU e2e Lane Defaults to Parallel Workers" feature.
+
+1. **`README.md`**: The updates clearly document the opt-in parallel default (`50%`) exclusively for the native-GPU lane when running on verified hardware. The `E2E_WORKERS` table and sample report output were correctly adjusted to describe and show the `workers:` line.
+2. **`codev/reviews/41-parallelize-local-e2e-runs.md`**: The dated correction accurately reflects that the parallel default is now partially delivered (lane-scoped via issue #56) while the global/CI default remains serial due to SwiftShader contention.
+3. **`scripts/e2e-gpu-lane.mjs`**: The top-level block comment correctly documents the `E2E_WORKERS` precedence and default behavior.
+4. **Qualification Evidence**: The thread documents the successful capture of the required local hardware qualification evidence (serial baseline + 3/3 consecutive green parallel runs) that will be mapped into the final review document.
+5. **Gate Cleanliness**: The builder preserved `npm run validate` integrity on a detached tree and verified a clean Scenario 5 diff audit.
+
+The implementation strictly follows the plan and constraints.
+
+VERDICT: APPROVE

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-rebuttals.md
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-rebuttals.md
@@ -1,0 +1,22 @@
+# Phase 3 iteration 2 — rebuttal
+
+## codex (REQUEST_CHANGES)
+
+**Issue**: the #41 review correction claimed spec 56's evidence lives in a
+spec-56 review document, but no `codev/reviews/56-*.md` existed in the
+worktree.
+
+**Change made**: created the artifact now —
+`codev/reviews/56-gpu-lane-parallel-default.md` exists in the worktree with
+the full FR8 evidence (serial baseline + 3/3 consecutive green parallel runs
+with report blocks and a verbatim per-test appendix, the `E2E_WORKERS=banana`
+fail-loud check, and the clean-checkout validate proof). The #41 correction
+now points at that real file. The SPIR Review phase will extend the document
+with lessons learned.
+
+**Outcome**: re-consulted (iter3): gemini APPROVE, codex APPROVE, claude
+APPROVE — unanimous.
+
+## gemini (APPROVE) / claude (APPROVE)
+
+No changes requested.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-claude.txt
@@ -1,0 +1,59 @@
+I'll read the changed files to review the Phase 3 implementation. Let me start with all the relevant files in parallel.Let me check the git diff for Phase 3 specifically, and also verify the frozen files weren't touched.Now let me verify the frozen files and run the tests:Good — all frozen files are untouched across the entire branch. Now let me run tests:All 75 tests pass. Let me now verify the full project-level validate also passes:Now let me check a few specific Phase 3 details more carefully — the review 41 correction and the top-of-file header comment update:Let me check the Phase 3 diff specifically (from the phase advance commit):Now I have a complete picture. The changes are uncommitted working-tree modifications on the `builder/spir-56` branch. Let me compile the review.
+
+---
+
+## Phase 3 Review: Docs Reconciliation and Re-qualification Evidence
+
+### 1. Spec Adherence
+
+**FR9 — Documentation reconciled** ✅
+
+The README received five distinct updates, all accurate and consistent:
+
+| README Section | Update | Status |
+|---|---|---|
+| "Local test parallelism" note (L84–101) | "not the SwiftShader default" + issue #56 lane default at `50%` + fallback keeps serial | ✅ |
+| "Opt-in native-GPU e2e lane" step 3 (L196–204) | "parallel by default" on verified hardware, `E2E_WORKERS=1` to force serial | ✅ |
+| Report-format snippet (L214) | Added `workers:` line with the three provenance labels + `n/a` | ✅ |
+| `E2E_WORKERS` env-table row (L280) | Describes `50%` default on hardware, override semantics, fallback serial | ✅ |
+| "Status and sequencing" (L337–349) | `50%` default + issue references + global-stays-serial explanation | ✅ |
+
+The #41 review follow-up correction (L360–369 of `codev/reviews/41-parallelize-local-e2e-runs.md`) is properly formatted as a dated inline addendum, correctly states the lane-scoped partial delivery, and preserves the global-serial rationale verbatim. It references `codev/reviews/56-gpu-lane-parallel-default.md` for qualification evidence (currently untracked — to be populated during the Review phase, which is correct workflow).
+
+**FR4/FR5 — Frozen files untouched** ✅  
+Verified: `scripts/e2e-workers.mjs`, `tests/e2e-workers.test.mjs`, `playwright.config.ts`, `.github/workflows/validation.yml` all zero-diff across the entire branch.
+
+**FR8 — Re-qualification evidence**: The plan explicitly states this is "captured for the review document (recorded in full during the Review phase)" — operational, not a code deliverable. The code infrastructure to support it (workers log line, additive report `workers:` line) is in place from Phase 2.
+
+### 2. Code Quality
+
+The `scripts/e2e-gpu-lane.mjs` header comment update (L44–47) is clean, concise, and correctly placed after the existing `E2E_GPU_REQUIRE` documentation. The wording accurately describes the relationship: "CONSULTS" (not "owns") E2E_WORKERS, with the scope qualifier "on verified-hardware runs" and the fallback qualification.
+
+No stale claims about workers remain in the file's header — the `suiteEnvFor` doc comment (from Phase 2) already describes the mechanism, so the top-of-file header correctly just summarizes the behavior. The plan's guidance to avoid churn between Phases 2–3 was followed.
+
+### 3. Test Coverage
+
+All 75 `tests/gpu-lane.test.mjs` tests pass. All `tests/e2e-workers.test.mjs` tests pass unmodified. Phase 3 added no new tests (correct — its deliverables are docs, comments, and operational evidence, not new code paths).
+
+### 4. Plan Alignment
+
+Every Phase 3 deliverable from the plan is accounted for:
+- [x] README updates (all five sections)
+- [x] Review 41 dated correction
+- [x] Lane script header comment (single edit, no duplication with Phase 2)
+- [x] Re-qualification evidence infrastructure in place (runs deferred to Review phase per plan)
+- [x] Frozen-file audit clean
+
+### 5. Minor Observations (non-blocking)
+
+- The README's inline `workers:` report snippet (L214) is a nice touch — matches the spec's example format and keeps the documentation self-contained.
+- No stale "serial by default" claims remain about the lane across any doc touched. I spot-checked and every mention of the lane's worker default now correctly says `50%` on hardware.
+
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 docs reconciliation is complete — all five README sections updated, review 41 correction properly scoped, header comment clean, frozen files untouched, tests green.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-codex.txt
@@ -1,0 +1,8 @@
+Using direct file reads to review only phase_3 deliverables and scoped files.Running targeted validation for the scoped phase artifacts.---
+VERDICT: APPROVE
+SUMMARY: Phase 3 is appropriately scoped and complete: docs reflect the lane-only parallel default, prior-review follow-up is reconciled, and the recorded implementation evidence aligns with the phase plan.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter3-gemini.txt
@@ -1,0 +1,7 @@
+---
+VERDICT: APPROVE
+SUMMARY: Phase 3 implementation correctly updates documentation across the README, previous review, and script headers, aligning with the spec and accurately reflecting the new split-default behavior.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-claude.txt
@@ -1,0 +1,69 @@
+I'll review the plan by first verifying the actual codebase state against the plan's claims. Let me read the key files in parallel.Now let me check the existing `suiteEnvFor` tests and the README sections referenced by the plan.I've now read all the key files. Let me complete the review.
+
+## Plan Review: 56-gpu-lane-parallel-default
+
+### 1. Spec Coverage
+
+Every functional requirement maps cleanly to a phase:
+
+| FR | Phase | Coverage |
+|---|---|---|
+| FR1 (hardware default 50%) | 1 | `suiteEnvFor` hardware-branch injection |
+| FR2 (operator override) | 1 | `operatorWorkersSet` guard + passthrough |
+| FR3 (fallback/no-run untouched) | 1 | Injection structurally in hardware branch only |
+| FR4 (CI unaffected) | 1 | Zero-diff on CI files; structural `CI→1` guard |
+| FR5 (plain-suite unchanged) | 1 | Zero-diff on `e2e-workers.mjs`, its tests, `playwright.config.ts` |
+| FR6 (worker visibility) | 2 | Log line + additive report `workers:` line |
+| FR7 (unit coverage) | 1 | Full matrix in the plan deliverables |
+| FR8 (re-qualification) | 3 | Serial baseline + ≥3 green runs |
+| FR9 (docs reconciliation) | 3 | README + #41 review correction |
+
+All six acceptance scenarios are addressed. No phase exceeds spec scope.
+
+### 2. Phase Breakdown
+
+The three-phase linear dependency (`1→2→3`) is the right shape:
+
+- **Phase 1** is the core mechanism: two files, pure `suiteEnvFor` modification, full unit matrix. Independently committable — the lane works with a silent default even without Phase 2's visibility.
+- **Phase 2** adds observability: same two files, additive report line. Independently committable — Phase 1's default still functions if Phase 2 were reverted.
+- **Phase 3** is docs + evidence: ≤3 files of documentation, plus real lane runs that exercise Phases 1+2 together. Correct to be last since it needs the `workers:` report line to capture evidence.
+
+Phase sizes are appropriate — none is trivially small or unmanageably large.
+
+### 3. Technical Approach
+
+I verified the actual code. The plan's approach is structurally sound:
+
+**Injection point is correct.** `suiteEnvFor` (line 635) already branches on `plan.mode === "hardware"` with two sub-branches (Chromium-inclusive at line 638, Firefox-only at line 648) and a separate `software-fallback` branch (line 656). The plan injects `E2E_WORKERS` only in the hardware sub-branches — this is the exact right location. The `composeEnv` spread (`{...baseEnv, ...candidate.env, ...extraEnv}`) already copies the operator's `E2E_WORKERS` into the result, so the guard `operatorWorkersSet(baseEnv)` correctly checks the source env before deciding whether to inject the default.
+
+**No mutation risk.** The env copy semantics are already established — `composeEnv` and `fallbackEnv` both spread `baseEnv`. The new injection follows the same pattern as the existing `env.E2E_ENGINES = engineList` assignments (lines 644, 653, 658).
+
+**`formatReport` change is safe.** The current signature is `{mode, engines, suite, wallClock}` (line 420). Adding `workers` is additive. I count four call sites (probe-only at ~482, skip-empty at ~1179, build-failure at ~1206, success at ~1227) — the plan explicitly accounts for all of them with appropriate values.
+
+**Files correctly identified.** The plan's claim that only `scripts/e2e-gpu-lane.mjs` and `tests/gpu-lane.test.mjs` are modified in Phases 1–2 aligns with the codebase structure. The header comment at lines 621–623 ("workers/retries/timeouts untouched") is correctly targeted for update.
+
+### 4. Testability
+
+The FR7 test matrix is comprehensive and maps directly to existing test patterns. The current `suiteEnvFor` tests (lines 1063–1149 in `gpu-lane.test.mjs`) already assert on env properties like `E2E_ENGINES`, `PW_CHROMIUM_ARGS`, `GALLIUM_DRIVER`, and base-env immutability — the new `E2E_WORKERS` assertions slot in naturally alongside these.
+
+The `workerDecisionFor` helper (Phase 2) is pure and testable. The `formatReport` additive-line test can assert on the `workers:` line while preserving existing verbatim-phrasing assertions — the plan correctly notes this.
+
+### 5. Risk Assessment
+
+The risk table is accurate and complete. The most material risk — fallback parallelization — is addressed by the injection's structural position (hardware branch only) plus a dedicated unit test. The qualification-flake risk is handled by Decision 8's protocol. The CI-leak risk is a non-risk by structure (the `CI→1` guard at line 69 of `e2e-workers.mjs` returns before `E2E_WORKERS` is read).
+
+### 6. Minor Observations
+
+**No issues, but two small notes for the builder:**
+
+1. The `operatorWorkersSet(baseEnv)` helper should check `baseEnv.E2E_WORKERS` specifically (not the post-`composeEnv` result), since candidate envs and `extraEnv` could theoretically shadow it. The plan text says "implements 'operator has set `E2E_WORKERS`' = value exists and is not whitespace-only" which implies checking `baseEnv` — correct, but worth the builder noting when implementing.
+
+2. Phase 2's `workerDecisionFor` reports `{value: "1", provenance: "config serial default"}` for the fallback no-operator case. This is a presentational lie in the sense that the actual `1` comes from `resolveWorkers(env)` in the config, not from the lane — but it's the *right* lie for operator comprehension. The lane knows the fallback env has no injected workers, so it can honestly predict the outcome. No action needed; just documenting the reasoning.
+
+---
+VERDICT: APPROVE
+SUMMARY: Plan is tightly scoped, technically sound against the actual codebase, covers all spec FRs, and the three-phase breakdown gives a builder clear boundaries with independently committable work.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-codex.txt
@@ -1,0 +1,9 @@
+I’m reviewing the plan against the actual repo files so I can verify coverage and file targets rather than relying on the summary alone.I’ve verified the referenced files exist and the current lane/test architecture matches the plan’s target areas. I’m checking a couple more implementation details in the lane script to make sure the phase breakdown lines up with actual call sites.---
+VERDICT: COMMENT
+SUMMARY: Plan is well-aligned to the spec and current codebase; only minor test-coverage clarifications would make execution safer.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- Phase 2 should more explicitly require unit coverage for every `formatReport(...)` call path that will now supply a worker decision (`skip-empty`, build-failure, software-fallback, success, and `--probe-only`/`n/a`). The current script has multiple report call sites in `scripts/e2e-gpu-lane.mjs`, so this is worth naming directly.
+- Phase 3 could be slightly clearer about doc scope in `README.md`: the existing lane section includes a report-format snippet that currently omits a `workers:` line, so that snippet should be called out explicitly, not just the surrounding prose/env-table updates.
+- Minor duplication only: the header-comment update is mentioned in both Phases 2 and 3. That is harmless, but the builder should treat it as one edit to avoid churn.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-plan-iter1-gemini.txt
@@ -1,0 +1,16 @@
+This plan perfectly captures the requirements, boundaries, and technical constraints of Specification 56. The phased approach is well-structured, testable, and accurately identifies the risk factors (e.g., fallback parallelization, CI leakage, and flakes blocking the release). 
+
+A few strong points of this plan:
+1. **Purity and Isolation**: Reusing the existing `suiteEnvFor` to inject `E2E_WORKERS` cleanly satisfies the "no second worker-resolution path" requirement and guarantees CI and the global default stay untouched.
+2. **Honesty in Reporting**: The `workerDecisionFor` and additive `workers:` line in the report correctly handle all edge cases, including skip-empty and probe-only paths, without breaking existing grep consumers.
+3. **Consistency**: Extracting the "operator has set `E2E_WORKERS`" check to a pure helper mirroring `resolveWorkers`' whitespace semantics ensures the two layers cannot diverge.
+
+Everything is solidly aligned with the baked decisions and constraints.
+
+---
+VERDICT: APPROVE
+SUMMARY: The plan thoroughly and accurately implements the hardware-scaled parallel worker default using the exact constraints and verification mechanisms required by the spec.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-claude.txt
@@ -1,0 +1,114 @@
+I'll start by reading the diff and key project files in parallel to understand the full picture.Now let me read the actual implementation files and more of the diff:Let me continue reading the diff for the remaining consultation files and also verify the frozen files:Good — frozen files confirmed zero-diff. Let me read the remaining diff sections (the implementation changes and arch/lessons updates) and run the unit tests:All tests pass (0 failures on both suites). Let me do the final checks — debug code, TODOs, commit format, and branch status:I've now thoroughly reviewed the entire PR. Here's my assessment:
+
+---
+
+## PR #59 Review — [Spec 56] Native-GPU e2e lane defaults to parallel workers
+
+### 1. Completeness
+
+**All spec requirements implemented.** FR1–FR9 are all delivered:
+
+| FR | Status | Verified |
+|---|---|---|
+| FR1 (hardware default 50%) | ✅ | `suiteEnvFor` hardware branch injects `LANE_DEFAULT_WORKERS` for both Chromium-inclusive and Firefox-only arms |
+| FR2 (operator override) | ✅ | `operatorWorkersSet` guard + verbatim passthrough (incl. `"1"`, `"banana"`) |
+| FR3 (fallback untouched) | ✅ | `software-fallback` branch structurally excluded; unit-tested |
+| FR4 (CI unchanged) | ✅ | Zero diff on `validation.yml`; `CI→1` guard structural |
+| FR5 (plain suite unchanged) | ✅ | Zero diff on `e2e-workers.mjs`, `e2e-workers.test.mjs`, `playwright.config.ts` |
+| FR6 (worker visibility) | ✅ | `workerDecisionFor` provenance + additive report line + log line |
+| FR7 (unit coverage) | ✅ | 17 new tests covering the complete FR7 matrix |
+| FR8 (re-qualification) | ✅ | Serial baseline + 3/3 consecutive green; verbatim per-test output |
+| FR9 (docs reconciled) | ✅ | 5 README sections, review 41 correction, report snippet, env table |
+
+**All plan phases complete.** Phase 1 (mechanism), Phase 2 (visibility), Phase 3 (docs/evidence) — all committed.
+
+**Review document exists** at `codev/reviews/56-gpu-lane-parallel-default.md` — comprehensive with evidence, spec compliance, lessons learned.
+
+**Commit format** uses `[Spec 56]` prefix consistently.
+
+### 2. Test Status
+
+- **`tests/gpu-lane.test.mjs`**: **75 tests, 0 failures** — all pass including the 17 new spec-56 tests
+- **`tests/e2e-workers.test.mjs`**: **24 tests, 0 failures** — existing frozen tests unmodified and green
+- No skipped or flaky tests
+- FR8 re-qualification: serial baseline (212s) + 3/3 green parallel (54s/57s/59s, ~3.8× speedup) under `retries: 0`
+
+### 3. Code Quality
+
+The implementation is excellent:
+
+- **`LANE_DEFAULT_WORKERS = "50%"`** — one exported constant, one source of truth
+- **`operatorWorkersSet(baseEnv)`** — pure 2-line function mirroring `resolveWorkers` semantics exactly
+- **`workerDecisionFor(plan, baseEnv)`** — pure provenance reporter with three clean outcomes
+- **`suiteEnvFor` injection** — structurally confined to the `hardware` branch; computed once at branch top; applied identically in both Chromium and Firefox arms; `undefined` sentinel cleanly distinguishes "don't inject" from "inject default"
+- **`formatReport` workers line** — additive only, last position, existing lines unchanged; falsy `workers` gracefully produces `n/a (no suite run)`
+- **Base env immutability preserved** — the spread-copy pattern matches existing `composeEnv`/`fallbackEnv` semantics
+
+No debug code left in. The `console.log` calls are the lane's intentional output mechanism (lane log prefix + report printing). No `TODO`/`FIXME`/`REVIEW` comments needing attention.
+
+### 4. Edge Cases and Error Handling
+
+Thoroughly addressed and unit-tested:
+- Whitespace-only `E2E_WORKERS` treated as unset (default injected)
+- Malformed values (`"banana"`) pass through for fail-loud at config load (`WorkerConfigError`)
+- `E2E_WORKERS=1` forces serial (operator override wins)
+- Software-fallback never receives injected workers
+- Skip-empty / abort never produce a suite env (guarded by throw)
+- Probe-only / skip-empty reports show `workers: n/a (no suite run)`
+- Build-failure report still states what workers the suite *would have* used
+
+### 5. Documentation
+
+- **Review document** (`codev/reviews/56-gpu-lane-parallel-default.md`): comprehensive — what shipped, FR8 evidence table, verbatim per-test appendix (4 runs), spec compliance, arch/lessons routing, retrospective
+- **README**: 5 sections updated, internally consistent, no stale "serial by default" claims about the lane's hardware path
+- **`codev/reviews/41-parallelize-local-e2e-runs.md`**: dated correction accurately describes the lane-scoped partial delivery
+- **`codev/resources/arch.md`**: Validation Baseline paragraph updated with lane-scoped exception
+- **`codev/resources/lessons-learned.md`**: new entry for pnpm env-var leakage
+- **Lane script header comments**: concise, accurate, non-duplicating with Phase 2's `suiteEnvFor` doc comment
+
+### 6. Security Concerns
+
+None. This is a local developer tool with no network exposure. The env variable pass-through follows existing patterns.
+
+### 7. Frozen File Audit
+
+Verified zero diff against `main` for all spec-mandated frozen files:
+- `.github/workflows/validation.yml` ✅
+- `scripts/e2e-workers.mjs` ✅
+- `tests/e2e-workers.test.mjs` ✅
+- `playwright.config.ts` ✅
+- `package.json` / `package-lock.json` ✅
+
+### 8. Minor Observations (non-blocking)
+
+- The diff is large (1973 additions) but this is dominated by consultation artifacts (34 files, ~20 of which are consultation transcripts/rebuttals). The actual code change is **252 lines across 2 files** — well-proportioned.
+- The consultation history shows healthy iteration: codex caught a dangling evidence pointer twice, resulting in the review document being created in-tree earlier than originally planned — a genuine process improvement documented in the lessons learned.
+
+---
+
+```
+---
+VERDICT: APPROVE
+SUMMARY: Cleanly implemented, thoroughly tested (75 + 24 tests green), well-documented feature that makes the native-GPU lane ~4× faster by default on verified hardware while provably preserving the serial CI/SwiftShader gate.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None
+
+PR_SUMMARY: |
+  ## Summary
+  The opt-in native-GPU e2e lane (`npm run test:e2e:gpu`) now defaults to hardware-scaled parallel workers (`E2E_WORKERS=50%`) on verified-hardware runs, delivering a ~3.8× speedup (212s → 54–59s). The SwiftShader canonical/CI gate remains serial and byte-for-byte unchanged. The mechanism is minimal: `suiteEnvFor` injects the default only in the hardware branch unless the operator sets `E2E_WORKERS`; the value flows through the existing `resolveWorkers` machinery — no second worker-resolution path.
+
+  ## Key Changes
+  - `scripts/e2e-gpu-lane.mjs`: `LANE_DEFAULT_WORKERS`, `operatorWorkersSet`, `workerDecisionFor` helpers; `suiteEnvFor` hardware-branch injection; additive `workers:` report line
+  - `tests/gpu-lane.test.mjs`: 17 new unit tests covering the complete FR7 matrix (hardware default, operator override, whitespace-as-unset, fallback isolation, base-env immutability, report visibility across all 5 call paths)
+  - README: 5 sections reconciled to the split-model (lane parallel-by-default, gate serial)
+  - `codev/reviews/41-parallelize-local-e2e-runs.md`: dated follow-up correction (lane-scoped default delivered; global stays serial)
+  - `codev/resources/arch.md` and `lessons-learned.md`: lane-scoped exception documented; pnpm env-var leakage lesson added
+
+  ## Test Plan
+  - Run `node --test tests/gpu-lane.test.mjs` — 75 tests pass (0 failures)
+  - Run `node --test tests/e2e-workers.test.mjs` — 24 tests pass, unmodified (frozen file proof)
+  - Verify frozen files: `git diff main -- .github/workflows/validation.yml scripts/e2e-workers.mjs tests/e2e-workers.test.mjs playwright.config.ts` shows zero diff
+  - FR8 re-qualification: serial baseline (212s, 1 worker) + 3/3 consecutive green plain `npm run test:e2e:gpu` (54s/57s/59s, 10 workers) under `retries: 0`
+```

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-codex.txt
@@ -1,0 +1,25 @@
+---
+VERDICT: COMMENT
+SUMMARY: The implementation looks correct and spec-aligned, with strong targeted coverage; only non-blocking PR-readiness notes are the env-sensitive full `npm test` result in this workspace and several non-standard `chore(porch)` commits.
+CONFIDENCE: MEDIUM
+---
+KEY_ISSUES:
+- `scripts/e2e-gpu-lane.mjs`, `tests/gpu-lane.test.mjs`, README, spec/plan/review, and the #41 follow-up all line up with the intended lane-scoped default: hardware runs inject `E2E_WORKERS=50%`, fallback stays serial, operator overrides pass through, and worker provenance is now visible.
+- Targeted verification passed: `node --test tests/gpu-lane.test.mjs` is green, frozen files remain untouched, and the branch is up to date with `main` (`0 28` divergence).
+- Full `npm test` is not green in this builder environment (`tests/audit-report.test.mjs` and `tests/toolchain.test.mjs` fail), but those files are unchanged in this PR and the review doc already calls out environment-noise/tooling issues; I don’t see evidence that this PR introduced those failures.
+- Commit hygiene note: the branch includes several `chore(porch): ...` commits that do not match the repo’s documented `[Spec 56]` / `[Spec 56][Phase: ...]` convention.
+
+PR_SUMMARY: |
+  ## Summary
+  This PR makes the opt-in native-GPU e2e lane default to hardware-scaled parallel workers on verified hardware only, while leaving the canonical SwiftShader/CI path serial and unchanged. It also adds explicit worker provenance to lane output and updates the docs/evidence to reflect the new lane-scoped default.
+
+  ## Key Changes
+  - Injects `E2E_WORKERS=50%` only for hardware-mode GPU lane runs when the operator has not set `E2E_WORKERS`.
+  - Preserves fallback/plain-suite behavior, reusing the existing worker-resolution path with no changes to CI, `playwright.config.ts`, or `scripts/e2e-workers.mjs`.
+  - Adds unit coverage and lane reporting for worker provenance (`lane default`, `operator override`, `config serial default`), plus README/review updates with qualification evidence.
+
+  ## Test Plan
+  - Run `node --test tests/gpu-lane.test.mjs`
+  - Run `npm run test:e2e:gpu` on verified hardware and confirm `workers: 50% (lane default)`
+  - Run `E2E_WORKERS=1 npm run test:e2e:gpu` and confirm operator override
+  - Run `npm run validate` on a clean checkout / clean env

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-review-iter1-gemini.txt
@@ -1,0 +1,24 @@
+---
+VERDICT: APPROVE
+SUMMARY: The implementation perfectly aligns with the spec and plan, flawlessly injecting the native-GPU parallel workers default while preserving serial fallback and CI untouched.
+CONFIDENCE: HIGH
+---
+KEY_ISSUES:
+- None
+
+PR_SUMMARY: |
+  ## Summary
+  This PR updates the opt-in native-GPU e2e lane (`npm run test:e2e:gpu`) to run with parallel workers (`E2E_WORKERS=50%`) by default on verified hardware, resulting in a ~4× speedup. It correctly preserves the serial behavior for the SwiftShader software fallback path and CI gate, adhering to the strict stability requirements of the test suite.
+
+  ## Key Changes
+  - Modified `suiteEnvFor` to automatically inject `E2E_WORKERS="50%"` for hardware runs when no operator override is present.
+  - Introduced `workerDecisionFor` and updated `formatReport` to explicitly log the effective worker count and its provenance (e.g., `lane default`, `operator override`, `config serial default`) at the end of every lane report.
+  - Updated documentation (README and review logs) to accurately reflect the lane-scoped parallel default and the unmodified global serial default.
+  - Added comprehensive unit test coverage in `gpu-lane.test.mjs` for the new logic, including operator overrides, white-space handling, and report output generation across all execution paths.
+
+  ## Test Plan
+  - **Unit Tests:** `npm run test` or `npm run test:e2e-workers` to ensure the new worker decision and reporting logic behaves correctly and does not negatively impact existing functionality.
+  - **Manual/Integration testing:** 
+    - Run the e2e gpu lane natively without E2E_WORKERS (`npm run test:e2e:gpu`) and observe that it completes approximately 4x faster with `workers: 50% (lane default)` in the report.
+    - Test forcing serial behavior by passing an override (`E2E_WORKERS=1 npm run test:e2e:gpu`) and verify `workers: 1 (operator override)` is used instead.
+    - Test the software fallback path (e.g. `E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu`) and verify it gracefully retains `workers: 1 (config serial default)`.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-claude.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-claude.txt
@@ -1,0 +1,73 @@
+I'll review this spec by reading the key source files it references to verify claims and assess feasibility.Good — I've read the four core source files. Let me also check the README sections the spec references and the `tests/e2e-workers.test.mjs` file to confirm the CI guard claim.I've now read all five referenced source files and the README sections. Here's my review.
+
+---
+
+## Specification Review: 56 — Native-GPU e2e Lane Defaults to Parallel Workers
+
+### 1. Completeness
+
+**Strong.** Every angle is covered — the core mechanism (injecting `E2E_WORKERS` into the hardware-mode suite env), invariants that must hold (CI guard, fallback serial, `resolveWorkers` untouched), testing requirements, documentation, and qualification evidence. The out-of-scope list is explicit and well-chosen.
+
+The nine FRs form a complete contract: FR1 (the core default), FR2 (operator override), FR3 (fallback untouched), FR4 (CI untouched), FR5 (plain-suite untouched), FR6 (observability), FR7 (unit tests), FR8 (re-qualification), FR9 (docs).
+
+### 2. Correctness — verified against the source
+
+I've read every file the spec references. Key claims check out:
+
+- **`suiteEnvFor` already branches on `hardware` vs `software-fallback`** (lines 635–665 of `e2e-gpu-lane.mjs`). Injecting `E2E_WORKERS` into the `hardware` branch, only when not operator-set, is a surgical change — a few lines inside an existing mode branch.
+- **`resolveWorkers` CI guard is structural** (line 69–71 of `e2e-workers.mjs`): `if (env.CI) { return 1; }` returns before `E2E_WORKERS` is read. The spec's claim that a lane-injected value can never leak into CI is correct.
+- **`resolveWorkers` empty/whitespace semantics** (lines 75–91): treats `undefined` and whitespace-only `E2E_WORKERS` as unset, falling to `DEFAULT_LOCAL_WORKERS = 1`. Decision 4's "unset or whitespace-only" mirrors this exactly — the two layers can never disagree about whether an override exists.
+- **The suite subprocess gets the composed env** — `runFullLane` (line 1216–1219) calls `runStage("suite", "npx", ..., suiteEnvFor(plan, process.env))`, so the spawned Playwright process sees the composed env as its `process.env`. An injected `E2E_WORKERS` in `suiteEnvFor`'s return value would be picked up by `resolveWorkers(process.env)` in `playwright.config.ts` (line 124). The mechanism is sound.
+- **`tests/e2e-workers.test.mjs` CI-precedence tests** already prove that `CI=1, E2E_WORKERS="50%"` resolves to `1` (lines 26–32). The spec correctly says this coverage stays green and unmodified.
+- **`formatReport`** (lines 420–429): currently emits `mode`, `engines`, per-engine `renderer.` lines, `suite`, `wall-clock`. Adding a `workers:` line is additive — existing line-prefix greps break on nothing.
+- **README sections** exist at the exact locations referenced (verified via grep).
+
+No contradictions found between the spec's claims and the actual codebase.
+
+### 3. Feasibility
+
+This is a small, well-bounded change:
+- **`suiteEnvFor`**: ~5 lines to check for operator-set `E2E_WORKERS` and inject the default constant.
+- **`formatReport`**: accept and render one additive `workers:` parameter.
+- **`runFullLane`**: a log line for the worker decision + pass the value to `formatReport`.
+- **Tests**: ~6 new test cases in `tests/gpu-lane.test.mjs`, following the existing test-harness patterns.
+- **Docs**: text updates in existing README sections.
+
+The test harness already has the fixture helpers (`chromiumHardwareVerdict`, `suiteEnvFor` tests, etc.) that make the new tests straightforward. No architectural risk.
+
+### 4. Clarity
+
+A builder would know exactly what to build. The spec names the exact function (`suiteEnvFor`), the exact constant name pattern (`LANE_DEFAULT_WORKERS`), the exact value (`'50%'`), the exact test file, and the exact README sections to update. The eight Confirmed Decisions eliminate ambiguity on every fork in the design space.
+
+### 5. Edge Cases and Error Scenarios
+
+Well-covered:
+- **Whitespace-only `E2E_WORKERS`** (Decision 4): treated as unset — default injected.
+- **Malformed `E2E_WORKERS`** (Decision 5, FR2, Scenario 3): passes through to `resolveWorkers`, fails loud. No lane pre-validation.
+- **Operator explicitly sets `E2E_WORKERS=1`** (FR2, Scenario 2): beats the lane default.
+- **Fallback avoids parallelism** (FR3, Scenario 4): hardware branch only.
+- **CI guard** (FR4, Scenario 5): structural — the lane's injection can never break CI.
+- **Probe-only runs**: don't run a suite, so the workers concept doesn't apply (implicit from FR6 scoping "for the suite run").
+
+### 6. Security Considerations
+
+Not applicable — this is a local developer tool with no network exposure, auth, or data handling. The env variable pass-through is the same existing pattern.
+
+### 7. Testing Strategy
+
+FR7's minimum coverage list is comprehensive and maps to the existing test patterns in `tests/gpu-lane.test.mjs`. The re-qualification evidence (FR8) is operationally rigorous.
+
+### 8. Minor Observations (not blocking)
+
+- **Report line placement**: the spec says the `workers:` line is "additive" but doesn't specify its position within the report (after `renderer.*`? before `suite:`?). This is a minor implementation detail the builder can decide — `formatReport` makes the ordering obvious.
+- **Probe-only reports**: FR6 says "the final machine-greppable report" which could be read as including probe-only reports. A probe-only run has no suite workers to report. The builder should probably omit the `workers:` line from probe-only reports, or include it as `workers: n/a (no suite)`. The spec doesn't address this explicitly, but it's a natural inference from "for the suite run."
+
+---
+
+VERDICT: APPROVE
+SUMMARY: Well-scoped, technically precise spec for a minimal injection into existing code; all claims verified against source files, no contradictions found.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None. The two minor observations above (report line placement, probe-only workers line) are implementation details the builder can resolve naturally.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-codex.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-codex.txt
@@ -1,0 +1,8 @@
+I’m checking the referenced project files directly to verify the spec against the actual codebase.I’ve verified the high-level worker/config setup; now I’m checking the lane wrapper and tests around `suiteEnvFor`/reporting to confirm the spec’s assumptions and spot any gaps.I found the relevant `suiteEnvFor` and report code locations; I’m opening those exact sections now to validate the spec’s proposed change surface.---
+VERDICT: APPROVE
+SUMMARY: Spec is complete, technically feasible, and well-aligned with the current lane/worker architecture without risking CI or the SwiftShader gate.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-gemini.txt
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-specify-iter1-gemini.txt
@@ -1,0 +1,14 @@
+---
+VERDICT: APPROVE
+SUMMARY: The specification is exceptionally well-aligned with the existing architecture, precisely scopes the pure configuration change, and correctly maintains the strict boundary between the opt-in lane and the canonical CI gate.
+CONFIDENCE: HIGH
+---
+
+KEY_ISSUES:
+- None.
+
+**Consultant Notes:**
+- **Feasibility:** Injecting `E2E_WORKERS='50%'` within `suiteEnvFor` (for `hardware` mode only) is technically sound. It perfectly leverages the existing `resolveWorkers` parser in `playwright.config.ts` without mutating it.
+- **Gate Safety:** Because `resolveWorkers` structurally returns `1` when `env.CI` is truthy—*before* reading `E2E_WORKERS`—it is impossible for this lane default to leak into CI shards, exactly as the spec asserts.
+- **Edge Cases:** The spec correctly identifies that whitespace-only overrides must be treated as "unset" to maintain parity with `resolveWorkers`'s parsing logic.
+- **Implementation detail (minor):** For paths where no suite is executed (e.g., `--probe-only` or `skip-empty`), the builder will need to ensure the new `workers:` report line gracefully indicates "skipped" (e.g., `workers: skipped (--probe-only)`), similar to how the `suite:` line handles it today. The spec provides sufficient room for the builder to handle this naturally.

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-24T19:08:43.001Z'
+    approved_at: '2026-07-24T19:09:05.722Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:08:43.001Z'
+updated_at: '2026-07-24T19:09:05.722Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,7 +1,7 @@
 id: '56'
 title: make-the-native-gpu-e2e-lane-d
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: phase_1
     title: Lane hardware-mode worker default (mechanism + unit tests)
@@ -11,8 +11,8 @@ plan_phases:
     status: complete
   - id: phase_3
     title: Docs reconciliation and re-qualification evidence
-    status: in_progress
-current_plan_phase: phase_3
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 3
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_3
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:01:25.522Z'
+updated_at: '2026-07-24T20:01:26.907Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -24,47 +24,17 @@ gates:
     approved_at: '2026-07-24T19:14:59.366Z'
   pr:
     status: pending
+    requested_at: '2026-07-24T20:06:45.326Z'
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
-history:
-  - iteration: 1
-    plan_phase: phase_3
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
-  - iteration: 2
-    plan_phase: phase_3
-    build_output: ''
-    reviews:
-      - model: gemini
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-gemini.txt
-      - model: codex
-        verdict: REQUEST_CHANGES
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-codex.txt
-      - model: claude
-        verdict: APPROVE
-        file: >-
-          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
+build_complete: false
+history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:04:12.103Z'
+updated_at: '2026-07-24T20:06:45.327Z'
 pr_history:
   - phase: review
     pr_number: 59
     branch: builder/spir-56
     created_at: '2026-07-24T20:03:37.862Z'
+pr_ready_for_human: true

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,9 +1,18 @@
 id: '56'
 title: make-the-native-gpu-e2e-lane-d
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: phase_1
+    title: Lane hardware-mode worker default (mechanism + unit tests)
+    status: in_progress
+  - id: phase_2
+    title: 'Worker visibility: lane log line and additive report line'
+    status: pending
+  - id: phase_3
+    title: Docs reconciliation and re-qualification evidence
+    status: pending
+current_plan_phase: phase_1
 gates:
   spec-approval:
     status: approved
@@ -21,4 +30,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:14:59.366Z'
+updated_at: '2026-07-24T19:15:29.844Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_3
@@ -62,7 +62,7 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:03:37.862Z'
+updated_at: '2026-07-24T20:04:12.103Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 3
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_3
@@ -62,4 +62,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:01:02.574Z'
+updated_at: '2026-07-24T20:01:25.522Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -62,4 +62,9 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:01:26.907Z'
+updated_at: '2026-07-24T20:03:37.862Z'
+pr_history:
+  - phase: review
+    pr_number: 59
+    branch: builder/spir-56
+    created_at: '2026-07-24T20:03:37.862Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -5,14 +5,14 @@ phase: implement
 plan_phases:
   - id: phase_1
     title: Lane hardware-mode worker default (mechanism + unit tests)
-    status: in_progress
+    status: complete
   - id: phase_2
     title: 'Worker visibility: lane log line and additive report line'
-    status: pending
+    status: in_progress
   - id: phase_3
     title: Docs reconciliation and re-qualification evidence
     status: pending
-current_plan_phase: phase_1
+current_plan_phase: phase_2
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:18:15.968Z'
+updated_at: '2026-07-24T19:19:51.105Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:19:51.105Z'
+updated_at: '2026-07-24T19:22:10.331Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -11,12 +11,13 @@ gates:
     approved_at: '2026-07-24T19:09:05.722Z'
   plan-approval:
     status: pending
+    requested_at: '2026-07-24T19:13:26.139Z'
   pr:
     status: pending
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:10:56.666Z'
+updated_at: '2026-07-24T19:13:26.139Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-07-24T19:08:43.001Z'
   plan-approval:
     status: pending
   pr:
@@ -14,7 +15,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:06:29.654Z'
+updated_at: '2026-07-24T19:08:43.001Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,7 +1,7 @@
 id: '56'
 title: make-the-native-gpu-e2e-lane-d
 protocol: spir
-phase: review
+phase: verify
 plan_phases:
   - id: phase_1
     title: Lane hardware-mode worker default (mechanism + unit tests)
@@ -32,7 +32,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:10:48.160Z'
+updated_at: '2026-07-24T20:11:04.430Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:05:59.483Z'
+updated_at: '2026-07-24T19:06:29.654Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,7 +1,7 @@
 id: '56'
 title: make-the-native-gpu-e2e-lane-d
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:09:05.722Z'
+updated_at: '2026-07-24T19:09:16.667Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 3
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_3
@@ -45,5 +45,21 @@ history:
         verdict: APPROVE
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
+  - iteration: 2
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter2-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:53:33.250Z'
+updated_at: '2026-07-24T20:01:02.574Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_3
@@ -46,4 +46,4 @@ history:
         file: >-
           /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:53:05.030Z'
+updated_at: '2026-07-24T19:53:33.250Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-07-24T19:08:43.001Z'
     approved_at: '2026-07-24T19:09:05.722Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-24T19:13:26.139Z'
+    approved_at: '2026-07-24T19:14:59.366Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:13:26.139Z'
+updated_at: '2026-07-24T19:14:59.366Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,0 +1,20 @@
+id: '56'
+title: make-the-native-gpu-e2e-lane-d
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-24T19:05:59.482Z'
+updated_at: '2026-07-24T19:05:59.483Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -8,11 +8,11 @@ plan_phases:
     status: complete
   - id: phase_2
     title: 'Worker visibility: lane log line and additive report line'
-    status: in_progress
+    status: complete
   - id: phase_3
     title: Docs reconciliation and re-qualification evidence
-    status: pending
-current_plan_phase: phase_2
+    status: in_progress
+current_plan_phase: phase_3
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:22:10.331Z'
+updated_at: '2026-07-24T19:26:06.169Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:15:29.844Z'
+updated_at: '2026-07-24T19:18:15.968Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -23,18 +23,19 @@ gates:
     requested_at: '2026-07-24T19:13:26.139Z'
     approved_at: '2026-07-24T19:14:59.366Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-24T20:06:45.326Z'
+    approved_at: '2026-07-24T20:10:48.159Z'
   verify-approval:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:06:45.327Z'
+updated_at: '2026-07-24T20:10:48.160Z'
 pr_history:
   - phase: review
     pr_number: 59
     branch: builder/spir-56
     created_at: '2026-07-24T20:03:37.862Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:09:16.667Z'
+updated_at: '2026-07-24T19:10:56.666Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -26,8 +26,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /home/user/code/graph-site_root/nextjs-3d-force-graph-impl/.builders/spir-56/codev/projects/56-make-the-native-gpu-e2e-lane-d/56-phase_3-iter1-claude.txt
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:47:52.426Z'
+updated_at: '2026-07-24T19:53:05.030Z'

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T19:26:06.169Z'
+updated_at: '2026-07-24T19:47:52.426Z'

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -24,8 +24,13 @@ found parallel execution destabilizes the timing-sensitive Chromium
 `matrix.spec.ts` camera-settle/drag assertions under SwiftShader CPU contention
 (4–5 of 22 tests fail on every parallel run — the problem is destabilization, not
 slowness), so the **local default is serial too**. Local parallelism is **opt-in**
-via `E2E_WORKERS` (integer or percentage; invalid ⇒ loud `WorkerConfigError`;
-`50%` is ~4× faster and mostly green only on the native-GPU lane). Do not trim the
+via `E2E_WORKERS` (integer or percentage; invalid ⇒ loud `WorkerConfigError`),
+with one lane-scoped exception (spec 56): the native-GPU lane
+(`scripts/e2e-gpu-lane.mjs`) defaults its **verified-hardware** suite runs to
+`E2E_WORKERS=50%` (~4× faster, re-qualified 3/3 green) by injecting the value
+into the suite env unless the operator set one — reusing `resolveWorkers`, so
+the `CI ⇒ 1` pin and fail-loud validation still apply, and the lane's
+software-fallback path keeps the serial default. Do not trim the
 qualified per-test waits. Full and production npm audits are separate evidence: CI validates
 their JSON/original status and uploads them without turning existing advisory
 totals into a zero-findings gate. Contributor commands and artifact names live in

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -94,6 +94,15 @@ gotcha, or constraint.
 
 ## Toolchain and Worktree Hygiene
 
+- A builder shell spawned by a pnpm-launched harness inherits pnpm's
+  `npm_config_*` env vars (notably `npm_config_user_agent=pnpm/...`), which npm
+  treats as config overrides — so `tests/toolchain.test.mjs`'s npm user-agent
+  assertion fails under a bare `npm test` even though the pinned npm is first
+  on PATH. This is the same environment-noise class as the untracked-hooks lint
+  failure below: prove the gate with the pollution stripped
+  (`env -u npm_config_user_agent … npm test`, or unset all `npm_*`/`pnpm_*`/
+  `PNPM_*` vars), never by weakening the toolchain test.
+
 - A local gate failure caused **only** by an untracked builder-harness file
   (e.g. `.claude/hooks/worktree-write-guard.cjs`, which `eslint .` lints but which
   is absent from any `git clone`/`actions/checkout`) is environment noise, not a

--- a/codev/reviews/41-parallelize-local-e2e-runs.md
+++ b/codev/reviews/41-parallelize-local-e2e-runs.md
@@ -357,6 +357,16 @@ pressure.
   revisiting the default; the machinery is already in place, only
   `DEFAULT_LOCAL_WORKERS` would change. (The click-to-focus flake **#34** remains a
   separate open item.)
+  *(Correction, spec 56, 2026-07-24: this follow-up is now **partially
+  delivered, lane-scoped**. Issue #56 shipped a parallel default for the
+  native-GPU lane only — `scripts/e2e-gpu-lane.mjs` injects
+  `E2E_WORKERS=50%` on verified-hardware runs unless the operator sets it,
+  reusing `resolveWorkers` — see issue #56; its qualification evidence
+  (serial baseline + 3/3 consecutive green parallel runs) is recorded in
+  `codev/reviews/56-gpu-lane-parallel-default.md`. The **global**
+  `DEFAULT_LOCAL_WORKERS` remains `1`, exactly for the reasons above: the
+  deterministic Chromium SwiftShader parallel contention is unsolved, CI is
+  GPU-less and hard-pinned to `workers: 1`, and the lane is never the gate.)*
 - Consider a convenience script (e.g. `test:smoke:parallel`) if opt-in parallel on
   the GPU lane becomes a common local workflow.
 

--- a/codev/reviews/56-gpu-lane-parallel-default.md
+++ b/codev/reviews/56-gpu-lane-parallel-default.md
@@ -1,0 +1,173 @@
+# Review 56 — Make the native-GPU e2e lane default to parallel workers
+
+**Status**: implementation complete; FR8 re-qualification evidence recorded
+below. Lessons learned and the final retrospective are added during the SPIR
+Review phase before the PR opens.
+
+## What shipped
+
+- `scripts/e2e-gpu-lane.mjs`: on **verified-hardware** runs the lane now
+  defaults the suite to `E2E_WORKERS=50%` (`LANE_DEFAULT_WORKERS`), unless the
+  operator set a non-whitespace `E2E_WORKERS` (`operatorWorkersSet`), reusing
+  the existing `resolveWorkers` machinery — no second worker-resolution path.
+  The software-fallback branch keeps the config's serial default; the absolute
+  `CI → workers: 1` guard is untouched and wins last.
+- Visibility (FR6): `workerDecisionFor` provenance ("lane default" /
+  "operator override" / "config serial default"), one additive trailing
+  `workers:` report line (probe-only / skip-empty read `n/a (no suite run)`),
+  and a lane log line before the suite stage.
+- Docs (FR9): README lane section/parallelism note/env table/report snippet
+  reconciled; dated correction in
+  `codev/reviews/41-parallelize-local-e2e-runs.md` (lane-scoped default
+  delivered; the global default stays serial).
+- Frozen files untouched (FR4/FR5): `.github/workflows/validation.yml`,
+  `scripts/e2e-workers.mjs`, `tests/e2e-workers.test.mjs`,
+  `playwright.config.ts`, `package.json`, lockfile.
+
+## FR8 re-qualification evidence (2026-07-24)
+
+Host: 20-core WSL2 + NVIDIA RTX 3080, Mesa d3d12 recipe. All runs
+`mode: hardware`, both engines verified
+(`renderer.chromium: ANGLE (Microsoft Corporation, D3D12 (NVIDIA GeForce RTX
+3080), OpenGL 4.6)`, `renderer.firefox: D3D12 (NVIDIA GeForce RTX 3080)`),
+`retries: 0`, exit 0, 22/22 tests passed per run.
+
+| Run | Command | Workers (report) | Suite | Wall clock |
+| --- | --- | --- | --- | --- |
+| Serial baseline | `E2E_WORKERS=1 npm run test:e2e:gpu` | `1 (operator override)` | 22 passed (3.3m) | 212s (build 10s, suite 200s) |
+| Parallel 1/3 | `npm run test:e2e:gpu` (no `E2E_WORKERS`) | `50% (lane default)` — 10 workers | 22 passed (42.2s) | 54s (build 10s, suite 43s) |
+| Parallel 2/3 | `npm run test:e2e:gpu` (no `E2E_WORKERS`) | `50% (lane default)` — 10 workers | 22 passed (44.1s) | 57s (build 10s, suite 45s) |
+| Parallel 3/3 | `npm run test:e2e:gpu` (no `E2E_WORKERS`) | `50% (lane default)` — 10 workers | 22 passed (46.2s) | 59s (build 10s, suite 47s) |
+
+3/3 consecutive green under the plain lane default — ~3.8× faster than the
+serial baseline. Scenario 3 spot check: `E2E_WORKERS=banana` exits 1 with a
+loud `WorkerConfigError` at config load; the lane log/report honestly show
+`workers: banana (operator override)`.
+
+Validation gate: proved green on a clean detached checkout
+(`git worktree add --detach HEAD` + real `npm ci`): lint, typecheck, and the
+serial SwiftShader `test:smoke` (22 passed, 1 worker) — the canonical gate
+remains serial and untouched.
+
+## Per-test appendix (verbatim Playwright list-reporter output)
+
+### serial-baseline
+```
+✓ Compiled successfully in 2.8s
+✓ Generating static pages using 5 workers (4/4) in 296ms
+Running 22 tests using 1 worker
+  ✓   1 [chromium] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (2.6s)
+  ✓   2 [chromium] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (7.7s)
+  ✓   3 [chromium] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (6.9s)
+  ✓   4 [chromium] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (8.6s)
+  ✓   5 [chromium] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (15.5s)
+  ✓   6 [chromium] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (17.6s)
+  ✓   7 [chromium] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (4.6s)
+  ✓   8 [chromium] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (4.0s)
+  ✓   9 [chromium] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (2.9s)
+  ✓  10 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (17.9s)
+  ✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (6.9s)
+  ✓  12 [firefox] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (2.9s)
+  ✓  13 [firefox] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (8.0s)
+  ✓  14 [firefox] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (7.4s)
+  ✓  15 [firefox] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (9.1s)
+  ✓  16 [firefox] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (14.5s)
+  ✓  17 [firefox] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (18.1s)
+  ✓  18 [firefox] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (4.8s)
+  ✓  19 [firefox] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (4.3s)
+  ✓  20 [firefox] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (2.9s)
+  ✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (21.0s)
+  ✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (8.8s)
+  22 passed (3.3m)
+```
+
+### parallel-1
+```
+✓ Compiled successfully in 2.4s
+✓ Generating static pages using 5 workers (4/4) in 305ms
+Running 22 tests using 10 workers
+  ✓   1 [chromium] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (3.8s)
+  ✓  10 [chromium] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (5.5s)
+  ✓   8 [chromium] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (5.7s)
+  ✓   4 [chromium] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (6.5s)
+  ✓   6 [chromium] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (9.0s)
+  ✓   5 [chromium] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (9.1s)
+  ✓   2 [chromium] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (12.0s)
+  ✓  13 [firefox] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (5.3s)
+  ✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (10.5s)
+  ✓   3 [chromium] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (17.9s)
+  ✓  14 [firefox] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (10.9s)
+  ✓  12 [firefox] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (16.2s)
+  ✓   9 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (25.1s)
+  ✓  18 [firefox] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (11.2s)
+  ✓   7 [chromium] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (25.4s)
+  ✓  16 [firefox] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (14.8s)
+  ✓  20 [firefox] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (7.2s)
+  ✓  19 [firefox] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (11.8s)
+  ✓  15 [firefox] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (17.7s)
+  ✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (10.5s)
+  ✓  17 [firefox] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (23.4s)
+  ✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (21.8s)
+  22 passed (42.2s)
+```
+
+### parallel-2
+```
+✓ Compiled successfully in 2.6s
+✓ Generating static pages using 5 workers (4/4) in 350ms
+Running 22 tests using 10 workers
+  ✓   7 [chromium] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (4.5s)
+  ✓   3 [chromium] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (5.1s)
+  ✓   2 [chromium] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (6.1s)
+  ✓   6 [chromium] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (7.8s)
+  ✓  10 [chromium] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (8.6s)
+  ✓   1 [chromium] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (9.2s)
+  ✓   9 [chromium] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (12.3s)
+  ✓  12 [firefox] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (6.8s)
+  ✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (11.4s)
+  ✓   8 [chromium] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (17.4s)
+  ✓  14 [firefox] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (11.2s)
+  ✓  13 [firefox] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (15.5s)
+  ✓   4 [chromium] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (23.7s)
+  ✓   5 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (24.1s)
+  ✓  18 [firefox] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (10.5s)
+  ✓  15 [firefox] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (14.7s)
+  ✓  19 [firefox] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (7.8s)
+  ✓  20 [firefox] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (7.5s)
+  ✓  16 [firefox] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (18.5s)
+  ✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (11.0s)
+  ✓  17 [firefox] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (23.7s)
+  ✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (21.8s)
+  22 passed (44.1s)
+```
+
+### parallel-3
+```
+✓ Compiled successfully in 2.5s
+✓ Generating static pages using 5 workers (4/4) in 302ms
+Running 22 tests using 10 workers
+  ✓   9 [chromium] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (4.5s)
+  ✓   3 [chromium] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (4.9s)
+  ✓   5 [chromium] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (5.2s)
+  ✓   1 [chromium] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (7.0s)
+  ✓   8 [chromium] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (9.6s)
+  ✓   2 [chromium] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (9.9s)
+  ✓  12 [firefox] › tests/e2e/matrix.spec.ts:76:5 › settles an initial force layout with positioned nodes (6.4s)
+  ✓   7 [chromium] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (13.0s)
+  ✓  11 [chromium] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (11.9s)
+  ✓   4 [chromium] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (19.0s)
+  ✓  14 [firefox] › tests/e2e/matrix.spec.ts:135:5 › keeps pointer navigation inert until the enable delay elapses (11.4s)
+  ✓  13 [firefox] › tests/e2e/matrix.spec.ts:105:5 › rotates the camera automatically until paused, then resumes (17.7s)
+  ✓  10 [chromium] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (27.2s)
+  ✓   6 [chromium] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (28.2s)
+  ✓  15 [firefox] › tests/e2e/matrix.spec.ts:195:5 › zooms out with the wheel (16.9s)
+  ✓  18 [firefox] › tests/e2e/matrix.spec.ts:478:5 › toggles AxesHelper visibility through the axes control (14.8s)
+  ✓  20 [firefox] › tests/e2e/matrix.spec.ts:572:5 › remounts a fresh working canvas on re-navigation (9.8s)
+  ✓  19 [firefox] › tests/e2e/matrix.spec.ts:511:5 › keeps the canvas consistent and interactive across a resize (12.5s)
+  ✓  16 [firefox] › tests/e2e/matrix.spec.ts:225:5 › zooms in with the wheel and rotates with a background drag (20.2s)
+  ✓  22 [firefox] › tests/e2e/smoke.spec.ts:78:5 › renders the graph and exercises its core controls (11.8s)
+  ✓  17 [firefox] › tests/e2e/matrix.spec.ts:314:5 › click-to-focus fixes the node, animates the camera, and reset restores the view (24.2s)
+  ✓  21 [firefox] › tests/e2e/right-click-release.spec.ts:174:5 › right-clicking a fixed node releases its fx/fy/fz (24.7s)
+  22 passed (46.2s)
+```
+

--- a/codev/reviews/56-gpu-lane-parallel-default.md
+++ b/codev/reviews/56-gpu-lane-parallel-default.md
@@ -180,7 +180,7 @@ lockfile; `CI ⇒ 1` guard structurally unreachable by the lane default), FR6
 (provenance log + additive report line), FR7 (unit matrix), FR8 (evidence
 above), FR9 (docs reconciled). No new dependencies; no lockfile movement.
 
-## Architecture documentation updates
+## Architecture Updates
 
 - `codev/resources/arch.md` (Validation Baseline): the "local parallelism is
   opt-in" paragraph now records the lane-scoped exception — the native-GPU
@@ -191,7 +191,7 @@ above), FR9 (docs reconciled). No new dependencies; no lockfile movement.
   contracts; the existing hot entries (validate gate, environment-noise
   lesson) already cover what matters at decision time.
 
-## Lessons learned updates
+## Lessons Learned Updates
 
 - `codev/resources/lessons-learned.md` (Toolchain and Worktree Hygiene): new
   entry — a pnpm-launched harness leaks `npm_config_*` env vars (notably
@@ -199,7 +199,7 @@ above), FR9 (docs reconciled). No new dependencies; no lockfile movement.
   user-agent test under a bare `npm test`; prove the gate with the pollution
   stripped, never by weakening the test.
 
-## Lessons learned (narrative)
+## Lessons Learned
 
 - **What went well**: the #41 `resolveWorkers` contract made the change tiny —
   the lane only decides *whether to set* `E2E_WORKERS`; validation, CI

--- a/codev/reviews/56-gpu-lane-parallel-default.md
+++ b/codev/reviews/56-gpu-lane-parallel-default.md
@@ -171,3 +171,53 @@ Running 22 tests using 10 workers
   22 passed (46.2s)
 ```
 
+## Spec compliance
+
+All spec FRs delivered: FR1–FR3 (hardware-arm-only injection, operator
+pass-through incl. forcing serial, whitespace-as-unset), FR4/FR5 (frozen files
+untouched — `validation.yml`, `e2e-workers.mjs`, `playwright.config.ts`,
+lockfile; `CI ⇒ 1` guard structurally unreachable by the lane default), FR6
+(provenance log + additive report line), FR7 (unit matrix), FR8 (evidence
+above), FR9 (docs reconciled). No new dependencies; no lockfile movement.
+
+## Architecture documentation updates
+
+- `codev/resources/arch.md` (Validation Baseline): the "local parallelism is
+  opt-in" paragraph now records the lane-scoped exception — the native-GPU
+  lane defaults verified-hardware runs to `E2E_WORKERS=50%` via env injection,
+  reusing `resolveWorkers` (CI pin and fail-loud validation intact).
+- Hot tier (`arch-critical.md` / `lessons-critical.md`): no changes — the
+  facts are lane-scoped reference detail, not behavior-changing cross-cutting
+  contracts; the existing hot entries (validate gate, environment-noise
+  lesson) already cover what matters at decision time.
+
+## Lessons learned updates
+
+- `codev/resources/lessons-learned.md` (Toolchain and Worktree Hygiene): new
+  entry — a pnpm-launched harness leaks `npm_config_*` env vars (notably
+  `npm_config_user_agent`) into builder shells, falsely failing the toolchain
+  user-agent test under a bare `npm test`; prove the gate with the pollution
+  stripped, never by weakening the test.
+
+## Lessons learned (narrative)
+
+- **What went well**: the #41 `resolveWorkers` contract made the change tiny —
+  the lane only decides *whether to set* `E2E_WORKERS`; validation, CI
+  pinning, and scaling all stayed in one place. The pure `suiteEnvFor` /
+  `formatReport` layers made every behavior unit-testable without spawning
+  browsers. Qualification was clean: 3/3 green first attempt (the #55 fix
+  held), ~3.8× speedup confirmed.
+- **What was challenging**: environment noise, twice — pnpm env-var leakage
+  failing the toolchain test, and the known untracked-hooks lint failure —
+  both resolved by proving gates on clean/stripped environments per the
+  established lesson rather than touching committed config. Reviewer iteration
+  (codex, twice) centered on a dangling evidence pointer; resolved by creating
+  the evidence artifact in-tree instead of forward-referencing it.
+- **Do differently**: create the review/evidence document at the moment the
+  evidence is produced (Phase 3), not in the Review phase — reviewers rightly
+  reject references to files that don't exist yet.
+
+## Flaky Tests
+
+None encountered; no tests skipped. All qualification runs were green with
+`retries: 0`.

--- a/codev/specs/56-gpu-lane-parallel-default.md
+++ b/codev/specs/56-gpu-lane-parallel-default.md
@@ -1,0 +1,380 @@
+# Specification 56: Native-GPU e2e Lane Defaults to Parallel Workers (SwiftShader Gate Stays Serial)
+
+## Summary
+
+Make the opt-in native-GPU e2e lane (`npm run test:e2e:gpu`, driven by
+`scripts/e2e-gpu-lane.mjs`) default to **hardware-scaled parallel workers**
+(`E2E_WORKERS='50%'`) on its **verified-hardware suite runs only**, while the
+SwiftShader canonical/CI gate stays **serial and byte-for-byte unchanged**.
+
+Issue #41 shipped serial-default + opt-in-parallel (`DEFAULT_LOCAL_WORKERS = 1`)
+because parallel workers deterministically destabilize the SwiftShader path
+(4–5 of 22 tests fail on **every** parallel SwiftShader run — CPU contention,
+not flakiness). On hardware WebGL that rationale evaporates: rendering is off
+the CPU, and #41's own qualification ran the two-engine lane at 10 workers
+~4.3× faster. The sole parallel failure back then — the Firefox background-drag
+flake — is now **fixed and re-qualified green 3/3 in the exact
+`E2E_WORKERS=50%` two-engine parallel regime** (issue #55, closed 2026-07-24;
+evidence in `codev/reviews/55-firefox-background-drag-flake.md`, FR6). The
+blocker named in issue #56 is therefore resolved, and the lane's parallel
+default is realizable.
+
+The mechanism is deliberately small: the lane wrapper injects
+`E2E_WORKERS='50%'` into the **hardware** suite environment when the operator
+has not set `E2E_WORKERS` themselves. The value then flows through the existing
+`resolveWorkers` machinery (`scripts/e2e-workers.mjs`) untouched — no second
+worker-resolution path, no change to `resolveWorkers`, its tests, or
+`playwright.config.ts`'s `workers:` line.
+
+### Why this is worth building
+
+- The two-engine hardware lane is ~4× faster parallel (~4–5 min vs ~18 min on
+  the qualified host class) and is now proven flake-free in that regime
+  (#55 FR6, green 3/3). Making the fast path the default removes a footgun:
+  today a plain `npm run test:e2e:gpu` silently runs 4× slower than the lane's
+  qualified capability.
+- It delivers the #41 review's "revisit the default" follow-up in the only
+  scope where it is deliverable: the *lane-scoped* default. The *global*
+  serial default must stay (SwiftShader parallel contention is unsolved, CI
+  has no GPU, hardware is not reproducible, and "the lane is never the gate"
+  is a Baked Decision — #44 Decision 1, #52 Decision 1).
+
+## Problem Analysis
+
+### Current state
+
+- `playwright.config.ts` sets `workers: resolveWorkers(process.env)`.
+  `resolveWorkers` (pure, unit-tested in `tests/e2e-workers.test.mjs`)
+  resolves: (1) `CI` truthy ⇒ `1`, structurally before reading anything else;
+  (2) `E2E_WORKERS` override — positive integer or percentage, malformed ⇒
+  loud `WorkerConfigError`; (3) default `DEFAULT_LOCAL_WORKERS = 1`.
+- `scripts/e2e-gpu-lane.mjs` probes per-engine hardware, then runs build +
+  one Playwright suite invocation with an env composed by `suiteEnvFor(plan,
+  baseEnv)`. The suite env starts from the pristine inherited env, so an
+  operator's `E2E_WORKERS` already passes through — the lane is parallelizable
+  today, but **only** by explicit opt-in.
+- `suiteEnvFor` already branches on run mode: `hardware` (injects the verified
+  recipe env + `E2E_ENGINES`), `software-fallback` (SwiftShader defaults,
+  Chromium-only), and guards `skip-empty`/`abort` (no suite runs).
+
+### Desired state
+
+- A plain `npm run test:e2e:gpu` that verifies hardware runs the suite with
+  `E2E_WORKERS='50%'` (hardware-scaled; 10 workers on the qualified 20-core
+  host class).
+- A lane run that **falls back to SwiftShader keeps the serial default** — the
+  exact regime that deterministically fails 4–5/22 in parallel must never
+  become a parallel default through the lane's back door.
+- Operator control is unchanged: `E2E_WORKERS` still overrides on the lane
+  (including `E2E_WORKERS=1` to force serial for diagnostics), and malformed
+  values still fail loud via `WorkerConfigError` at config load.
+- CI and the plain SwiftShader suite (`npm run validate`, `test:smoke`) are
+  byte-for-byte unaffected.
+
+### Stakeholders
+
+- **Developers running the lane** get the qualified fast path by default.
+- **The green gate** (`npm run validate`, CI) must be provably untouched.
+- **Future qualification work** (FR9-style evidence) needs runs that
+  self-document their worker count.
+
+## Confirmed Decisions
+
+1. **Lane-wrapper default, not a `resolveWorkers` hardware signal.** The issue
+   allows either. Selected: `scripts/e2e-gpu-lane.mjs` defaults `E2E_WORKERS`
+   in the suite env it composes. Rejected: having `resolveWorkers` key off
+   lane-recipe env (`GALLIUM_DRIVER`, `PW_CHROMIUM_ARGS`) — those keys can
+   legitimately exist in an operator's shell for unrelated reasons, it would
+   couple the pure worker module to lane-recipe internals, and it would break
+   the config's simple contract ("reads only `CI` and `E2E_WORKERS`"). The
+   lane already owns the "is this verified hardware?" decision; the default
+   belongs where the knowledge lives.
+2. **The parallel default applies to `hardware`-mode suite runs only** —
+   including two-engine, Chromium-only, and Firefox-only hardware runs. The
+   `software-fallback` suite env gets **no injected default** (an operator's
+   explicit `E2E_WORKERS` still passes through to fallback, exactly as
+   today — explicit opt-in remains the operator's call and stays honest).
+3. **Default value is the string `'50%'`** — the same hardware-relative value
+   #41 recommended and #55 re-qualified. Exported as a named constant (e.g.
+   `LANE_DEFAULT_WORKERS`) so tests and docs reference one value.
+4. **"Operator has not set `E2E_WORKERS`" means unset or whitespace-only**,
+   mirroring `resolveWorkers`'s own unset/empty semantics so the two layers
+   can never disagree about whether an override exists.
+5. **No pre-validation in the lane.** A malformed `E2E_WORKERS` passes through
+   and fails loud at config load (`WorkerConfigError`) — `resolveWorkers`
+   remains the single validation source of truth.
+6. **`scripts/e2e-workers.mjs` is not in the diff.** `DEFAULT_LOCAL_WORKERS`
+   stays `1`; `resolveWorkers` and `tests/e2e-workers.test.mjs` are untouched.
+   The CI guard therefore remains structural: even with the lane's injected
+   `E2E_WORKERS`, a truthy `CI` resolves to `1` before `E2E_WORKERS` is read.
+7. **Workers become visible in lane output.** The lane logs the effective
+   worker decision (defaulted vs. operator-set vs. fallback-serial), and the
+   machine-greppable final report gains one **additive** `workers:` line so
+   qualification evidence is self-documenting. Existing report lines keep
+   their stable phrasing (spec 52 FR10 consumers grep by line prefix; an
+   added line breaks none of them).
+8. **Ship only on green re-qualification.** The parallel default does not
+   merge without ≥3 consecutive green parallel two-engine lane runs under the
+   *new default path itself* (plain `npm run test:e2e:gpu`, no `E2E_WORKERS`),
+   plus a serial-lane baseline for comparison. If a new flake surfaces (e.g.
+   the #34/#58 click-to-focus family), the default must not ship — the change
+   reverts to opt-in and the flake gets its own issue.
+
+## Scope
+
+### In scope
+
+- `scripts/e2e-gpu-lane.mjs`: inject the `E2E_WORKERS='50%'` default into the
+  hardware-mode suite env (pure change inside/alongside `suiteEnvFor`);
+  workers log line + additive report line; header-comment updates.
+- `tests/gpu-lane.test.mjs`: unit coverage of the new default semantics.
+- Re-qualification evidence (serial baseline + ≥3 green parallel default
+  runs) recorded in the review document.
+- Documentation: README ("Opt-in native-GPU e2e lane" section, the "Local
+  test parallelism" note, the lane env-var table row for `E2E_WORKERS`);
+  reconcile the #41 review's "Revisiting the serial default" follow-up item
+  (this delivers the lane-scoped default; the global default remains blocked
+  on SwiftShader contention).
+
+### Out of scope (non-goals)
+
+- Changing `DEFAULT_LOCAL_WORKERS`, `resolveWorkers`, or anything in
+  `scripts/e2e-workers.mjs` / `tests/e2e-workers.test.mjs`.
+- Touching `.github/workflows/validation.yml` or any CI behavior.
+- Changing the plain suite / `npm run validate` / `test:smoke` defaults.
+- Solving the SwiftShader parallel-contention failures (the standing global
+  blocker — #41 review Follow-up Items).
+- A `test:smoke:parallel` convenience script (#41 review follow-up; separate).
+- New dependencies, lockfile, or toolchain movement.
+- Weakening or retuning any canonical assertion; changing `retries: 0`.
+
+## Constraints and Invariants
+
+- **CI byte-for-byte unchanged**: `.github/workflows/validation.yml` not in
+  the diff; the absolute `CI → workers: 1` guard stays structural (a lane
+  default can never parallelize a CI shard, even hypothetically, because
+  `resolveWorkers` returns before reading `E2E_WORKERS`).
+- **Canonical serial gate unchanged**: SwiftShader `npm run validate` /
+  `test:smoke` remain serial by default; the lane's **fallback** path also
+  remains serial by default (Decision 2).
+- **`E2E_WORKERS` override precedence on the lane**: any operator-set value —
+  including `1` — beats the lane default; invalid values fail loud
+  (`WorkerConfigError`), never silently.
+- **Local `retries: 0` preserved**; flakes never masked; canonical assertions
+  never weakened.
+- **Reproducibility contract**: exact Node/npm from `package.json`/`.nvmrc`,
+  lockfile v3, `npm ci`; no new dependencies.
+- **The lane is never the gate** (Baked Decision, #44/#52): nothing here may
+  be cited as, or wired into, the green gate.
+
+## Solution Exploration
+
+### Approach A: `resolveWorkers` detects a lane signal
+
+Have `resolveWorkers` return a scaled value when lane-recipe env
+(`GALLIUM_DRIVER`, `PW_CHROMIUM_ARGS`) is present. Rejected (Decision 1):
+false-positive prone (those keys are not lane-exclusive), couples the pure
+module to lane internals, complicates the config contract, and forces changes
+to a module this issue explicitly wants untouched.
+
+### Approach B: Lane wrapper defaults `E2E_WORKERS` in the hardware suite env (selected)
+
+`suiteEnvFor` already knows the run mode and composes the suite env from a
+pristine base. Injecting `E2E_WORKERS = '50%'` there — only for `hardware`
+mode, only when the operator hasn't set it — is a few lines, pure,
+unit-testable with the existing test harness, and reuses `resolveWorkers`
+end-to-end (the injected value is resolved, validated, and CI-guarded by the
+exact same code as an operator export).
+
+### Approach C: Flip the global default (`DEFAULT_LOCAL_WORKERS = '50%'`)
+
+Rejected — restated for the record (issue #56 "Why not…" section, #41 review
+follow-up): the SwiftShader gate deterministically fails 4–5/22 parallel; CI
+has no GPU (Firefox cannot create a WebGL context on GitHub runners; the
+Kaggle GPU-CI path was rejected on AUP grounds, #42); hardware WebGL is
+probed, evidence-dated, and not reproducible; the lane is never the gate.
+
+## Functional Requirements
+
+### FR1 — Hardware lane runs default to hardware-scaled parallel workers
+
+When the lane's run plan is `hardware` (two-engine, Chromium-only, or
+Firefox-only) and the inherited env has no operator-set `E2E_WORKERS`
+(unset or whitespace-only), the suite env composed by the lane MUST contain
+`E2E_WORKERS` set to the exported lane default constant (`'50%'`). The value
+MUST flow through the existing `resolveWorkers` path — no second
+worker-resolution mechanism anywhere in the diff.
+
+### FR2 — Operator override fully preserved
+
+An operator-set `E2E_WORKERS` (integer, percentage, or `1` to force the lane
+serial for diagnostics) MUST pass through unchanged and beat the lane default.
+A malformed value MUST still fail loud with `WorkerConfigError` at config
+load; the lane MUST NOT pre-validate or rewrite it (single source of truth).
+
+### FR3 — Fallback and no-run paths untouched
+
+The `software-fallback` suite env MUST NOT contain a lane-injected
+`E2E_WORKERS` (operator passthrough only, exactly today's behavior), so a
+SwiftShader fallback run stays serial by default. `skip-empty` and `abort`
+run no suite and remain guarded as today.
+
+### FR4 — CI provably unaffected
+
+`.github/workflows/validation.yml` MUST NOT appear in the diff. The existing
+structural guard (CI resolves to `1` before `E2E_WORKERS` is read) MUST be
+called out in the review as the reason a lane default cannot leak into CI;
+existing `tests/e2e-workers.test.mjs` coverage already proves it and MUST
+remain green and unmodified.
+
+### FR5 — Plain-suite defaults unchanged
+
+`scripts/e2e-workers.mjs` (including `DEFAULT_LOCAL_WORKERS = 1`),
+`tests/e2e-workers.test.mjs`, and the `workers:` wiring in
+`playwright.config.ts` MUST be unchanged. `npm run validate` and `test:smoke`
+MUST remain serial by default and green.
+
+### FR6 — Worker visibility in lane output
+
+The lane MUST log the effective worker decision for the suite run (lane
+default applied / operator override honored / fallback serial default) and
+MUST add one additive `workers: <value> (<provenance>)` line to the final
+machine-greppable report. All existing report lines keep their stable
+phrasing verbatim.
+
+### FR7 — Unit coverage of the default semantics
+
+`tests/gpu-lane.test.mjs` MUST cover at minimum: hardware two-engine run
+injects the default; Firefox-only hardware run injects the default; operator
+`E2E_WORKERS=4` and `E2E_WORKERS=1` pass through un-overridden; whitespace-only
+`E2E_WORKERS` is treated as unset (default injected); software-fallback env
+has no injected `E2E_WORKERS` while operator passthrough is preserved; the
+base env is never mutated.
+
+### FR8 — Re-qualification evidence under the new default
+
+Recorded in the review, FR9-style (#41): (a) one serial-lane baseline
+(`E2E_WORKERS=1 npm run test:e2e:gpu`) with per-test results and wall clock;
+(b) **≥3 consecutive green** parallel two-engine lane runs invoked as a plain
+`npm run test:e2e:gpu` (no `E2E_WORKERS` in the env — the default path itself
+is what qualifies), each report showing the `workers:` line and hardware
+renderers for both engines. Any non-green run resets the consecutive count
+and, if a genuine flake, blocks shipping the default (Decision 8).
+
+### FR9 — Documentation reconciled
+
+README updates: the "Opt-in native-GPU e2e lane" section states the lane is
+parallel-by-default on verified hardware, tunable/serial via `E2E_WORKERS`,
+and serial on software fallback; the "Local test parallelism" note and the
+lane's `E2E_WORKERS` env-table row are updated to match. The #41 review's
+"Revisiting the serial default" follow-up gains a dated correction noting the
+lane-scoped parallel default shipped here, while the **global** default
+remains serial, still blocked on SwiftShader parallel contention. Header
+comments in `scripts/e2e-gpu-lane.mjs` are updated where they describe worker
+behavior.
+
+## Non-Functional Requirements
+
+### Behavior preservation
+
+Every non-lane path byte-identical in behavior: CI, `npm run validate`,
+`test:smoke`, plain `npx playwright test`. Within the lane, probe logic,
+candidate lifecycle, fallback semantics, engine gating, and exit codes are
+unchanged — only the suite env's worker default (hardware mode) and the
+output lines change.
+
+### Evidence honesty
+
+Qualification runs are evidence-dated and host-class-specific, like the lane
+recipe itself. A fallback run's serial default and a hardware run's parallel
+default must both be visible in output (FR6) so no transcript can be
+misread.
+
+### Reproducibility
+
+No dependency, lockfile, or toolchain movement. `npm run validate` green on
+the exact pinned toolchain via `npm ci`.
+
+### Maintainability
+
+The default lives in one exported constant next to the code that applies it;
+`resolveWorkers` remains the only validation/resolution logic.
+
+## Risks and Mitigations
+
+- **Host variance**: parallel qualification holds on the qualified host class
+  (20-core WSL2 + RTX 3080, Mesa d3d12), not universally. Mitigation: the
+  default is hardware-relative (`50%`), the lane already only applies it on
+  *verified* hardware, `E2E_WORKERS=1` remains a one-variable escape hatch,
+  and docs state the evidence-dated nature.
+- **A latent flake surfaces under the parallel default** (e.g. the #34/#58
+  click-to-focus family): Decision 8 — do not ship; revert to opt-in; file or
+  link the flake issue. `retries: 0` guarantees it stays visible.
+- **Accidental fallback parallelism** (the SwiftShader 4–5/22 failure mode):
+  structurally prevented by injecting only in the `hardware` branch (FR3) and
+  covered by unit tests (FR7).
+- **Report-format consumers**: the `workers:` line is additive only; existing
+  line phrasing is untouched (Decision 7).
+
+## Acceptance Scenarios
+
+### Scenario 1 — Plain lane run on verified hardware
+
+`npm run test:e2e:gpu` on the qualified host: both engines verify hardware,
+the suite runs with `E2E_WORKERS=50%` (10 workers on the 20-core host), all
+tests green, and the report shows `mode: hardware`, both hardware renderer
+lines, and `workers: 50% (lane default)` (exact phrasing per implementation).
+
+### Scenario 2 — Operator forces the lane serial
+
+`E2E_WORKERS=1 npm run test:e2e:gpu`: hardware run executes serially; report
+shows the operator-provided value.
+
+### Scenario 3 — Malformed override still fails loud
+
+`E2E_WORKERS=banana npm run test:e2e:gpu`: the suite invocation fails at
+config load with `WorkerConfigError`; the lane surfaces the non-zero exit.
+
+### Scenario 4 — Software fallback stays serial
+
+`E2E_GPU_FORCE_FALLBACK=1 npm run test:e2e:gpu` (and the organic-exhaustion
+path): Chromium SwiftShader suite runs with the config's serial default; no
+injected `E2E_WORKERS` in the suite env.
+
+### Scenario 5 — Gate untouched
+
+`npm run validate` green; `git diff` contains no changes to
+`.github/workflows/validation.yml`, `scripts/e2e-workers.mjs`,
+`tests/e2e-workers.test.mjs`, or the `workers:` line of
+`playwright.config.ts`; existing worker-resolution tests pass unmodified.
+
+### Scenario 6 — Re-qualification recorded
+
+The review contains the serial baseline plus ≥3 consecutive green plain
+`npm run test:e2e:gpu` parallel runs with per-test results, wall clocks, and
+reports (FR8).
+
+## Success Criteria
+
+- The lane's default path is the qualified fast path: plain
+  `npm run test:e2e:gpu` ≈ 4× faster than the serial baseline on the
+  qualified host, green 3/3.
+- Zero behavioral movement outside the lane's hardware suite env and output
+  lines; CI and gate provably untouched.
+- Docs and the #41 follow-up record accurately describe the split model:
+  lane parallel-by-default, gate serial, global default unchanged.
+
+## References
+
+- Issue #56 (this spec); issue #41 (worker machinery, serial-default
+  rationale, GPU-parallel qualification); issue #55 (blocker — fixed, closed
+  2026-07-24, green 3/3 parallel re-qualification); issues #44/#52 (the lane;
+  "lane is never the gate" Baked Decision); issue #42 (GPU-in-CI rejected).
+- `scripts/e2e-gpu-lane.mjs` (`suiteEnvFor`, `computeRunPlan`, report format),
+  `scripts/e2e-workers.mjs` (`resolveWorkers`, `DEFAULT_LOCAL_WORKERS`),
+  `playwright.config.ts`, `tests/gpu-lane.test.mjs`,
+  `tests/e2e-workers.test.mjs`.
+- `codev/reviews/41-parallelize-local-e2e-runs.md` (qualification evidence,
+  "Revisiting the serial default" follow-up),
+  `codev/reviews/55-firefox-background-drag-flake.md` (FR6 re-qualification,
+  green 3/3), README "Opt-in native-GPU e2e lane" / "Local test parallelism".

--- a/codev/state/spir-56_thread.md
+++ b/codev/state/spir-56_thread.md
@@ -4,3 +4,30 @@
 - Spec already existed on branch (868fcdb) and is thorough — blocker #55 is resolved (green 3/3 parallel re-qual), so the lane default is realizable. Signaled `porch done` for specify build.
 - Running iter1 3-way spec consultation (gemini/codex/claude) in background.
 - Iter1 spec consultation: unanimous APPROVE (gemini/codex/claude). Reached `spec-approval` gate; architect notified. Waiting for human approval.
+- Spec approved by architect. Drafted 3-phase plan (mechanism+tests / worker visibility / docs+re-qual evidence), committed.
+- Iter1 plan consultation: gemini APPROVE, codex COMMENT (minor test/doc scoping — folded into plan), claude APPROVE. At `plan-approval` gate; architect notified.
+
+## Implement phase_1 — lane hardware-mode worker default (2026-07-24)
+
+- plan-approval gate approved by architect; armed the context-threshold monitor as instructed.
+- Implemented spec 56 phase_1 in `scripts/e2e-gpu-lane.mjs`: exported `LANE_DEFAULT_WORKERS = "50%"` and `operatorWorkersSet(baseEnv)` (set = present and not whitespace-only, mirroring resolveWorkers). `suiteEnvFor` injects `E2E_WORKERS=50%` in both hardware arms only when the operator hasn't set it; software-fallback branch and guard throw untouched; baseEnv never mutated.
+- Added the full FR7 unit-test matrix to `tests/gpu-lane.test.mjs` (9 new tests): default injection (two-engine + Firefox-only), operator pass-through (4/1/banana), whitespace-as-unset, fallback non-injection, base-env immutability, constant export.
+- Environment note: the builder shell inherits pnpm `npm_config_*` vars from the afx harness, which makes `tests/toolchain.test.mjs` user-agent assertion fail under a bare `npm test`. Stripping `npm_*`/`pnpm_*`/`PNPM_*` env vars gives a clean run — 130/130 pass, `npm run build` green. This is environment noise (see lessons-critical), not a project failure.
+
+## Implement phase_2 — worker visibility (2026-07-24)
+
+- Phase 1 got unanimous APPROVE from the 3-way consultation; porch committed and advanced to phase_2.
+- Added `workerDecisionFor(plan, baseEnv)` ({value, provenance}: operator override / lane default / config serial default) and an additive trailing `workers:` report line in `formatReport` — appended last so every pre-existing line keeps its position (existing tests index lines[0..6] and pass unmodified). Suite-running paths (success, build-failure, fallback) pass the decision; probe-only and skip-empty read `workers: n/a (no suite run)`. A `log()` line states the decision before the suite stage.
+- 8 new unit tests (decision matrix + all five report call paths). 138/138 pass, build green, `--probe-only` output eyeballed on real hardware (RTX 3080 verified both engines).
+
+## Implement phase_3 — docs + re-qualification evidence (2026-07-24)
+
+- Phase 2 unanimous APPROVE; porch advanced to phase_3.
+- README updated: "Local test parallelism" note, lane step 3, report snippet (new `workers:` line), env-table `E2E_WORKERS` row, #41-evidence paragraph, and "Status and sequencing" bullet — the lane is parallel-by-default (`50%`) on verified hardware, serial on fallback/global/CI. `codev/reviews/41-parallelize-local-e2e-runs.md` "Revisiting the serial default" got a dated spec-56 correction (lane-scoped default delivered; global stays serial). Lane header comment now notes the E2E_WORKERS consultation.
+- FR8 qualification on the qualified host (20-core WSL2 + RTX 3080, Mesa d3d12), all `mode: hardware`, both engines verified, 22/22 pass each run:
+  - serial baseline `E2E_WORKERS=1`: pass, wall-clock 212s (build 10s, suite 200s), `workers: 1 (operator override)`;
+  - plain runs 1–3 (no E2E_WORKERS): pass, 54s/57s/59s (suite 43s/45s/47s), each `workers: 50% (lane default)`, 10 workers — 3/3 consecutive green, ~3.8× faster than serial.
+  - Scenario 3 spot check: `E2E_WORKERS=banana` exits 1 with loud `WorkerConfigError`; report honestly shows `workers: banana (operator override)`.
+  - Full logs preserved in the session scratchpad (`qual/*.log`) for the Review-phase evidence appendix.
+- Scenario 5 diff audit clean: diff vs main touches only README, lane script, lane tests, #41 review, plan/status/thread — no frozen files (`validation.yml`, `e2e-workers.mjs`, `playwright.config.ts`, lockfile untouched).
+- Final gate: in-worktree `npm run validate` failed only on 21 lint errors in the untracked builder-harness hook `.claude/hooks/worktree-write-guard.cjs` (the documented environment-noise case). Proved the gate per lessons-critical on a clean detached checkout (`git worktree add --detach HEAD` + working-tree files copied in + real `npm ci`): lint + typecheck + test:smoke all green, 22/22 passed serially — CLEAN_VALIDATE_EXIT=0.

--- a/codev/state/spir-56_thread.md
+++ b/codev/state/spir-56_thread.md
@@ -1,0 +1,6 @@
+# spir-56 thread — GPU lane parallel default
+
+- Spawned in strict mode for issue #56 (native-GPU e2e lane defaults to parallel workers; SwiftShader gate stays serial).
+- Spec already existed on branch (868fcdb) and is thorough — blocker #55 is resolved (green 3/3 parallel re-qual), so the lane default is realizable. Signaled `porch done` for specify build.
+- Running iter1 3-way spec consultation (gemini/codex/claude) in background.
+- Iter1 spec consultation: unanimous APPROVE (gemini/codex/claude). Reached `spec-approval` gate; architect notified. Waiting for human approval.

--- a/scripts/e2e-gpu-lane.mjs
+++ b/scripts/e2e-gpu-lane.mjs
@@ -41,6 +41,10 @@
 //                             GPU-capable host).
 //   E2E_GPU_REQUIRE=1         exit non-zero instead of falling back when any
 //                             requested engine does not verify hardware.
+// The lane also CONSULTS E2E_WORKERS (owned by playwright.config.ts /
+// resolveWorkers, spec 41): on verified-hardware runs it defaults the suite to
+// E2E_WORKERS=50% unless the operator set a value (spec 56); the
+// software-fallback path keeps the config's serial default.
 //
 // CLI (read ONLY by this wrapper):
 //   --engine=chromium|firefox|all  select the probe/suite engine set (default
@@ -417,7 +421,12 @@ export function engineReportLine(outcome) {
 // is an ordered [{engine, renderer}] list; every requested engine gets exactly
 // one `renderer.<engine>` line (a skipped engine is represented explicitly,
 // never omitted silently).
-export function formatReport({mode, engines, suite, wallClock}) {
+// The `workers` entry is a {value, provenance} decision from workerDecisionFor
+// for report paths that run (or would have run) a suite; omitted for
+// --probe-only and skip-empty, which honestly report `n/a (no suite run)`.
+// The line is ADDITIVE and last — every pre-existing line keeps its position
+// and phrasing verbatim (spec 52 FR10 consumers grep by line prefix).
+export function formatReport({mode, engines, suite, wallClock, workers}) {
     return [
         "=== E2E GPU LANE REPORT ===",
         `mode: ${mode}`,
@@ -425,6 +434,11 @@ export function formatReport({mode, engines, suite, wallClock}) {
         ...engines.map((entry) => `renderer.${entry.engine}: ${entry.renderer}`),
         `suite: ${suite}`,
         `wall-clock: ${wallClock}`,
+        `workers: ${
+            workers
+                ? `${workers.value} (${workers.provenance})`
+                : "n/a (no suite run)"
+        }`,
     ].join("\n");
 }
 
@@ -618,9 +632,43 @@ export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
     };
 }
 
+// Lane-scoped parallel default (spec 56): hardware-mode suite runs get a
+// hardware-scaled worker count via the existing E2E_WORKERS contract, resolved
+// by the config's resolveWorkers — no second worker-resolution path. Applies
+// ONLY to the hardware branch; software-fallback keeps the config's serial
+// default, and the absolute CI → 1 guard in resolveWorkers still wins last.
+export const LANE_DEFAULT_WORKERS = "50%";
+
+// "Operator has set E2E_WORKERS" mirrors resolveWorkers' unset/empty
+// semantics: present and not whitespace-only. A whitespace-only value is
+// treated as unset (the default is injected); any other value — including an
+// invalid one — passes through verbatim so config-load's WorkerConfigError
+// still fails loud.
+export function operatorWorkersSet(baseEnv) {
+    const value = baseEnv.E2E_WORKERS;
+    return value !== undefined && value.trim() !== "";
+}
+
+// The effective worker decision for a suite-running plan (spec 56 FR6,
+// Decision 7): what E2E_WORKERS value the suite process will see and where it
+// came from. Pure — reads only the plan mode and the operator's baseEnv.
+// Provenance vocabulary: "operator override" (E2E_WORKERS set, any mode),
+// "lane default" (hardware, lane-injected 50%), "config serial default"
+// (software-fallback with no operator value — the config's own workers: 1).
+export function workerDecisionFor(plan, baseEnv) {
+    if (operatorWorkersSet(baseEnv)) {
+        return {value: baseEnv.E2E_WORKERS, provenance: "operator override"};
+    }
+    if (plan.mode === "hardware") {
+        return {value: LANE_DEFAULT_WORKERS, provenance: "lane default"};
+    }
+    return {value: "1", provenance: "config serial default"};
+}
+
 // Env for the actual suite run (spec 44 FR4 / spec 52 FR5: the full suite for
-// the resolved engine set, workers/retries/timeouts untouched — those stay the
-// config's own defaults). Consumes the run plan from computeRunPlan:
+// the resolved engine set, retries/timeouts untouched — those stay the
+// config's own defaults; hardware-mode workers default to
+// LANE_DEFAULT_WORKERS unless the operator sets E2E_WORKERS). Consumes the run plan from computeRunPlan:
 //   - Hardware with Chromium in the set (Chromium alone OR Chromium+Firefox):
 //     inject the verified Chromium recipe's Mesa env into the suite process and
 //     set E2E_ENGINES to the resolved set; a two-engine run's Firefox INHERITS
@@ -635,6 +683,9 @@ export function computeRunPlan({requestedEngines, verdicts = {}, controls}) {
 export function suiteEnvFor(plan, baseEnv) {
     if (plan.mode === "hardware") {
         const engineList = plan.suiteEngines.join(",");
+        const laneWorkers = operatorWorkersSet(baseEnv)
+            ? undefined
+            : LANE_DEFAULT_WORKERS;
         if (plan.suiteEngines.includes("chromium")) {
             const env = composeEnv(
                 baseEnv,
@@ -643,6 +694,7 @@ export function suiteEnvFor(plan, baseEnv) {
             );
             env.E2E_ENGINES = engineList;
             env.PW_CHROMIUM_ARGS = plan.chromiumCandidate.flags.join(" ");
+            if (laneWorkers !== undefined) env.E2E_WORKERS = laneWorkers;
             return env;
         }
         const env = composeEnv(
@@ -651,6 +703,7 @@ export function suiteEnvFor(plan, baseEnv) {
             plan.firefoxExtraEnv ?? {},
         );
         env.E2E_ENGINES = engineList;
+        if (laneWorkers !== undefined) env.E2E_WORKERS = laneWorkers;
         return env;
     }
     if (plan.mode === "software-fallback") {
@@ -1196,6 +1249,10 @@ async function runFullLane(args, controls, elapsedSeconds) {
         );
     }
 
+    // Decided once, before build: the build-failure report must still state
+    // what workers the suite WOULD have run with (FR6).
+    const workers = workerDecisionFor(plan, process.env);
+
     // The build never needs recipe env; it runs under the untouched inherited
     // env in both modes.
     const build = await runStage("build", "npm", ["run", "build"], process.env);
@@ -1208,11 +1265,13 @@ async function runFullLane(args, controls, elapsedSeconds) {
                 engines: reportEntriesFromPlan(plan, requestedEngines),
                 suite: `not-run (build failed, exit ${build.code})`,
                 wallClock: `${elapsedSeconds()}s (build ${build.seconds}s)`,
+                workers,
             }),
         );
         return build.code;
     }
 
+    log(`workers: ${workers.value} (${workers.provenance})`);
     const suite = await runStage(
         "suite",
         "npx",
@@ -1233,6 +1292,7 @@ async function runFullLane(args, controls, elapsedSeconds) {
                 build.seconds,
                 suite.seconds,
             ),
+            workers,
         }),
     );
     // The suite's own pass/fail semantics are the lane's exit code (FR3).

--- a/tests/gpu-lane.test.mjs
+++ b/tests/gpu-lane.test.mjs
@@ -11,6 +11,7 @@ import {
     CANDIDATES,
     ENGINES,
     FIREFOX_PROBE_RECIPE,
+    LANE_DEFAULT_WORKERS,
     LaneUsageError,
     buildHostView,
     classifyRenderer,
@@ -23,6 +24,7 @@ import {
     formatReport,
     formatWallClock,
     isHeadedRun,
+    operatorWorkersSet,
     parseArgs,
     parseControls,
     partitionCandidates,
@@ -34,6 +36,7 @@ import {
     runSelection,
     suiteEnvFor,
     suiteResultLabel,
+    workerDecisionFor,
 } from "../scripts/e2e-gpu-lane.mjs";
 
 // Host-view fixtures mirroring the shapes the lane must handle.
@@ -1146,6 +1149,192 @@ test("suiteEnvFor: skip-empty / abort never produce a suite env (no empty E2E_EN
         () => suiteEnvFor({mode: "abort", suiteEngines: []}, {}),
         /no suite runs for plan mode "abort"/,
     );
+});
+
+// Spec 56 FR7: lane-scoped parallel default. Hardware-mode suite envs default
+// E2E_WORKERS to LANE_DEFAULT_WORKERS; operator values (valid or not) pass
+// through verbatim; the software-fallback branch never injects.
+const twoEngineHardwarePlan = {
+    mode: "hardware",
+    suiteEngines: ["chromium", "firefox"],
+    chromiumCandidate: candidateById("wsl2-d3d12-angle-gl"),
+    chromiumExtraEnv: {},
+    firefoxRecipe: FIREFOX_PROBE_RECIPE,
+    firefoxExtraEnv: {},
+};
+const firefoxOnlyHardwarePlan = {
+    mode: "hardware",
+    suiteEngines: ["firefox"],
+    firefoxRecipe: FIREFOX_PROBE_RECIPE,
+    firefoxExtraEnv: {},
+};
+
+test("LANE_DEFAULT_WORKERS is the hardware-scaled 50% sentinel", () => {
+    assert.equal(LANE_DEFAULT_WORKERS, "50%");
+});
+
+test("operatorWorkersSet mirrors resolveWorkers unset/empty semantics", () => {
+    assert.equal(operatorWorkersSet({}), false);
+    assert.equal(operatorWorkersSet({E2E_WORKERS: ""}), false);
+    assert.equal(operatorWorkersSet({E2E_WORKERS: "   "}), false);
+    assert.equal(operatorWorkersSet({E2E_WORKERS: "1"}), true);
+    assert.equal(operatorWorkersSet({E2E_WORKERS: "50%"}), true);
+    assert.equal(operatorWorkersSet({E2E_WORKERS: "banana"}), true);
+});
+
+test("suiteEnvFor hardware two-engine: lane defaults E2E_WORKERS to 50%", () => {
+    const env = suiteEnvFor(twoEngineHardwarePlan, {PATH: "/usr/bin"});
+    assert.equal(env.E2E_WORKERS, "50%");
+});
+
+test("suiteEnvFor Firefox-only hardware: lane default injected too", () => {
+    const env = suiteEnvFor(firefoxOnlyHardwarePlan, {PATH: "/usr/bin"});
+    assert.equal(env.E2E_WORKERS, "50%");
+});
+
+test("suiteEnvFor hardware: operator E2E_WORKERS passes through verbatim (incl. forcing serial)", () => {
+    for (const value of ["4", "1"]) {
+        const env = suiteEnvFor(twoEngineHardwarePlan, {
+            PATH: "/usr/bin",
+            E2E_WORKERS: value,
+        });
+        assert.equal(env.E2E_WORKERS, value);
+    }
+});
+
+test("suiteEnvFor hardware: whitespace-only E2E_WORKERS is unset ⇒ default injected", () => {
+    const env = suiteEnvFor(twoEngineHardwarePlan, {
+        PATH: "/usr/bin",
+        E2E_WORKERS: "   ",
+    });
+    assert.equal(env.E2E_WORKERS, "50%");
+});
+
+test("suiteEnvFor hardware: malformed operator value passes through — WorkerConfigError stays config-load's job", () => {
+    const env = suiteEnvFor(twoEngineHardwarePlan, {
+        PATH: "/usr/bin",
+        E2E_WORKERS: "banana",
+    });
+    assert.equal(env.E2E_WORKERS, "banana");
+});
+
+test("suiteEnvFor software-fallback: no lane-injected E2E_WORKERS; operator value still passes through", () => {
+    const fallbackPlan = {mode: "software-fallback", suiteEngines: ["chromium"]};
+    const bare = suiteEnvFor(fallbackPlan, {PATH: "/usr/bin"});
+    assert.equal(Object.hasOwn(bare, "E2E_WORKERS"), false);
+    const withOperator = suiteEnvFor(fallbackPlan, {
+        PATH: "/usr/bin",
+        E2E_WORKERS: "3",
+    });
+    assert.equal(withOperator.E2E_WORKERS, "3");
+});
+
+test("suiteEnvFor hardware: base env object is never mutated by the workers default", () => {
+    const base = {PATH: "/usr/bin"};
+    suiteEnvFor(twoEngineHardwarePlan, base);
+    assert.deepEqual(base, {PATH: "/usr/bin"});
+    const withValue = {PATH: "/usr/bin", E2E_WORKERS: "   "};
+    suiteEnvFor(twoEngineHardwarePlan, withValue);
+    assert.deepEqual(withValue, {PATH: "/usr/bin", E2E_WORKERS: "   "});
+});
+
+// Spec 56 FR6: worker-decision visibility. workerDecisionFor is the single
+// provenance source; formatReport gains one additive trailing `workers:` line.
+test("workerDecisionFor: hardware with no operator value ⇒ lane default", () => {
+    assert.deepEqual(workerDecisionFor(twoEngineHardwarePlan, {PATH: "/usr/bin"}), {
+        value: "50%",
+        provenance: "lane default",
+    });
+    // Whitespace-only is unset (mirrors operatorWorkersSet).
+    assert.deepEqual(
+        workerDecisionFor(twoEngineHardwarePlan, {E2E_WORKERS: "   "}),
+        {value: "50%", provenance: "lane default"},
+    );
+});
+
+test("workerDecisionFor: operator override wins verbatim in any mode", () => {
+    assert.deepEqual(
+        workerDecisionFor(twoEngineHardwarePlan, {E2E_WORKERS: "4"}),
+        {value: "4", provenance: "operator override"},
+    );
+    assert.deepEqual(
+        workerDecisionFor({mode: "software-fallback"}, {E2E_WORKERS: "1"}),
+        {value: "1", provenance: "operator override"},
+    );
+});
+
+test("workerDecisionFor: software-fallback with no operator value ⇒ config serial default", () => {
+    assert.deepEqual(workerDecisionFor({mode: "software-fallback"}, {}), {
+        value: "1",
+        provenance: "config serial default",
+    });
+});
+
+// The five report call paths that now carry a worker decision (per plan
+// phase_2): full-lane success, build-failure, software-fallback, skip-empty,
+// and --probe-only. The first three pass a decision; the last two omit it and
+// read `n/a (no suite run)`.
+test("formatReport full-lane success path: additive trailing workers line, prior lines verbatim", () => {
+    const report = formatReport({
+        mode: "hardware",
+        engines: [{engine: "chromium", renderer: "ANGLE (...)"}],
+        suite: "pass",
+        wallClock: "192s (build 45s, suite 147s)",
+        workers: {value: "50%", provenance: "lane default"},
+    });
+    const lines = report.split("\n");
+    // Existing positions untouched — the workers line is strictly appended.
+    assert.equal(lines[4], "suite: pass");
+    assert.equal(lines[5], "wall-clock: 192s (build 45s, suite 147s)");
+    assert.equal(lines.at(-1), "workers: 50% (lane default)");
+    assert.equal(report.match(/^workers: /gm).length, 1);
+});
+
+test("formatReport build-failure path: workers line states what the suite would have used", () => {
+    const report = formatReport({
+        mode: "hardware",
+        engines: [{engine: "chromium", renderer: "ANGLE (...)"}],
+        suite: "not-run (build failed, exit 1)",
+        wallClock: "50s (build 45s)",
+        workers: {value: "4", provenance: "operator override"},
+    });
+    assert.match(report, /^workers: 4 \(operator override\)$/m);
+});
+
+test("formatReport software-fallback path: config serial default provenance", () => {
+    const report = formatReport({
+        mode: "software-fallback",
+        engines: [{engine: "chromium", renderer: "(software-fallback — SwiftShader)"}],
+        suite: "pass",
+        wallClock: "10s",
+        workers: {value: "1", provenance: "config serial default"},
+    });
+    assert.match(report, /^workers: 1 \(config serial default\)$/m);
+});
+
+test("formatReport skip-empty path: no decision ⇒ workers: n/a (no suite run)", () => {
+    const report = formatReport({
+        mode: "skipped",
+        engines: [{engine: "firefox", renderer: "skipped (unverified — x)"}],
+        suite: "skipped (no verified engine)",
+        wallClock: "3s",
+    });
+    assert.match(report, /^workers: n\/a \(no suite run\)$/m);
+});
+
+test("probeOnlyOutcome report carries workers: n/a (no suite run)", () => {
+    const {report} = probeOnlyOutcome({
+        requestedEngines: ["chromium"],
+        verdicts: {chromium: chromiumHardwareVerdict()},
+        plan: computeRunPlan({
+            requestedEngines: ["chromium"],
+            verdicts: {chromium: chromiumHardwareVerdict()},
+            controls: nonStrict,
+        }),
+        controls: nonStrict,
+        wallClock: "5s",
+    });
+    assert.match(report, /^workers: n\/a \(no suite run\)$/m);
 });
 
 test("playwrightTestArgs: headed reaches Playwright via the CLI flag only", () => {


### PR DESCRIPTION
Closes #56.

## What

The opt-in native-GPU e2e lane (`npm run test:e2e:gpu`) now **defaults to hardware-scaled parallel workers**: on verified-hardware runs `scripts/e2e-gpu-lane.mjs` injects `E2E_WORKERS=50%` into the suite env unless the operator set a value, reusing the existing `resolveWorkers` machinery (#41) — no second worker-resolution path. The SwiftShader canonical/CI gate is **byte-for-byte unchanged and serial**.

- `LANE_DEFAULT_WORKERS = "50%"` + `operatorWorkersSet()` (whitespace-only = unset, mirroring `resolveWorkers`); injection lives structurally inside `suiteEnvFor`'s hardware branch only — software fallback keeps the config's serial default.
- Operator overrides pass through verbatim (incl. `E2E_WORKERS=1` to force serial; invalid values still fail loud with `WorkerConfigError` at config load).
- Visibility (FR6): `workerDecisionFor` provenance, an additive trailing `workers:` report line (`n/a (no suite run)` for probe-only/skip-empty), and a pre-suite log line.
- Docs reconciled (FR9): README lane section/env table/report snippet; dated correction in the #41 review (lane-scoped default delivered; **global default stays serial** — SwiftShader contention unsolved, CI GPU-less, lane never the gate).

## Evidence (FR8 — `codev/reviews/56-gpu-lane-parallel-default.md`)

Host: 20-core WSL2 + RTX 3080, Mesa d3d12; all runs `mode: hardware`, both engines verified, `retries: 0`, 22/22:

| Run | Workers | Wall clock |
|---|---|---|
| Serial baseline (`E2E_WORKERS=1`) | `1 (operator override)` | 212s |
| Plain runs 1–3 | `50% (lane default)` (10 workers) | 54s / 57s / 59s |

**3/3 consecutive green** under the plain default, ~3.8× faster. `E2E_WORKERS=banana` exits 1 loud. Frozen files untouched: `.github/workflows/validation.yml`, `scripts/e2e-workers.mjs`, `playwright.config.ts`, lockfile. Validate gate proven green on a clean detached checkout with real `npm ci`. 17 new unit tests; 3-way consultation unanimous APPROVE on every phase (phase 3 after two codex iterations on the evidence pointer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)