### PR TITLE
[Spec 56] Protocol state: verify + protocol-complete (follow-up)

### DIFF
--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -28,11 +28,12 @@ gates:
     approved_at: '2026-07-24T20:10:48.159Z'
   verify-approval:
     status: pending
+    requested_at: '2026-07-24T20:19:43.624Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:11:04.430Z'
+updated_at: '2026-07-24T20:19:43.624Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -30,10 +30,10 @@ gates:
     status: pending
     requested_at: '2026-07-24T20:19:43.624Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:19:43.624Z'
+updated_at: '2026-07-24T20:19:55.968Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -27,13 +27,14 @@ gates:
     requested_at: '2026-07-24T20:06:45.326Z'
     approved_at: '2026-07-24T20:10:48.159Z'
   verify-approval:
-    status: pending
+    status: approved
     requested_at: '2026-07-24T20:19:43.624Z'
+    approved_at: '2026-07-24T20:19:57.155Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:19:55.968Z'
+updated_at: '2026-07-24T20:19:57.155Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
+++ b/codev/projects/56-make-the-native-gpu-e2e-lane-d/status.yaml
@@ -1,7 +1,7 @@
 id: '56'
 title: make-the-native-gpu-e2e-lane-d
 protocol: spir
-phase: verify
+phase: verified
 plan_phases:
   - id: phase_1
     title: Lane hardware-mode worker default (mechanism + unit tests)
@@ -34,7 +34,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-24T19:05:59.482Z'
-updated_at: '2026-07-24T20:19:57.155Z'
+updated_at: '2026-07-24T20:19:58.352Z'
 pr_history:
   - phase: review
     pr_number: 59

--- a/codev/state/spir-56_thread.md
+++ b/codev/state/spir-56_thread.md
@@ -31,3 +31,9 @@
   - Full logs preserved in the session scratchpad (`qual/*.log`) for the Review-phase evidence appendix.
 - Scenario 5 diff audit clean: diff vs main touches only README, lane script, lane tests, #41 review, plan/status/thread — no frozen files (`validation.yml`, `e2e-workers.mjs`, `playwright.config.ts`, lockfile untouched).
 - Final gate: in-worktree `npm run validate` failed only on 21 lint errors in the untracked builder-harness hook `.claude/hooks/worktree-write-guard.cjs` (the documented environment-noise case). Proved the gate per lessons-critical on a clean detached checkout (`git worktree add --detach HEAD` + working-tree files copied in + real `npm ci`): lint + typecheck + test:smoke all green, 22/22 passed serially — CLEAN_VALIDATE_EXIT=0.
+
+## Verify phase (2026-07-24)
+
+- PR #59 merged into main (regular merge, all CI checks green — quality + 4 serial Chromium shards, proving the lane default does not leak into CI). Merged main pulled into the worktree.
+- Post-merge verification: plain `npm run test:e2e:gpu` from the integrated tree — `mode: hardware`, both engines verified, `suite: pass`, `workers: 50% (lane default)`, wall-clock 59s. Exit 0.
+- Per architect: porch-state commits made after the merge will land via a small follow-up PR once porch reaches protocol complete.


### PR DESCRIPTION
Follow-up to #59 (merged before verify completed): lands the trailing porch-state commits — verify-phase transitions, post-merge verification thread entry, verify-approval, and `chore(porch): 56 protocol complete` — so project 56's protocol state is recorded on main. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)